### PR TITLE
fix: restore b19c880 FAB evaluate behavior on 0.2.0

### DIFF
--- a/packages/core/src/devtools.ts
+++ b/packages/core/src/devtools.ts
@@ -2,6 +2,19 @@ import type { Page } from '@playwright/test';
 import { writeScreenBuffer } from './configure.js';
 
 const FAB_SCRIPT = `(function () {
+  if (!window.__ocrKeyboardShield) {
+    window.__ocrKeyboardShield = true;
+    const shield = (e) => {
+      const backdrop = document.getElementById('__ocr-modal-backdrop');
+      if (backdrop && backdrop.contains(e.target)) {
+        e.stopImmediatePropagation();
+      }
+    };
+    for (const type of ['keydown', 'keyup', 'keypress']) {
+      document.addEventListener(type, shield, true);
+    }
+  }
+
   if (window.__ocrDevtools) return;
   window.__ocrDevtools = true;
 
@@ -19,19 +32,31 @@ const FAB_SCRIPT = `(function () {
         right: 20px;
         z-index: 2147483647;
         font-family: system-ui, sans-serif;
+        display: block;
+        line-height: 0;
       }
       #__ocr-fab-btn {
         width: 48px;
         height: 48px;
+        min-width: 48px;
+        min-height: 48px;
+        padding: 0;
+        margin: 0;
+        box-sizing: border-box;
         border-radius: 50%;
         background: #1a1a2e;
         border: 2px solid #4f46e5;
         color: #fff;
         font-size: 20px;
+        line-height: 1;
         cursor: pointer;
         display: flex;
         align-items: center;
         justify-content: center;
+        flex-shrink: 0;
+        aspect-ratio: 1;
+        appearance: none;
+        -webkit-appearance: none;
         box-shadow: 0 4px 12px rgba(0,0,0,0.4);
         transition: transform 0.15s;
       }
@@ -69,6 +94,7 @@ const FAB_SCRIPT = `(function () {
         display: flex;
         align-items: center;
         justify-content: center;
+        font-family: system-ui, sans-serif;
       }
       #__ocr-modal {
         background: #1a1a2e;
@@ -79,6 +105,7 @@ const FAB_SCRIPT = `(function () {
         max-width: 90vw;
         box-shadow: 0 8px 32px rgba(0,0,0,0.6);
         font-family: system-ui, sans-serif;
+        line-height: normal;
       }
       #__ocr-modal h3 { margin: 0 0 12px; color: #e2e8f0; font-size: 15px; }
       #__ocr-modal img { width: 100%; border-radius: 6px; border: 1px solid #4f46e5; margin-bottom: 12px; }
@@ -93,6 +120,9 @@ const FAB_SCRIPT = `(function () {
         font-size: 13px;
         margin-bottom: 12px;
         outline: none;
+        pointer-events: auto;
+        user-select: text;
+        -webkit-user-select: text;
       }
       #__ocr-modal input:focus { border-color: #818cf8; }
       #__ocr-modal-actions { display: flex; gap: 8px; justify-content: flex-end; }
@@ -128,9 +158,14 @@ const FAB_SCRIPT = `(function () {
       <button id="__ocr-fab-btn" title="OCR Devtools">\u{1F441}</button>
     \`;
 
-    fab.addEventListener('mousedown', (e) => e.stopPropagation());
-    fab.addEventListener('mouseup', (e) => e.stopPropagation());
-    fab.addEventListener('click', (e) => e.stopPropagation());
+    function isolateFromPage(el) {
+      const types = ['mousedown', 'mouseup', 'click', 'dblclick', 'keydown', 'keyup', 'keypress', 'input', 'compositionstart', 'compositionupdate', 'compositionend'];
+      for (const type of types) {
+        el.addEventListener(type, (e) => e.stopPropagation());
+      }
+    }
+
+    isolateFromPage(fab);
 
     (document.body || document.documentElement).appendChild(fab);
 
@@ -171,9 +206,14 @@ const FAB_SCRIPT = `(function () {
       \`;
       document.body.appendChild(backdrop);
 
+      const modal = backdrop.querySelector('#__ocr-modal');
       const input = backdrop.querySelector('#__ocr-name-input');
       const saveBtn = backdrop.querySelector('#__ocr-modal-save');
       const cancelBtn = backdrop.querySelector('#__ocr-modal-cancel');
+
+      isolateFromPage(backdrop);
+      isolateFromPage(modal);
+      isolateFromPage(input);
 
       input.focus();
 

--- a/packages/core/src/devtools.ts
+++ b/packages/core/src/devtools.ts
@@ -5,8 +5,11 @@ const FAB_SCRIPT = `(function () {
   if (window.__ocrDevtools) return;
   window.__ocrDevtools = true;
 
+  console.log('[OCR devtools] script loaded, readyState:', document.readyState);
+
   function init() {
     if (document.getElementById('__ocr-fab')) return;
+    console.log('[OCR devtools] mounting FAB');
 
     const style = document.createElement('style');
     style.textContent = \`
@@ -225,5 +228,7 @@ export async function injectDevtools(page: Page): Promise<void> {
     writeScreenBuffer(name, Buffer.from(b64, 'base64'));
   });
 
+  // addInitScript covers future navigations; evaluate covers the already-loaded page.
   await page.addInitScript(FAB_SCRIPT);
+  await page.evaluate(FAB_SCRIPT);
 }

--- a/packages/core/tests/devtools.spec.ts
+++ b/packages/core/tests/devtools.spec.ts
@@ -37,4 +37,26 @@ test.describe('devtools FAB', () => {
     await page.locator('#__ocr-fab-btn').click();
     await expect(page.locator('#__ocr-fab-menu')).toHaveClass(/open/);
   });
+
+  test('FAB button stays circular', async ({ page }) => {
+    await page.goto('/');
+    await injectDevtools(page);
+
+    const box = await page.locator('#__ocr-fab-btn').boundingBox();
+    expect(box).not.toBeNull();
+    expect(Math.abs(box!.width - box!.height)).toBeLessThan(1);
+  });
+
+  test('capture modal name input accepts typing', async ({ page }) => {
+    await page.goto('/');
+    await injectDevtools(page);
+
+    await page.locator('#__ocr-fab-btn').click();
+    await page.locator('#__ocr-capture-btn').click();
+
+    const input = page.locator('#__ocr-name-input');
+    await expect(input).toBeVisible();
+    await input.fill('customer-info');
+    await expect(input).toHaveValue('customer-info');
+  });
 });

--- a/packages/core/tests/devtools.spec.ts
+++ b/packages/core/tests/devtools.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+import { injectDevtools } from '../src/devtools.js';
+import { configure } from '../src/configure.js';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+
+test.describe('devtools FAB', () => {
+  test('FAB is visible after injectDevtools on already-loaded page', async ({ page }) => {
+    await page.goto('/');
+    await injectDevtools(page);
+
+    await expect(page.locator('#__ocr-fab')).toBeVisible();
+  });
+
+  test('FAB is visible via configure({ devtools, page }) after navigation', async ({ page }) => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-test-'));
+    await configure({ storage: { root: tmp }, devtools: true, page });
+
+    await page.goto('/');
+    await expect(page.locator('#__ocr-fab')).toBeVisible();
+  });
+
+  test('FAB survives navigation and reappears', async ({ page }) => {
+    await injectDevtools(page);
+    await page.goto('/');
+    await expect(page.locator('#__ocr-fab')).toBeVisible();
+
+    await page.goto('/');
+    await expect(page.locator('#__ocr-fab')).toBeVisible();
+  });
+
+  test('FAB button opens capture menu on click', async ({ page }) => {
+    await page.goto('/');
+    await injectDevtools(page);
+
+    await page.locator('#__ocr-fab-btn').click();
+    await expect(page.locator('#__ocr-fab-menu')).toHaveClass(/open/);
+  });
+});


### PR DESCRIPTION
## Summary
- Restores the favorite `0.1.0-next.b19c880` (#29) behavior: `injectDevtools` runs `page.evaluate(FAB_SCRIPT)` so the FAB mounts on an already-loaded page, not only future navigations.
- Brings back the FAB e2e tests and the two debug `console.log`s from that commit.
- Leaves the package version at **0.2.0** (no `next` prerelease). Source matches `b19c880` except the version field.

## Test plan
- [ ] Merge to `main` and confirm publish CI releases a new `0.2.0-next.<sha>` (version in package.json is already 0.2.0, so this will be a `next` tag unless we bump again)
- [ ] Or bump if we want this on `latest` — current publish rules only stamp `latest` when the semver in package.json increases
- [ ] FAB appears after `injectDevtools` on an already-loaded page
- [ ] FAB survives navigation
- [ ] QA Wolf still installs after opening the flow in a new tab


Made with [Cursor](https://cursor.com)