### PR TITLE
fix: restore original capture click handler

### DIFF
--- a/packages/core/src/devtools.ts
+++ b/packages/core/src/devtools.ts
@@ -203,31 +203,16 @@ const FAB_SCRIPT = `(function () {
       if (!fab.contains(e.target)) menu.classList.remove('open');
     });
 
-    let capturing = false;
-    async function startCapture() {
-      if (capturing) return;
-      capturing = true;
+    captureBtn.addEventListener('click', async () => {
       menu.classList.remove('open');
       fab.style.display = 'none';
+      let b64;
       try {
-        const b64 = await window.__ocrCapture();
-        showModal(b64);
-      } catch (err) {
-        alert('Capture failed: ' + (err && err.message ? err.message : err));
+        b64 = await window.__ocrCapture();
       } finally {
         fab.style.display = '';
-        capturing = false;
       }
-    }
-
-    captureBtn.addEventListener('mousedown', (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      startCapture();
-    });
-    captureBtn.addEventListener('click', (e) => {
-      e.preventDefault();
-      e.stopPropagation();
+      showModal(b64);
     });
 
     function showModal(b64) {


### PR DESCRIPTION
## Summary
- Follow-up to #35. Capture Screen started failing with `Cannot read properties of undefined (reading 'toString')` because capture ran on **mousedown** while the FAB was hidden.
- Restores the original **click → screenshot → modal** path from b19.
- Does not change the name-field typing shield or circular FAB CSS.

## Test plan
- [ ] Capture Screen opens the modal with a real screenshot (no alert)
- [ ] Name field still accepts typing
- [ ] Eye FAB still looks circular


Made with [Cursor](https://cursor.com)