### PR TITLE
fix: framework-agnostic root entrypoint + configure() devtools API

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,10 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./test": {
+      "import": "./dist/ocr-test.js",
+      "types": "./dist/ocr-test.d.ts"
+    },
     "./configure": {
       "import": "./dist/configure.js",
       "types": "./dist/configure.d.ts"

--- a/packages/core/src/configure.ts
+++ b/packages/core/src/configure.ts
@@ -21,12 +21,17 @@ export function getGlobalConfig(): GlobalConfig {
 
 /**
  * Configure storage root and optional devtools FAB.
+ * Pass `page` as the second argument to inject the FAB immediately (QA Wolf / non-fixture usage).
+ * In fixture-based Playwright tests the FAB is injected automatically by the ocrScreen fixture.
  *
- * In QA Wolf: configure({ storage: { root: process.env.TEAM_STORAGE_DIR + '/ocr-screens/acme' }, devtools: true })
- * In regular dev: configure({ storage: { root: './tests/screens' } })
+ * await configure({ storage: { root: process.env.TEAM_STORAGE_DIR + '/screens' }, devtools: true }, page);
  */
-export function configure(config: GlobalConfig): void {
+export async function configure(config: GlobalConfig, page?: Page): Promise<void> {
   globalConfig = { ...globalConfig, ...config };
+  if (config.devtools && page) {
+    const { injectDevtools } = await import('./devtools.js');
+    await injectDevtools(page);
+  }
 }
 
 /**

--- a/packages/core/src/configure.ts
+++ b/packages/core/src/configure.ts
@@ -11,6 +11,7 @@ interface StorageConfig {
 interface GlobalConfig {
   storage?: StorageConfig;
   devtools?: boolean;
+  page?: Page;
 }
 
 let globalConfig: GlobalConfig = {};
@@ -26,9 +27,10 @@ export function getGlobalConfig(): GlobalConfig {
  *
  * await configure({ storage: { root: process.env.TEAM_STORAGE_DIR + '/screens' }, devtools: true }, page);
  */
-export async function configure(config: GlobalConfig, page?: Page): Promise<void> {
-  globalConfig = { ...globalConfig, ...config };
-  if (config.devtools && page) {
+export async function configure(config: GlobalConfig): Promise<void> {
+  const { page, ...rest } = config;
+  globalConfig = { ...globalConfig, ...rest };
+  if (rest.devtools && page) {
     const { injectDevtools } = await import('./devtools.js');
     await injectDevtools(page);
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export { configure, saveScreen } from './configure.js';
+export { injectDevtools } from './devtools.js';
 
 export { defineScreen, screenAssetsDir } from './screen-config.js';
 export type { ScreenConfig } from './screen-config.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,3 @@
-export { test, expect } from './ocr-test.js';
-export type { OcrScreen } from './ocr-test.js';
-
 export { configure, saveScreen } from './configure.js';
 
 export { defineScreen, screenAssetsDir } from './screen-config.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,4 @@
 export { configure, saveScreen } from './configure.js';
-export { injectDevtools } from './devtools.js';
 
 export { defineScreen, screenAssetsDir } from './screen-config.js';
 export type { ScreenConfig } from './screen-config.js';

--- a/packages/core/src/ocr-step.ts
+++ b/packages/core/src/ocr-step.ts
@@ -1,39 +1,39 @@
-import { test } from '@playwright/test';
+type PlaywrightTest = typeof import('@playwright/test').test;
 
-/**
- * Wrap OCR actions so they appear as named steps in the Playwright report and trace.
- * Falls back to running the body when called outside a test.
- */
-export async function ocrStep<T>(title: string, body: () => Promise<T>): Promise<T> {
+let _test: PlaywrightTest | null | undefined; // undefined=not yet loaded, null=unavailable
+
+async function getTest(): Promise<PlaywrightTest | null> {
+  if (_test !== undefined) return _test;
   try {
-    test.info();
+    _test = (await import('@playwright/test')).test;
   } catch {
-    return body();
+    _test = null;
   }
+  return _test;
+}
+
+export async function ocrStep<T>(title: string, body: () => Promise<T>): Promise<T> {
+  const test = await getTest();
+  if (!test) return body();
+  try { test.info(); } catch { return body(); }
   return test.step(title, body, { box: true });
 }
 
-/** Attach a PNG to the current Playwright test so it shows in the report and trace. */
 export async function attachOcrImage(name: string, buffer: Buffer): Promise<void> {
+  const test = await getTest();
+  if (!test) return;
   try {
     await test.info().attach(name, { body: buffer, contentType: 'image/png' });
-  } catch {
-    // Not running inside a Playwright test.
-  }
+  } catch {}
 }
 
 /**
  * Resolve the assertion timeout: explicit override → 5 000 ms default → 0 outside a test.
- * 5 000 ms matches Playwright's built-in expect.timeout default. Pass options.timeout to
- * override per-call, or pass 0 to assert once without retrying.
- * Returns 0 when called outside a Playwright test (no retry in unit/script contexts).
+ * Uses the cached test reference — will be populated after the first ocrStep call in a
+ * Playwright context. Returns 0 (no retry) when called outside a Playwright test.
  */
 export function expectTimeout(override?: number): number {
   if (override !== undefined) return override;
-  try {
-    test.info();
-    return 5_000;
-  } catch {
-    return 0;
-  }
+  if (!_test) return 0;
+  try { _test.info(); return 5_000; } catch { return 0; }
 }

--- a/packages/core/src/ocr-test.ts
+++ b/packages/core/src/ocr-test.ts
@@ -3,8 +3,7 @@ import fs from 'node:fs';
 import { FieldExtractor } from './field-extractor.js';
 import { ScreenResult } from './screen-result.js';
 import type { ScreenConfig } from './screen-config.js';
-import { loadScreen, getGlobalConfig } from './configure.js';
-import { injectDevtools } from './devtools.js';
+import { loadScreen, getGlobalConfig, configure } from './configure.js';
 import { getOCRUtil, cleanupOCR } from './utils/ocr.js';
 import { ensureCvReady } from './utils/vision.js';
 
@@ -27,7 +26,7 @@ export const test = base.extend<{ ocrScreen: OcrScreen; ocrOverlay: boolean }, {
       // Clipboard read is optional until a field sets read: 'clipboard'.
     }
     if (getGlobalConfig().devtools) {
-      await injectDevtools(page);
+      await configure({ devtools: true }, page);
     }
     const ocr = await getOCRUtil();
     const extractor = new FieldExtractor(ocr, !!process.env.OCR_DEBUG);

--- a/packages/core/src/ocr-test.ts
+++ b/packages/core/src/ocr-test.ts
@@ -26,7 +26,7 @@ export const test = base.extend<{ ocrScreen: OcrScreen; ocrOverlay: boolean }, {
       // Clipboard read is optional until a field sets read: 'clipboard'.
     }
     if (getGlobalConfig().devtools) {
-      await configure({ devtools: true }, page);
+      await configure({ devtools: true, page });
     }
     const ocr = await getOCRUtil();
     const extractor = new FieldExtractor(ocr, !!process.env.OCR_DEBUG);


### PR DESCRIPTION
## Summary

- **Lazy-load `@playwright/test`** in `ocr-step.ts` — replaces top-level import with a cached dynamic import, so the root entrypoint has zero Playwright references at module load time. Safe to import from any environment (QA Wolf, scripts, etc.)
- **`./test` subpath** for Playwright fixture consumers (`test`, `expect`, `OcrScreen`)
- **`configure()` is now async** and accepts `page` as a config property — when `devtools: true` and `page` is provided, the FAB is injected automatically. No separate `injectDevtools` call needed.

## Usage

**QA Wolf / any env:**
\`\`\`js
import { configure, saveScreen } from '@rickcedwhat/playwright-smart-vision';

await configure({
  storage: { root: process.env.TEAM_STORAGE_DIR + '/screens' },
  devtools: true,
  page,
});
\`\`\`

**Playwright test files:**
\`\`\`js
import { test, expect } from '@rickcedwhat/playwright-smart-vision/test';
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)