### PR TITLE
fix: ./configure subpath export for QA Wolf compatibility

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,10 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./configure": {
+      "import": "./dist/configure.js",
+      "types": "./dist/configure.d.ts"
+    },
     "./utils/ocr": {
       "import": "./dist/utils/ocr.js",
       "types": "./dist/utils/ocr.d.ts"


### PR DESCRIPTION
The root entrypoint re-exports \`test\`/\`expect\` from \`@playwright/test\`, which conflicts when QA Wolf imports the package (Playwright is already loaded). \`configure.ts\` only uses \`import type { Page }\` which is erased at compile time, so \`dist/configure.js\` has zero \`@playwright/test\` references.

Usage in QA Wolf:
\`\`\`js
import { configure, saveScreen } from "@rickcedwhat/playwright-smart-vision/configure";
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)