### PR TITLE
chore: bump core to 0.2.0 for QA Wolf install sanity check

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rickcedwhat/playwright-smart-vision",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Computer-vision and OCR-based element assertions for Playwright — local, fast, no GPT Vision required",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bumps `@rickcedwhat/playwright-smart-vision` from `0.1.0` to `0.2.0`.
- Publish CI treats this as a version bump and will release `0.2.0` on the `latest` tag (not another `0.1.0-next.<sha>`).
- Sanity check after A (`0.1.0-next.a679b0b`) worked in QA Wolf but the bit-for-bit A′ republish (`0.1.0-next.aab35ec`) failed with `Failed to install NPM dependencies`.

## Test plan
- [ ] Merge to `main` and confirm publish CI releases `0.2.0` as `latest`
- [ ] In QA Wolf, pin `"@rickcedwhat/playwright-smart-vision": "0.2.0"` (not `@next`)
- [ ] Confirm whether install succeeds vs A / A′
- [ ] If it fails, grab the raw `npm install` stderr, not just the wrapper message


Made with [Cursor](https://cursor.com)