### PR TITLE
fix: remove @playwright/test peer dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rickcedwhat/playwright-smart-vision",
   "version": "0.1.0",
-  "description": "Computer-vision and OCR-based element assertions for Playwright — local, fast, no GPT Vision required",
+  "description": "Computer-vision and OCR-based element assertions for Playwright \u2014 local, fast, no GPT Vision required",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -52,14 +52,6 @@
   },
   "author": "rickcedwhat",
   "license": "MIT",
-  "peerDependencies": {
-    "@playwright/test": ">=1.50.0"
-  },
-  "peerDependenciesMeta": {
-    "@playwright/test": {
-      "optional": true
-    }
-  },
   "dependencies": {
     "@techstark/opencv-js": "^5.0.0-release.1",
     "pixelmatch": "^7.2.0",


### PR DESCRIPTION
QA Wolf's npm version doesn't respect `peerDependenciesMeta.optional` and treats the peer as required, causing install failures. Since we lazy-load `@playwright/test` at runtime, it belongs only in `devDependencies`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)