### PR TITLE
ci: upgrade npm to latest for trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
+      - name: Upgrade npm
+        run: npm install -g npm@latest
+
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
npm trusted publishing requires npm 11.5.1+. Node 22 ships with npm 10.x, which authenticates via OIDC for provenance signing but can't complete the registry token exchange needed for the actual publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)