### PR TITLE
fix: inject FAB into current page, not just future navigations

### DIFF
--- a/packages/core/src/devtools.ts
+++ b/packages/core/src/devtools.ts
@@ -5,8 +5,11 @@ const FAB_SCRIPT = `(function () {
   if (window.__ocrDevtools) return;
   window.__ocrDevtools = true;
 
+  console.log('[OCR devtools] script loaded, readyState:', document.readyState);
+
   function init() {
     if (document.getElementById('__ocr-fab')) return;
+    console.log('[OCR devtools] mounting FAB');
 
     const style = document.createElement('style');
     style.textContent = \`
@@ -225,5 +228,7 @@ export async function injectDevtools(page: Page): Promise<void> {
     writeScreenBuffer(name, Buffer.from(b64, 'base64'));
   });
 
+  // addInitScript covers future navigations; evaluate covers the already-loaded page.
   await page.addInitScript(FAB_SCRIPT);
+  await page.evaluate(FAB_SCRIPT);
 }

--- a/packages/core/tests/devtools.spec.ts
+++ b/packages/core/tests/devtools.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+import { injectDevtools } from '../src/devtools.js';
+import { configure } from '../src/configure.js';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+
+test.describe('devtools FAB', () => {
+  test('FAB is visible after injectDevtools on already-loaded page', async ({ page }) => {
+    await page.goto('/');
+    await injectDevtools(page);
+
+    await expect(page.locator('#__ocr-fab')).toBeVisible();
+  });
+
+  test('FAB is visible via configure({ devtools, page }) after navigation', async ({ page }) => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-test-'));
+    await configure({ storage: { root: tmp }, devtools: true, page });
+
+    await page.goto('/');
+    await expect(page.locator('#__ocr-fab')).toBeVisible();
+  });
+
+  test('FAB survives navigation and reappears', async ({ page }) => {
+    await injectDevtools(page);
+    await page.goto('/');
+    await expect(page.locator('#__ocr-fab')).toBeVisible();
+
+    await page.goto('/');
+    await expect(page.locator('#__ocr-fab')).toBeVisible();
+  });
+
+  test('FAB button opens capture menu on click', async ({ page }) => {
+    await page.goto('/');
+    await injectDevtools(page);
+
+    await page.locator('#__ocr-fab-btn').click();
+    await expect(page.locator('#__ocr-fab-menu')).toHaveClass(/open/);
+  });
+});


### PR DESCRIPTION
## Root cause

`page.addInitScript` only fires on future page navigations. `configure({ devtools: true, page })` is called *after* Guacamole is already loaded — so the script never ran, and the FAB never appeared.

## Fix

```ts
await page.addInitScript(FAB_SCRIPT); // future navigations
await page.evaluate(FAB_SCRIPT);      // current page
```

The idempotency guard (`if (window.__ocrDevtools) return`) prevents double-injection on pages that do navigate.

## Also

- Added `console.log('[OCR devtools] ...')` breadcrumbs visible in browser devtools
- Added 4 Playwright tests in `tests/devtools.spec.ts` — all passing locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)