### PR TITLE
fix: add repository field for npm provenance verification

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,10 @@
     "tesseract",
     "opencv"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rickcedwhat/playwright-smart-vision"
+  },
   "author": "rickcedwhat",
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
npm verifies that package.json's `repository.url` matches the GitHub repo in the provenance bundle. Without this field, publish fails with E422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)