### PR TITLE
fix: restore optional @playwright/test peer dep

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,5 +64,13 @@
     "@types/pngjs": "^6.0.5",
     "typescript": "^5.8.0",
     "vitest": "^3.0.0"
+  },
+  "peerDependencies": {
+    "@playwright/test": ">=1.50.0"
+  },
+  "peerDependenciesMeta": {
+    "@playwright/test": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
PR #30 removed `peerDependencies` entirely. That broke QA Wolf's installer — the package has runtime references to `@playwright/test` (in `ocr-test.js`, `ocr-step.js`, and `.d.ts` files) but was no longer declaring it, which QA Wolf's dependency resolver rejects.

`a679b0b` (the last working version) had the peer dep declared as optional. Restoring that exact configuration.

`peerDependenciesMeta.optional: true` means standard npm won't fail when `@playwright/test` is absent — it's the correct declaration for an optionally-loaded peer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)