### PR TITLE
fix: optional @playwright/test peer dep + JSDoc

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,6 +55,11 @@
   "peerDependencies": {
     "@playwright/test": ">=1.50.0"
   },
+  "peerDependenciesMeta": {
+    "@playwright/test": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@techstark/opencv-js": "^5.0.0-release.1",
     "pixelmatch": "^7.2.0",

--- a/packages/core/src/configure.ts
+++ b/packages/core/src/configure.ts
@@ -22,10 +22,10 @@ export function getGlobalConfig(): GlobalConfig {
 
 /**
  * Configure storage root and optional devtools FAB.
- * Pass `page` as the second argument to inject the FAB immediately (QA Wolf / non-fixture usage).
+ * Pass `page` to inject the FAB immediately (QA Wolf / non-fixture usage).
  * In fixture-based Playwright tests the FAB is injected automatically by the ocrScreen fixture.
  *
- * await configure({ storage: { root: process.env.TEAM_STORAGE_DIR + '/screens' }, devtools: true }, page);
+ * await configure({ storage: { root: process.env.TEAM_STORAGE_DIR + '/screens' }, devtools: true, page });
  */
 export async function configure(config: GlobalConfig): Promise<void> {
   const { page, ...rest } = config;


### PR DESCRIPTION
- Marks `@playwright/test` as optional in `peerDependenciesMeta` so QA Wolf's installer doesn't fail when the project doesn't declare it directly.
- Fixes stale two-argument JSDoc example to match the current single config object shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)