### PR TITLE
chore: bump core to 0.3.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rickcedwhat/playwright-smart-vision",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Computer-vision and OCR-based element assertions for Playwright — local, fast, no GPT Vision required",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bumps `@rickcedwhat/playwright-smart-vision` from `0.2.0` to `0.3.0`.
- Publish CI will release `0.3.0` on the `latest` tag (one-click eye FAB capture, circular button, name-field typing in Guacamole).

## Test plan
- [ ] Merge to `main` and confirm publish CI releases `0.3.0` as `latest`
- [ ] Pin `"@rickcedwhat/playwright-smart-vision": "0.3.0"` in QA Wolf


Made with [Cursor](https://cursor.com)