### PR TITLE
feat: eye FAB captures immediately (no menu)

### DIFF
--- a/packages/core/src/devtools.ts
+++ b/packages/core/src/devtools.ts
@@ -58,13 +58,18 @@ const FAB_SCRIPT = `(function () {
         font-family: system-ui, sans-serif;
       }
       #__ocr-fab-btn {
+        position: relative;
+        z-index: 1;
         width: 48px;
         height: 48px;
         min-width: 48px;
         min-height: 48px;
+        max-width: 48px;
+        max-height: 48px;
         padding: 0;
         margin: 0;
         box-sizing: border-box;
+        overflow: hidden;
         border-radius: 50%;
         background: #1a1a2e;
         border: 2px solid #4f46e5;
@@ -87,6 +92,7 @@ const FAB_SCRIPT = `(function () {
         position: absolute;
         bottom: 56px;
         right: 0;
+        z-index: 2;
         background: #1a1a2e;
         border: 1px solid #4f46e5;
         border-radius: 8px;
@@ -175,10 +181,10 @@ const FAB_SCRIPT = `(function () {
     const fab = document.createElement('div');
     fab.id = '__ocr-fab';
     fab.innerHTML = \`
+      <button id="__ocr-fab-btn" title="OCR Devtools">\u{1F441}</button>
       <div id="__ocr-fab-menu">
         <button id="__ocr-capture-btn">\u{1F4F7} Capture Screen</button>
       </div>
-      <button id="__ocr-fab-btn" title="OCR Devtools">\u{1F441}</button>
     \`;
 
     function isolateFromPage(el) {

--- a/packages/core/src/devtools.ts
+++ b/packages/core/src/devtools.ts
@@ -58,8 +58,6 @@ const FAB_SCRIPT = `(function () {
         font-family: system-ui, sans-serif;
       }
       #__ocr-fab-btn {
-        position: relative;
-        z-index: 1;
         width: 48px;
         height: 48px;
         min-width: 48px;
@@ -88,33 +86,6 @@ const FAB_SCRIPT = `(function () {
         transition: transform 0.15s;
       }
       #__ocr-fab-btn:hover { transform: scale(1.1); }
-      #__ocr-fab-menu {
-        position: absolute;
-        bottom: 56px;
-        right: 0;
-        z-index: 2;
-        background: #1a1a2e;
-        border: 1px solid #4f46e5;
-        border-radius: 8px;
-        overflow: hidden;
-        box-shadow: 0 4px 16px rgba(0,0,0,0.5);
-        display: none;
-      }
-      #__ocr-fab-menu.open { display: block; }
-      #__ocr-fab-menu button {
-        display: block;
-        width: 100%;
-        padding: 10px 16px;
-        background: none;
-        border: none;
-        color: #e2e8f0;
-        font-size: 13px;
-        line-height: 1.4;
-        cursor: pointer;
-        white-space: nowrap;
-        text-align: left;
-      }
-      #__ocr-fab-menu button:hover { background: #2d2d4e; }
       #__ocr-modal-backdrop {
         position: fixed;
         inset: 0;
@@ -181,10 +152,7 @@ const FAB_SCRIPT = `(function () {
     const fab = document.createElement('div');
     fab.id = '__ocr-fab';
     fab.innerHTML = \`
-      <button id="__ocr-fab-btn" title="OCR Devtools">\u{1F441}</button>
-      <div id="__ocr-fab-menu">
-        <button id="__ocr-capture-btn">\u{1F4F7} Capture Screen</button>
-      </div>
+      <button id="__ocr-fab-btn" title="Capture screen">\u{1F441}</button>
     \`;
 
     function isolateFromPage(el) {
@@ -201,16 +169,8 @@ const FAB_SCRIPT = `(function () {
     (document.body || document.documentElement).appendChild(fab);
 
     const fabBtn = fab.querySelector('#__ocr-fab-btn');
-    const menu = fab.querySelector('#__ocr-fab-menu');
-    const captureBtn = fab.querySelector('#__ocr-capture-btn');
 
-    fabBtn.addEventListener('click', (e) => { e.stopPropagation(); menu.classList.toggle('open'); });
-    document.addEventListener('click', (e) => {
-      if (!fab.contains(e.target)) menu.classList.remove('open');
-    });
-
-    captureBtn.addEventListener('click', async () => {
-      menu.classList.remove('open');
+    fabBtn.addEventListener('click', async () => {
       fab.style.display = 'none';
       let b64;
       try {

--- a/packages/core/tests/devtools.spec.ts
+++ b/packages/core/tests/devtools.spec.ts
@@ -30,31 +30,6 @@ test.describe('devtools FAB', () => {
     await expect(page.locator('#__ocr-fab')).toBeVisible();
   });
 
-  test('FAB button opens capture menu on click', async ({ page }) => {
-    await page.goto('/');
-    await injectDevtools(page);
-
-    await page.locator('#__ocr-fab-btn').click();
-    await expect(page.locator('#__ocr-fab-menu')).toHaveClass(/open/);
-  });
-
-  test('Capture Screen menu item is hit-testable above the FAB button', async ({ page }) => {
-    await page.goto('/');
-    await injectDevtools(page);
-
-    await page.locator('#__ocr-fab-btn').click();
-    const menu = page.locator('#__ocr-fab-menu');
-    await expect(menu).toHaveClass(/open/);
-
-    const box = await menu.boundingBox();
-    expect(box).not.toBeNull();
-    const hit = await page.evaluate(({ x, y }) => {
-      const el = document.elementFromPoint(x, y);
-      return el?.closest('#__ocr-fab-menu')?.id ?? el?.id ?? null;
-    }, { x: box!.x + box!.width / 2, y: box!.y + box!.height / 2 });
-    expect(hit).toBe('__ocr-fab-menu');
-  });
-
   test('FAB button stays circular', async ({ page }) => {
     await page.goto('/');
     await injectDevtools(page);
@@ -64,12 +39,11 @@ test.describe('devtools FAB', () => {
     expect(Math.abs(box!.width - box!.height)).toBeLessThan(1);
   });
 
-  test('capture screen opens modal', async ({ page }) => {
+  test('FAB click captures and opens the modal', async ({ page }) => {
     await page.goto('/');
     await injectDevtools(page);
 
     await page.locator('#__ocr-fab-btn').click();
-    await page.locator('#__ocr-capture-btn').click();
 
     await expect(page.locator('#__ocr-modal-backdrop')).toBeVisible();
     await expect(page.locator('#__ocr-name-input')).toBeVisible();
@@ -80,7 +54,6 @@ test.describe('devtools FAB', () => {
     await injectDevtools(page);
 
     await page.locator('#__ocr-fab-btn').click();
-    await page.locator('#__ocr-capture-btn').click();
 
     const input = page.locator('#__ocr-name-input');
     await expect(input).toBeVisible();

--- a/packages/core/tests/devtools.spec.ts
+++ b/packages/core/tests/devtools.spec.ts
@@ -38,6 +38,23 @@ test.describe('devtools FAB', () => {
     await expect(page.locator('#__ocr-fab-menu')).toHaveClass(/open/);
   });
 
+  test('Capture Screen menu item is hit-testable above the FAB button', async ({ page }) => {
+    await page.goto('/');
+    await injectDevtools(page);
+
+    await page.locator('#__ocr-fab-btn').click();
+    const menu = page.locator('#__ocr-fab-menu');
+    await expect(menu).toHaveClass(/open/);
+
+    const box = await menu.boundingBox();
+    expect(box).not.toBeNull();
+    const hit = await page.evaluate(({ x, y }) => {
+      const el = document.elementFromPoint(x, y);
+      return el?.closest('#__ocr-fab-menu')?.id ?? el?.id ?? null;
+    }, { x: box!.x + box!.width / 2, y: box!.y + box!.height / 2 });
+    expect(hit).toBe('__ocr-fab-menu');
+  });
+
   test('FAB button stays circular', async ({ page }) => {
     await page.goto('/');
     await injectDevtools(page);


### PR DESCRIPTION
## Summary
- Eye button click hides the FAB, takes a screenshot, and opens the save modal. No Capture Screen menu.
- Avoids the extra click that was getting lost in Guacamole.
- Circular FAB and name-field typing shield are unchanged.

## Test plan
- [ ] Eye click opens the captured-screen modal (no menu)
- [ ] Screenshot still excludes the FAB
- [ ] Name field accepts typing
- [ ] Save / Cancel still work