### PR TITLE
fix: lazy-load @playwright/test — root entrypoint is now framework-agnostic

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,10 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./test": {
+      "import": "./dist/ocr-test.js",
+      "types": "./dist/ocr-test.d.ts"
+    },
     "./configure": {
       "import": "./dist/configure.js",
       "types": "./dist/configure.d.ts"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,3 @@
-export { test, expect } from './ocr-test.js';
-export type { OcrScreen } from './ocr-test.js';
-
 export { configure, saveScreen } from './configure.js';
 
 export { defineScreen, screenAssetsDir } from './screen-config.js';

--- a/packages/core/src/ocr-step.ts
+++ b/packages/core/src/ocr-step.ts
@@ -1,39 +1,39 @@
-import { test } from '@playwright/test';
+type PlaywrightTest = typeof import('@playwright/test').test;
 
-/**
- * Wrap OCR actions so they appear as named steps in the Playwright report and trace.
- * Falls back to running the body when called outside a test.
- */
-export async function ocrStep<T>(title: string, body: () => Promise<T>): Promise<T> {
+let _test: PlaywrightTest | null | undefined; // undefined=not yet loaded, null=unavailable
+
+async function getTest(): Promise<PlaywrightTest | null> {
+  if (_test !== undefined) return _test;
   try {
-    test.info();
+    _test = (await import('@playwright/test')).test;
   } catch {
-    return body();
+    _test = null;
   }
+  return _test;
+}
+
+export async function ocrStep<T>(title: string, body: () => Promise<T>): Promise<T> {
+  const test = await getTest();
+  if (!test) return body();
+  try { test.info(); } catch { return body(); }
   return test.step(title, body, { box: true });
 }
 
-/** Attach a PNG to the current Playwright test so it shows in the report and trace. */
 export async function attachOcrImage(name: string, buffer: Buffer): Promise<void> {
+  const test = await getTest();
+  if (!test) return;
   try {
     await test.info().attach(name, { body: buffer, contentType: 'image/png' });
-  } catch {
-    // Not running inside a Playwright test.
-  }
+  } catch {}
 }
 
 /**
  * Resolve the assertion timeout: explicit override → 5 000 ms default → 0 outside a test.
- * 5 000 ms matches Playwright's built-in expect.timeout default. Pass options.timeout to
- * override per-call, or pass 0 to assert once without retrying.
- * Returns 0 when called outside a Playwright test (no retry in unit/script contexts).
+ * Uses the cached test reference — will be populated after the first ocrStep call in a
+ * Playwright context. Returns 0 (no retry) when called outside a Playwright test.
  */
 export function expectTimeout(override?: number): number {
   if (override !== undefined) return override;
-  try {
-    test.info();
-    return 5_000;
-  } catch {
-    return 0;
-  }
+  if (!_test) return 0;
+  try { _test.info(); return 5_000; } catch { return 0; }
 }


### PR DESCRIPTION
## Problem
The root entrypoint pulled in \`@playwright/test\` at module load time via \`index.ts → ocr-test.ts\` and \`ocr-step.ts\`. Importing the package in QA Wolf (or any env where Playwright's global state must not be initialized early) caused a conflict.

## Fix
- **\`ocr-step.ts\`**: top-level \`import { test }\` replaced with a lazy dynamic import cached on first call. The existing \`try { test.info() } catch\` fallback is unchanged — outside a Playwright test, \`ocrStep\` runs the body directly.
- **\`index.ts\`**: \`test\`, \`expect\`, \`OcrScreen\` removed from root exports.
- **\`package.json\`**: added \`./test\` subpath pointing to \`dist/ocr-test.js\`.

## Migration
```js
// Before
import { test, expect } from '@rickcedwhat/playwright-smart-vision'

// After
import { test, expect } from '@rickcedwhat/playwright-smart-vision/test'
```

QA Wolf usage unchanged:
```js
import { configure, saveScreen } from '@rickcedwhat/playwright-smart-vision/configure'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)