### PR TITLE
ci: use npm trusted publishing (OIDC) — remove NODE_AUTH_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,8 +86,6 @@ jobs:
           else
             npm publish --provenance --access public --tag "$TAG"
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         if: steps.check_version.outputs.changed == 'true'


### PR DESCRIPTION
Removes `NODE_AUTH_TOKEN` from the publish step so npm uses OIDC trusted publishing instead of trying to authenticate with an empty token (the secret doesn't exist in this repo). Trusted publisher is configured on npmjs.com for this repo/workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)