### PR TITLE
feat: TM v2 authoring with labels and dropdown+field sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test:unit": "pnpm -r --if-present test:unit",
     "test:e2e": "pnpm -r --if-present test:e2e",
     "dev": "node packages/tools/template-manager-server.mjs",
+    "tm:v2": "pnpm build && node packages/tools/tm-v2/server.mjs",
     "dev:fixtures": "node packages/core/scripts/serve-fixtures.mjs",
     "capture": "pnpm --filter @rickcedwhat/playwright-smart-vision test:e2e --grep=CAPTURE_ONLY_NO_TESTS --pass-with-no-tests"
   }

--- a/packages/core/src/author/apply.ts
+++ b/packages/core/src/author/apply.ts
@@ -2,19 +2,29 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { PNG } from 'pngjs';
 import {
+  cellRunsToRects,
+  evenHorizontalSlices,
   expandLeftForLabel,
+  findAlignedCells,
   insetRect,
   kebab,
   ocrRectFromBoxes,
   relativeToCrop,
+  sliceRectHorizontal,
+  unionRects,
   type DetectedBox,
 } from './geometry.js';
 import type { BoxesFile } from './detect.js';
+import type { DetectedLabel } from './labels.js';
 import { screenDir } from './storage.js';
 
 export interface FirstPassPart {
   name: string;
-  boxId: number;
+  /** Detected box. Omit to split the parent field box left-to-right. */
+  boxId?: number;
+  /** Optional 0–1 span of the parent field union when boxId is omitted. */
+  start?: number;
+  end?: number;
 }
 
 export interface FirstPassElement {
@@ -22,17 +32,35 @@ export interface FirstPassElement {
   type?: string;
   section?: string | null;
   boxIds: number[];
+  /** Detected label ids to union into the crop (any side of the control). */
+  labelIds?: number[];
   parts?: FirstPassPart[];
   charset?: string;
   options?: string[];
+  /** If true and labelIds is empty, grow the crop left (legacy). Default is box-only. */
+  includeLabel?: boolean;
+}
+
+export interface FirstPassSection {
+  name: string;
+  boxIds: number[];
 }
 
 export interface FirstPass {
   screen?: { name?: string; width?: number; height?: number };
   notes?: string[];
   unknowns?: string[];
-  sections?: unknown[];
+  sections?: FirstPassSection[];
   elements: FirstPassElement[];
+}
+
+export interface AppliedSection {
+  name: string;
+  filename: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
 }
 
 export interface AppliedElement {
@@ -44,8 +72,10 @@ export interface AppliedElement {
   width: number;
   height: number;
   boxIds?: number[];
+  labelIds?: number[];
   charset?: string;
   options?: string[];
+  section?: string;
   ocrRect?: { x: number; y: number; width: number; height: number };
   parts?: Array<{ name: string; x: number; y: number; width: number; height: number }>;
 }
@@ -71,12 +101,104 @@ function cropPng(pngBuffer: Buffer, x: number, y: number, width: number, height:
   return PNG.sync.write(out);
 }
 
-function toIndex(name: string, elements: AppliedElement[]) {
+function padRect(rect: { x: number; y: number; width: number; height: number }, pad: number) {
+  return {
+    x: Math.max(0, rect.x - pad),
+    y: Math.max(0, rect.y - pad),
+    width: rect.width + pad * 2,
+    height: rect.height + pad * 2,
+  };
+}
+
+/** Union of assigned boxes + labels. Left-grow only when includeLabel is true and no labelIds. */
+function cropForElement(
+  el: FirstPassElement,
+  boxes: DetectedBox[],
+  fieldBoxes: DetectedBox[],
+  labelRects: DetectedLabel[],
+  png: { width: number; height: number; data: Buffer | Uint8Array },
+  extraBoxes: DetectedBox[] = [],
+) {
+  const joined = [...fieldBoxes, ...labelRects, ...extraBoxes];
+  if (!joined.length) return undefined;
+  if (labelRects.length) return padRect(unionRects(joined), 4);
+  if (el.includeLabel === true && fieldBoxes.length) {
+    const grown = expandLeftForLabel(boxes, fieldBoxes, 8, 140, png);
+    return extraBoxes.length ? unionRects([grown, ...extraBoxes]) : grown;
+  }
+  if (extraBoxes.length) return padRect(unionRects(joined), 2);
+  return unionRects(fieldBoxes);
+}
+
+function toIndex(name: string, elements: AppliedElement[], sections: AppliedSection[]) {
   return {
     name,
-    sections: [],
+    sections,
     elements,
   };
+}
+
+function columnMeans(png: { width: number; height: number; data: Buffer | Uint8Array }, rect: { x: number; y: number; width: number; height: number }): number[] {
+  const y0 = Math.max(0, Math.round(rect.y) + 2);
+  const y1 = Math.min(png.height, Math.round(rect.y + rect.height) - 2);
+  const rows = Math.max(1, y1 - y0);
+  const x0 = Math.round(rect.x);
+  const width = Math.round(rect.width);
+  const means: number[] = [];
+  for (let dx = 0; dx < width; dx++) {
+    const x = x0 + dx;
+    if (x < 0 || x >= png.width) {
+      means.push(0);
+      continue;
+    }
+    let sum = 0;
+    for (let y = y0; y < y1; y++) {
+      const i = (y * png.width + x) * 4;
+      sum += (png.data[i]! + png.data[i + 1]! + png.data[i + 2]!) / 3;
+    }
+    means.push(sum / rows);
+  }
+  return means;
+}
+
+function resolveParts(
+  specs: FirstPassPart[],
+  fieldBoxes: DetectedBox[],
+  crop: { x: number; y: number; width: number; height: number },
+  byId: Map<number, DetectedBox>,
+  png?: { width: number; height: number; data: Buffer | Uint8Array },
+): Array<{ name: string; x: number; y: number; width: number; height: number }> {
+  if (!specs.length || !fieldBoxes.length) return [];
+  const union = unionRects(fieldBoxes);
+  const namesOnly = specs.every((part) => part.boxId == null);
+  let cells: ReturnType<typeof cellRunsToRects> = [];
+  if (namesOnly && png && specs.every((part) => part.start == null && part.end == null)) {
+    const runs = findAlignedCells(columnMeans(png, union), specs.length);
+    if (runs) cells = cellRunsToRects(union, runs);
+  }
+  const even = namesOnly && !cells.length
+    ? evenHorizontalSlices(insetRect(union, 2), specs.length)
+    : [];
+  const out: Array<{ name: string; x: number; y: number; width: number; height: number }> = [];
+  for (let i = 0; i < specs.length; i++) {
+    const part = specs[i]!;
+    let rect;
+    if (part.boxId != null) {
+      const box = byId.get(part.boxId);
+      if (!box) continue;
+      rect = insetRect(box, 2);
+    } else if (part.start != null && part.end != null) {
+      rect = sliceRectHorizontal(insetRect(union, 2), part.start, part.end);
+    } else if (cells[i]) {
+      rect = cells[i]!;
+    } else if (even[i]) {
+      rect = even[i]!;
+    } else {
+      continue;
+    }
+    out.push({ name: part.name, ...relativeToCrop(rect, crop) });
+  }
+  return out;
 }
 
 /**
@@ -102,48 +224,70 @@ export function applyScreen(name: string, firstPass?: FirstPass): ApplyScreenRes
   }
 
   const blank = fs.readFileSync(blankPath);
-  const { boxes } = JSON.parse(fs.readFileSync(boxesPath, 'utf8')) as BoxesFile;
+  const png = PNG.sync.read(blank);
+  const boxesFile = JSON.parse(fs.readFileSync(boxesPath, 'utf8')) as BoxesFile;
+  const { boxes } = boxesFile;
+  const labels = boxesFile.labels || [];
   const pass = JSON.parse(fs.readFileSync(firstPassPath, 'utf8')) as FirstPass;
   const byId = new Map(boxes.map((box) => [box.id, box]));
+  const byLabel = new Map(labels.map((label) => [label.id, label]));
   const tmplDir = path.join(dir, 'templates');
   fs.rmSync(tmplDir, { recursive: true, force: true });
   fs.mkdirSync(tmplDir, { recursive: true });
 
+  const indexSections: AppliedSection[] = [];
+  const sectionFile = new Map<string, string>();
+  const sectionBoxesByName = new Map<string, DetectedBox[]>();
+  for (const sec of pass.sections || []) {
+    const secBoxes = (sec.boxIds || []).map((id) => byId.get(id)).filter((b): b is DetectedBox => Boolean(b));
+    if (!sec.name || !secBoxes.length) continue;
+    const memberLabels = (pass.elements || [])
+      .filter((el) => el.section === sec.name)
+      .flatMap((el) => (el.labelIds || []).map((id) => byLabel.get(id)).filter((l): l is DetectedLabel => Boolean(l)));
+    const union = unionRects([...secBoxes, ...memberLabels]);
+    const crop = padRect(union, memberLabels.length ? 4 : 2);
+    const filename = `section-${kebab(sec.name)}.png`;
+    fs.writeFileSync(path.join(tmplDir, filename), cropPng(blank, crop.x, crop.y, crop.width, crop.height));
+    indexSections.push({ name: sec.name, filename, ...crop });
+    sectionFile.set(sec.name, filename);
+    sectionBoxesByName.set(sec.name, secBoxes);
+  }
+
   const elements: AppliedElement[] = [];
   for (const el of pass.elements || []) {
     const fieldBoxes = (el.boxIds || []).map((id) => byId.get(id)).filter((b): b is DetectedBox => Boolean(b));
-    const crop = fieldBoxes.length ? expandLeftForLabel(boxes, fieldBoxes) : undefined;
-    if (!crop) continue;
+    const labelRects = (el.labelIds || []).map((id) => byLabel.get(id)).filter((l): l is DetectedLabel => Boolean(l));
+    const extraBoxes = el.section ? (sectionBoxesByName.get(el.section) || []) : [];
+    const overlay = cropForElement(el, boxes, fieldBoxes, labelRects, png);
+    const match = cropForElement(el, boxes, fieldBoxes, labelRects, png, extraBoxes);
+    if (!match) continue;
     const filename = `${kebab(el.name)}.png`;
-    fs.writeFileSync(path.join(tmplDir, filename), cropPng(blank, crop.x, crop.y, crop.width, crop.height));
-    const parts = (el.parts || [])
-      .map((part) => {
-        const box = byId.get(part.boxId);
-        if (!box) return null;
-        return { name: part.name, ...relativeToCrop(insetRect(box, 2), crop) };
-      })
-      .filter((p): p is NonNullable<typeof p> => p !== null);
+    fs.writeFileSync(path.join(tmplDir, filename), cropPng(blank, match.x, match.y, match.width, match.height));
+    const parts = resolveParts(el.parts || [], fieldBoxes, match, byId, png);
+    const shown = overlay || match;
 
     const applied: AppliedElement = {
       name: el.name,
       filename,
       type: el.type || 'field',
-      x: crop.x,
-      y: crop.y,
-      width: crop.width,
-      height: crop.height,
+      x: shown.x,
+      y: shown.y,
+      width: shown.width,
+      height: shown.height,
     };
     if (el.boxIds?.length) applied.boxIds = el.boxIds;
+    if (el.labelIds?.length) applied.labelIds = el.labelIds;
     if (el.charset) applied.charset = el.charset;
     if (el.options?.length) applied.options = el.options;
-    if (fieldBoxes.length) applied.ocrRect = ocrRectFromBoxes(crop, fieldBoxes, el.type || 'field');
+    if (el.section) applied.section = sectionFile.get(el.section) || el.section;
+    if (fieldBoxes.length) applied.ocrRect = ocrRectFromBoxes(match, fieldBoxes, el.type || 'field');
     if (parts.length) applied.parts = parts;
     elements.push(applied);
   }
 
   const folder = pass.screen?.name || name;
   const indexPath = path.join(dir, 'index.json');
-  fs.writeFileSync(indexPath, `${JSON.stringify(toIndex(folder, elements), null, 2)}\n`);
+  fs.writeFileSync(indexPath, `${JSON.stringify(toIndex(folder, elements, indexSections), null, 2)}\n`);
 
   return { dir, indexPath, firstPassPath, elements };
 }

--- a/packages/core/src/author/author.test.ts
+++ b/packages/core/src/author/author.test.ts
@@ -28,6 +28,9 @@ describe('author apply + catalog', () => {
         { id: 1, x: 590, y: 147, width: 204, height: 22 },
         { id: 2, x: 590, y: 174, width: 204, height: 22 },
       ],
+      labels: [
+        { id: 1, x: 500, y: 149, width: 80, height: 16, text: 'Username:' },
+      ],
     }, null, 2)}\n`);
   });
 
@@ -43,12 +46,99 @@ describe('author apply + catalog', () => {
       ],
     });
     expect(result.elements.map((e) => e.name)).toEqual(['username', 'password']);
+    expect(result.elements[0]).toMatchObject({ x: 590, y: 147, width: 204, height: 22 });
+    expect(result.elements[0]!.x + result.elements[0]!.width).toBe(590 + 204);
     expect(fs.existsSync(path.join(result.dir, 'index.json'))).toBe(true);
     for (const el of result.elements) {
       expect(fs.existsSync(path.join(result.dir, 'templates', el.filename))).toBe(true);
     }
     const screen = loadScreen(name);
     expect(screen.elementConfigs.map((e) => e.name)).toEqual(['username', 'password']);
+  });
+
+  it('applyScreen splits a merged box into named parts without extra boxIds', () => {
+    const result = applyScreen(name, {
+      screen: { name },
+      elements: [
+        {
+          name: 'delivered',
+          type: 'field',
+          boxIds: [1],
+          parts: [{ name: 'month' }, { name: 'day' }, { name: 'year' }],
+        },
+      ],
+    });
+    const delivered = result.elements.find((el) => el.name === 'delivered');
+    expect(delivered?.parts?.map((p) => p.name)).toEqual(['month', 'day', 'year']);
+    expect(delivered?.parts?.[0]?.width).toBeGreaterThan(0);
+    expect(delivered?.parts?.[2]?.x).toBeGreaterThan(delivered!.parts![0]!.x);
+  });
+
+  it('applyScreen keeps button crops on the detected box', () => {
+    const result = applyScreen(name, {
+      screen: { name },
+      elements: [
+        { name: 'username', type: 'field', boxIds: [1] },
+        { name: 'ok', type: 'button', boxIds: [2] },
+      ],
+    });
+    const ok = result.elements.find((el) => el.name === 'ok');
+    expect(ok).toMatchObject({ x: 590, y: 174, width: 204, height: 22 });
+    const username = result.elements.find((el) => el.name === 'username');
+    expect(username).toMatchObject({ x: 590, y: 147, width: 204, height: 22 });
+  });
+
+  it('applyScreen unions section boxes into the match crop and keeps overlay on the element', () => {
+    const result = applyScreen(name, {
+      screen: { name },
+      sections: [{ name: 'pairSection', boxIds: [1, 2] }],
+      elements: [
+        { name: 'wide', type: 'dropdown', section: 'pairSection', boxIds: [1] },
+        { name: 'narrow', type: 'field', section: 'pairSection', boxIds: [2] },
+      ],
+    });
+    const wide = result.elements.find((el) => el.name === 'wide')!;
+    const narrow = result.elements.find((el) => el.name === 'narrow')!;
+    expect(wide).toMatchObject({ x: 590, y: 147, width: 204, height: 22 });
+    expect(narrow).toMatchObject({ x: 590, y: 174, width: 204, height: 22 });
+    expect(wide.section).toBe('section-pair-section.png');
+    expect(narrow.section).toBe('section-pair-section.png');
+    expect(wide.ocrRect!.y).toBeLessThan(10);
+    expect(narrow.ocrRect!.y).toBeGreaterThan(20);
+    const index = JSON.parse(fs.readFileSync(result.indexPath, 'utf8')) as {
+      sections: Array<{ name: string; filename: string; x: number; y: number; width: number; height: number }>;
+    };
+    expect(index.sections[0]).toMatchObject({
+      name: 'pairSection',
+      filename: 'section-pair-section.png',
+      x: 588,
+      y: 145,
+    });
+    expect(index.sections[0]!.height).toBeGreaterThan(48);
+  });
+
+  it('applyScreen unions assigned labelIds into the crop', () => {
+    const result = applyScreen(name, {
+      screen: { name },
+      elements: [
+        { name: 'username', type: 'field', boxIds: [1], labelIds: [1] },
+      ],
+    });
+    const username = result.elements[0]!;
+    expect(username.x).toBeLessThan(500);
+    expect(username.x + username.width).toBeGreaterThan(590 + 204);
+    expect(username.labelIds).toEqual([1]);
+  });
+
+  it('applyScreen grows left only when includeLabel is true and labelIds are empty', () => {
+    const result = applyScreen(name, {
+      screen: { name },
+      elements: [
+        { name: 'username', type: 'field', boxIds: [1], includeLabel: true },
+      ],
+    });
+    expect(result.elements[0]!.x).toBeLessThan(590);
+    expect(result.elements[0]!.x + result.elements[0]!.width).toBeGreaterThan(590 + 204);
   });
 
   it('writeScreenCatalog emits typed screen/element names', () => {

--- a/packages/core/src/author/detect.ts
+++ b/packages/core/src/author/detect.ts
@@ -3,18 +3,31 @@ import path from 'node:path';
 import { PNG } from 'pngjs';
 import { VisionUtil, ensureCvReady, getCv } from '../utils/vision.js';
 import type { Rect } from '../utils/vision.js';
-import { dedupeBoxes, numberBoxes, type DetectedBox } from './geometry.js';
+import {
+  dedupeBoxes,
+  dropNestedBoxes,
+  numberBoxes,
+  splitBoxGutters,
+  splitMergedFields,
+  unionRects,
+  type DetectedBox,
+} from './geometry.js';
+import { labelsFromOcr, type DetectedLabel } from './labels.js';
+import { getOCRUtil } from '../utils/ocr.js';
 import { screenDir } from './storage.js';
 
-const MIN_W = 14;
-const MAX_W = 400;
-const MIN_H = 12;
-const MAX_H = 28;
+const MIN = 10;
+const EMPTY_MEAN = 205;
+const FILLED_EXTENT = 0.88;
+const LABEL_SCALE = 2;
+/** Room for a caption sitting just outside the outermost control. */
+const LABEL_PAD = 72;
 
 export interface BoxesFile {
   width: number;
   height: number;
   boxes: DetectedBox[];
+  labels?: DetectedLabel[];
 }
 
 export interface DetectScreenResult {
@@ -24,6 +37,60 @@ export interface DetectScreenResult {
   width: number;
   height: number;
   boxes: DetectedBox[];
+  labels: DetectedLabel[];
+}
+
+function columnMeansGray(gray: { rows: number; cols: number; data: Uint8Array }, rect: Rect): number[] {
+  const y0 = Math.max(0, rect.y + 2);
+  const y1 = Math.min(gray.rows, rect.y + rect.height - 2);
+  const rowCount = Math.max(1, y1 - y0);
+  const means: number[] = [];
+  for (let dx = 0; dx < rect.width; dx++) {
+    const x = rect.x + dx;
+    if (x < 0 || x >= gray.cols) {
+      means.push(0);
+      continue;
+    }
+    let sum = 0;
+    for (let y = y0; y < y1; y++) {
+      sum += gray.data[y * gray.cols + x]!;
+    }
+    means.push(sum / rowCount);
+  }
+  return means;
+}
+
+function rowMeansGray(gray: { rows: number; cols: number; data: Uint8Array }, rect: Rect): number[] {
+  const x0 = Math.max(0, rect.x);
+  const x1 = Math.min(gray.cols, rect.x + rect.width);
+  const colCount = Math.max(1, x1 - x0);
+  const means: number[] = [];
+  for (let dy = 0; dy < rect.height; dy++) {
+    const y = rect.y + dy;
+    if (y < 0 || y >= gray.rows) {
+      means.push(0);
+      continue;
+    }
+    let sum = 0;
+    for (let x = x0; x < x1; x++) {
+      sum += gray.data[y * gray.cols + x]!;
+    }
+    means.push(sum / colCount);
+  }
+  return means;
+}
+
+function keepRect(
+  rect: Rect,
+  mean: number,
+  vertices: number,
+  extent: number,
+  imgW: number,
+  imgH: number,
+): boolean {
+  if (rect.width < MIN || rect.height < MIN) return false;
+  if (rect.width > imgW * 0.85 || rect.height > imgH * 0.85) return false;
+  return mean >= EMPTY_MEAN || (vertices === 4 && extent >= FILLED_EXTENT);
 }
 
 export function detectBoxes(pngBuffer: Buffer): DetectedBox[] {
@@ -44,15 +111,26 @@ export function detectBoxes(pngBuffer: Buffer): DetectedBox[] {
   for (let i = 0; i < contours.size(); i++) {
     const contour = contours.get(i);
     const rect = cv.boundingRect(contour) as Rect;
+    const peri = cv.arcLength(contour, true);
+    const approx = new cv.Mat();
+    cv.approxPolyDP(contour, approx, 0.04 * peri, true);
+    const area = cv.contourArea(contour);
+    const extent = area / (rect.width * rect.height || 1);
+    let mean = 0;
+    if (rect.width >= 2 && rect.height >= 2 && rect.x + rect.width <= gray.cols && rect.y + rect.height <= gray.rows) {
+      const roi = gray.roi(rect);
+      mean = cv.mean(roi)[0] as number;
+      roi.delete();
+    }
+    if (keepRect(rect, mean, approx.rows, extent, gray.cols, gray.rows)) {
+      raw.push({ x: rect.x, y: rect.y, width: rect.width, height: rect.height });
+    }
+    approx.delete();
     contour.delete();
-    if (rect.width < MIN_W || rect.width > MAX_W) continue;
-    if (rect.height < MIN_H || rect.height > MAX_H) continue;
-    const roi = gray.roi(rect);
-    const mean = cv.mean(roi)[0] as number;
-    roi.delete();
-    if (mean < 205) continue;
-    raw.push({ x: rect.x, y: rect.y, width: rect.width, height: rect.height });
   }
+
+  const split = raw.flatMap((box) => splitBoxGutters(box, columnMeansGray(gray, box), rowMeansGray(gray, box)) || [box]);
+  const cells = split.filter((box) => box.height < 80);
 
   color.delete();
   gray.delete();
@@ -62,22 +140,24 @@ export function detectBoxes(pngBuffer: Buffer): DetectedBox[] {
   contours.delete();
   hierarchy.delete();
 
-  return numberBoxes(dedupeBoxes(raw));
+  return numberBoxes(dedupeBoxes(dropNestedBoxes(splitMergedFields(cells))));
 }
 
-export function annotateBoxes(pngBuffer: Buffer, boxes: DetectedBox[]): Buffer {
+export function annotateBoxes(pngBuffer: Buffer, boxes: DetectedBox[], labels: DetectedLabel[] = []): Buffer {
   const cv = getCv();
   const png = PNG.sync.read(pngBuffer);
   const mat = new cv.Mat(png.height, png.width, cv.CV_8UC4);
   mat.data.set(png.data);
-  const color = new cv.Scalar(220, 40, 40, 255);
-  const textColor = new cv.Scalar(180, 0, 0, 255);
+  const boxColor = new cv.Scalar(220, 40, 40, 255);
+  const boxText = new cv.Scalar(180, 0, 0, 255);
+  const labelColor = new cv.Scalar(30, 140, 200, 255);
+  const labelText = new cv.Scalar(20, 90, 150, 255);
   for (const box of boxes) {
     cv.rectangle(
       mat,
       new cv.Point(box.x, box.y),
       new cv.Point(box.x + box.width, box.y + box.height),
-      color,
+      boxColor,
       1,
     );
     cv.putText(
@@ -86,7 +166,25 @@ export function annotateBoxes(pngBuffer: Buffer, boxes: DetectedBox[]): Buffer {
       new cv.Point(box.x + 1, Math.max(10, box.y - 2)),
       cv.FONT_HERSHEY_SIMPLEX,
       0.35,
-      textColor,
+      boxText,
+      1,
+    );
+  }
+  for (const label of labels) {
+    cv.rectangle(
+      mat,
+      new cv.Point(label.x, label.y),
+      new cv.Point(label.x + label.width, label.y + label.height),
+      labelColor,
+      1,
+    );
+    cv.putText(
+      mat,
+      `L${label.id}`,
+      new cv.Point(label.x + 1, Math.max(10, label.y - 2)),
+      cv.FONT_HERSHEY_SIMPLEX,
+      0.32,
+      labelText,
       1,
     );
   }
@@ -96,8 +194,85 @@ export function annotateBoxes(pngBuffer: Buffer, boxes: DetectedBox[]): Buffer {
   return PNG.sync.write(out);
 }
 
+function cropPngBuffer(pngBuffer: Buffer, x: number, y: number, width: number, height: number): Buffer {
+  const png = PNG.sync.read(pngBuffer);
+  const sx = Math.max(0, Math.round(x));
+  const sy = Math.max(0, Math.round(y));
+  const sw = Math.max(1, Math.min(png.width - sx, Math.round(width)));
+  const sh = Math.max(1, Math.min(png.height - sy, Math.round(height)));
+  const out = new PNG({ width: sw, height: sh });
+  for (let row = 0; row < sh; row++) {
+    const src = ((sy + row) * png.width + sx) * 4;
+    out.data.set(png.data.subarray(src, src + sw * 4), row * sw * 4);
+  }
+  return PNG.sync.write(out);
+}
+
+function labelRoi(boxes: DetectedBox[], imgW: number, imgH: number): Rect {
+  if (!boxes.length) return { x: 0, y: 0, width: imgW, height: imgH };
+  const union = unionRects(boxes);
+  const x = Math.max(0, union.x - LABEL_PAD);
+  const y = Math.max(0, union.y - LABEL_PAD);
+  const right = Math.min(imgW, union.x + union.width + LABEL_PAD);
+  const bottom = Math.min(imgH, union.y + union.height + LABEL_PAD);
+  return { x, y, width: Math.max(1, right - x), height: Math.max(1, bottom - y) };
+}
+
+function scaleGrayPng(pngBuffer: Buffer, scale: number): Buffer {
+  const cv = getCv();
+  const vision = new VisionUtil();
+  const color = vision.loadImage(pngBuffer);
+  const gray = vision.toGrayscale(color);
+  color.delete();
+  const scaled = new cv.Mat();
+  cv.resize(
+    gray,
+    scaled,
+    new cv.Size(Math.max(1, gray.cols * scale), Math.max(1, gray.rows * scale)),
+    0,
+    0,
+    cv.INTER_CUBIC,
+  );
+  gray.delete();
+  const buf = vision.matToBuffer(scaled);
+  scaled.delete();
+  return buf;
+}
+
+async function detectLabels(pngBuffer: Buffer, boxes: DetectedBox[]): Promise<DetectedLabel[]> {
+  const png = PNG.sync.read(pngBuffer);
+  const roi = labelRoi(boxes, png.width, png.height);
+  const cropped = cropPngBuffer(pngBuffer, roi.x, roi.y, roi.width, roi.height);
+  const scaled = scaleGrayPng(cropped, LABEL_SCALE);
+  const ocr = await getOCRUtil();
+  const words = await ocr.extractPageWords(scaled);
+  const mapped = words.map((word) => ({
+    ...word,
+    x: word.x / LABEL_SCALE + roi.x,
+    y: word.y / LABEL_SCALE + roi.y,
+    width: word.width / LABEL_SCALE,
+    height: word.height / LABEL_SCALE,
+  }));
+  return labelsFromOcr(mapped, boxes);
+}
+
+function writeDetectFiles(
+  dir: string,
+  blank: Buffer,
+  meta: { width: number; height: number },
+  boxes: DetectedBox[],
+  labels: DetectedLabel[],
+): { boxesPath: string; annotatedPath: string } {
+  const boxesPath = path.join(dir, 'boxes.json');
+  const annotatedPath = path.join(dir, 'boxes-annotated.png');
+  const payload: BoxesFile = { width: meta.width, height: meta.height, boxes, labels };
+  fs.writeFileSync(boxesPath, `${JSON.stringify(payload, null, 2)}\n`);
+  fs.writeFileSync(annotatedPath, annotateBoxes(blank, boxes, labels));
+  return { boxesPath, annotatedPath };
+}
+
 /**
- * Run OpenCV box detection on `{storage.root}/{name}/blank.png`.
+ * Run OpenCV box detection + OCR labels on `{storage.root}/{name}/blank.png`.
  * Writes `boxes.json` and `boxes-annotated.png` next to the blank.
  */
 export async function detectScreen(name: string): Promise<DetectScreenResult> {
@@ -110,10 +285,48 @@ export async function detectScreen(name: string): Promise<DetectScreenResult> {
   const blank = fs.readFileSync(blankPath);
   const meta = PNG.sync.read(blank);
   const boxes = detectBoxes(blank);
+  const labels = await detectLabels(blank, boxes);
+  const { boxesPath, annotatedPath } = writeDetectFiles(dir, blank, meta, boxes, labels);
+  return { dir, boxesPath, annotatedPath, width: meta.width, height: meta.height, boxes, labels };
+}
+
+/** Persist boxes (including hand-drawn) and rewrite boxes-annotated.png. Keeps existing labels. */
+export async function writeBoxes(name: string, boxes: DetectedBox[]): Promise<DetectScreenResult> {
+  await ensureCvReady();
+  const dir = screenDir(name);
+  const blankPath = path.join(dir, 'blank.png');
+  if (!fs.existsSync(blankPath)) {
+    throw new Error(`writeBoxes('${name}'): no blank.png at ${blankPath}`);
+  }
+  const blank = fs.readFileSync(blankPath);
+  const meta = PNG.sync.read(blank);
+  const clean = boxes
+    .map((box) => ({
+      id: Number(box.id),
+      x: Math.round(box.x),
+      y: Math.round(box.y),
+      width: Math.max(1, Math.round(box.width)),
+      height: Math.max(1, Math.round(box.height)),
+    }))
+    .sort((a, b) => a.id - b.id);
   const boxesPath = path.join(dir, 'boxes.json');
-  const annotatedPath = path.join(dir, 'boxes-annotated.png');
-  const payload: BoxesFile = { width: meta.width, height: meta.height, boxes };
-  fs.writeFileSync(boxesPath, `${JSON.stringify(payload, null, 2)}\n`);
-  fs.writeFileSync(annotatedPath, annotateBoxes(blank, boxes));
-  return { dir, boxesPath, annotatedPath, width: meta.width, height: meta.height, boxes };
+  let labels: DetectedLabel[] = [];
+  if (fs.existsSync(boxesPath)) {
+    try {
+      const prev = JSON.parse(fs.readFileSync(boxesPath, 'utf8')) as BoxesFile;
+      labels = prev.labels || [];
+    } catch {
+      labels = [];
+    }
+  }
+  const written = writeDetectFiles(dir, blank, meta, clean, labels);
+  return {
+    dir,
+    boxesPath: written.boxesPath,
+    annotatedPath: written.annotatedPath,
+    width: meta.width,
+    height: meta.height,
+    boxes: clean,
+    labels,
+  };
 }

--- a/packages/core/src/author/geometry.test.ts
+++ b/packages/core/src/author/geometry.test.ts
@@ -5,9 +5,17 @@ import {
   insetRect,
   relativeToCrop,
   ocrRectFromBoxes,
+  includeLabelForType,
   expandLeftForLabel,
   dedupeBoxes,
+  dropNestedBoxes,
+  splitMergedFields,
   numberBoxes,
+  evenHorizontalSlices,
+  findAlignedCells,
+  findCellRow,
+  splitRowGutters,
+  sliceRectHorizontal,
 } from './geometry.js';
 
 describe('kebab', () => {
@@ -39,6 +47,117 @@ describe('unionRects / insetRect / relativeToCrop', () => {
   });
 });
 
+describe('sliceRectHorizontal / evenHorizontalSlices', () => {
+  it('splits a merged date box into thirds', () => {
+    const box = { x: 640, y: 344, width: 81, height: 18 };
+    const parts = evenHorizontalSlices(box, 3);
+    expect(parts).toHaveLength(3);
+    expect(parts[0]).toEqual({ x: 640, y: 344, width: 27, height: 18 });
+    expect(parts[1]?.x).toBe(667);
+    expect(parts[2]!.x + parts[2]!.width).toBe(721);
+  });
+
+  it('slices by explicit fractions', () => {
+    expect(sliceRectHorizontal({ x: 10, y: 2, width: 100, height: 8 }, 0, 0.25)).toEqual({
+      x: 10, y: 2, width: 25, height: 8,
+    });
+  });
+});
+
+describe('findAlignedCells', () => {
+  it('picks the three white date cells and skips slash gutters', () => {
+    const cols: number[] = [];
+    const paint = (n: number, v: number) => {
+      for (let i = 0; i < n; i++) cols.push(v);
+    };
+    paint(1, 38);
+    paint(18, 238);
+    paint(1, 39);
+    paint(10, 228);
+    paint(1, 39);
+    paint(18, 238);
+    paint(1, 38);
+    paint(10, 228);
+    paint(1, 39);
+    paint(18, 238);
+    paint(3, 38);
+    const runs = findAlignedCells(cols, 3);
+    expect(runs).toEqual([
+      { start: 1, end: 19 },
+      { start: 31, end: 49 },
+      { start: 61, end: 79 },
+    ]);
+  });
+
+  it('returns null when there is only one bright run', () => {
+    expect(findAlignedCells(Array(80).fill(238), 3)).toBeNull();
+  });
+});
+
+describe('findCellRow', () => {
+  const paint = (cols: number[], n: number, v: number) => {
+    for (let i = 0; i < n; i++) cols.push(v);
+  };
+
+  it('keeps unlike-width adjacent cells (sales agent id + name)', () => {
+    const cols: number[] = [];
+    paint(cols, 1, 38);
+    paint(cols, 18, 238);
+    paint(cols, 5, 38);
+    paint(cols, 162, 238);
+    paint(cols, 3, 38);
+    expect(findCellRow(cols)).toEqual([
+      { start: 1, end: 19 },
+      { start: 24, end: 186 },
+    ]);
+  });
+
+  it('keeps three similar date cells', () => {
+    const cols: number[] = [];
+    paint(cols, 1, 38);
+    paint(cols, 18, 238);
+    paint(cols, 12, 38);
+    paint(cols, 18, 238);
+    paint(cols, 12, 38);
+    paint(cols, 18, 238);
+    paint(cols, 3, 38);
+    expect(findCellRow(cols)).toHaveLength(3);
+  });
+
+  it('returns null for a single empty field', () => {
+    const cols: number[] = [];
+    paint(cols, 1, 38);
+    paint(cols, 242, 238);
+    paint(cols, 3, 38);
+    expect(findCellRow(cols)).toBeNull();
+  });
+});
+
+describe('splitRowGutters', () => {
+  const paint = (rows: number[], n: number, v: number) => {
+    for (let i = 0; i < n; i++) rows.push(v);
+  };
+
+  it('slices a hairline-divided panel into one row per item', () => {
+    const means: number[] = [];
+    paint(means, 31, 255);
+    for (let i = 0; i < 12; i++) {
+      paint(means, 3, 209);
+      paint(means, 31, 255);
+    }
+    const parent = { x: 168, y: 110, width: 218, height: means.length };
+    const rows = splitRowGutters(parent, means);
+    expect(rows).toHaveLength(13);
+    expect(rows![0]).toMatchObject({ x: 168, y: 110, width: 218 });
+    expect(rows![2]!.y - rows![1]!.y).toBe(34);
+  });
+
+  it('ignores a panel without repeating hairlines', () => {
+    const means = Array(220).fill(243);
+    expect(splitRowGutters({ x: 800, y: 320, width: 150, height: 220 }, means)).toBeNull();
+  });
+});
+
 describe('ocrRectFromBoxes', () => {
   it('is relative to the crop and trims dropdowns', () => {
     const crop = { x: 0, y: 0, width: 100, height: 20 };
@@ -50,7 +169,16 @@ describe('ocrRectFromBoxes', () => {
   });
 });
 
-describe('expandLeftForLabel', () => {
+describe('includeLabelForType / expandLeftForLabel', () => {
+  it('includes labels for fields and dropdowns, not buttons', () => {
+    expect(includeLabelForType('field')).toBe(true);
+    expect(includeLabelForType('dropdown')).toBe(true);
+    expect(includeLabelForType('button')).toBe(false);
+    expect(includeLabelForType('icon')).toBe(false);
+    expect(includeLabelForType('field', false)).toBe(false);
+    expect(includeLabelForType('button', true)).toBe(true);
+  });
+
   it('extends left from the field boxes', () => {
     const boxes = [
       { id: 1, x: 10, y: 10, width: 40, height: 16 },
@@ -59,6 +187,109 @@ describe('expandLeftForLabel', () => {
     const crop = expandLeftForLabel(boxes, [boxes[1]!]);
     expect(crop.x).toBeLessThan(60);
     expect(crop.x + crop.width).toBeGreaterThan(60 + 80);
+  });
+
+  it('does not walk left into dark window chrome', () => {
+    const width = 200;
+    const height = 40;
+    const data = Buffer.alloc(width * height * 4, 245);
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < 30; x++) {
+        const i = (y * width + x) * 4;
+        data[i] = 0;
+        data[i + 1] = 0;
+        data[i + 2] = 0;
+        data[i + 3] = 255;
+      }
+    }
+    const field = { id: 1, x: 80, y: 10, width: 50, height: 16 };
+    const crop = expandLeftForLabel([], [field], 8, 140, { width, height, data });
+    expect(crop.x).toBeGreaterThanOrEqual(30);
+    expect(crop.x).toBeLessThan(80);
+  });
+});
+
+describe('splitMergedFields', () => {
+  it('drops the outer mm/dd/yy box and keeps inflated inner cells', () => {
+    const parent = { x: 640, y: 384, width: 82, height: 18 };
+    const kept = splitMergedFields([
+      parent,
+      { x: 642, y: 386, width: 18, height: 14 },
+      { x: 672, y: 386, width: 18, height: 14 },
+      { x: 702, y: 386, width: 18, height: 14 },
+    ]);
+    expect(kept).toEqual([
+      { x: 640, y: 384, width: 22, height: 18 },
+      { x: 670, y: 384, width: 22, height: 18 },
+      { x: 700, y: 384, width: 22, height: 18 },
+    ]);
+  });
+
+  it('keeps a single field that only has an inner inset', () => {
+    const outer = { x: 785, y: 157, width: 22, height: 18 };
+    const inner = { x: 787, y: 159, width: 18, height: 14 };
+    expect(splitMergedFields([outer, inner])).toEqual([outer, inner]);
+  });
+
+  it('splits a wide control into unlike-width adjacent boxes (sales agent id + name)', () => {
+    const parent = { x: 621, y: 217, width: 189, height: 18 };
+    const left = { x: 623, y: 219, width: 18, height: 14 };
+    const rest = { x: 646, y: 219, width: 160, height: 14 };
+    expect(splitMergedFields([parent, left, rest])).toEqual([
+      { x: 621, y: 217, width: 22, height: 18 },
+      { x: 644, y: 217, width: 164, height: 18 },
+    ]);
+  });
+
+  it('drops a wrapping panel and keeps the stacked buttons inside', () => {
+    const panel = { x: 174, y: 58, width: 268, height: 520 };
+    const buttons = Array.from({ length: 12 }, (_, i) => ({
+      x: 178, y: 61 + i * 43, width: 261, height: 41,
+    }));
+    const kept = splitMergedFields([panel, ...buttons]);
+    expect(kept).toHaveLength(12);
+    expect(kept.some((box) => box.width === 268 && box.height === 520)).toBe(false);
+    expect(kept.every((box) => box.height >= 41 && box.height <= 45)).toBe(true);
+  });
+
+  it('keeps a button that only contains small text scraps', () => {
+    const button = { x: 178, y: 147, width: 261, height: 41 };
+    const scraps = [
+      { x: 200, y: 160, width: 40, height: 14 },
+      { x: 250, y: 160, width: 40, height: 14 },
+    ];
+    expect(splitMergedFields([button, ...scraps])).toEqual([button, ...scraps]);
+  });
+
+  it('keeps a button that has a near-full inner inset plus a scrap', () => {
+    const button = { x: 178, y: 147, width: 261, height: 41 };
+    const inset = { x: 180, y: 149, width: 257, height: 37 };
+    const scrap = { x: 200, y: 160, width: 40, height: 14 };
+    expect(splitMergedFields([button, inset, scrap])).toEqual([button, inset, scrap]);
+  });
+
+  it('drops a short-wide header strip and keeps the inner fields', () => {
+    const header = { x: 192, y: 89, width: 756, height: 38 };
+    const fields = [
+      { x: 331, y: 94, width: 76, height: 18 },
+      { x: 466, y: 94, width: 70, height: 18 },
+      { x: 588, y: 94, width: 147, height: 18 },
+      { x: 917, y: 94, width: 14, height: 18 },
+    ];
+    const kept = splitMergedFields([header, ...fields]);
+    expect(kept).toHaveLength(4);
+    expect(kept.some((box) => box.width === 756)).toBe(false);
+  });
+});
+
+describe('dropNestedBoxes', () => {
+  it('keeps the outer button and drops inner text scraps', () => {
+    const kept = dropNestedBoxes([
+      { x: 200, y: 160, width: 40, height: 14 },
+      { x: 178, y: 147, width: 261, height: 41 },
+      { x: 180, y: 149, width: 257, height: 37 },
+    ]);
+    expect(kept).toEqual([{ x: 178, y: 147, width: 261, height: 41 }]);
   });
 });
 

--- a/packages/core/src/author/geometry.ts
+++ b/packages/core/src/author/geometry.ts
@@ -39,7 +39,159 @@ export function relativeToCrop(rect: Rect, crop: Rect): Rect {
   };
 }
 
-/** Value box relative to the label crop. Dropdowns drop the spinner on the right. */
+/** Slice a rect by horizontal fractions in [0, 1]. */
+export function sliceRectHorizontal(rect: Rect, start: number, end: number): Rect {
+  const left = rect.x + rect.width * start;
+  const right = rect.x + rect.width * end;
+  const x = Math.round(left);
+  return {
+    x,
+    y: rect.y,
+    width: Math.max(1, Math.round(right) - x),
+    height: rect.height,
+  };
+}
+
+export function evenHorizontalSlices(rect: Rect, count: number): Rect[] {
+  const n = Math.max(1, count);
+  return Array.from({ length: n }, (_, i) => sliceRectHorizontal(rect, i / n, (i + 1) / n));
+}
+
+/** Bright column runs inside a merged field (cells vs `/` gutters). */
+export function findAlignedCells(
+  columnMeans: number[],
+  count: number,
+  minWidth = 10,
+  bright = 220,
+): Array<{ start: number; end: number }> | null {
+  if (count < 2 || columnMeans.length < count * minWidth) return null;
+  const runs: Array<{ start: number; end: number }> = [];
+  let start: number | null = null;
+  for (let i = 0; i <= columnMeans.length; i++) {
+    const on = i < columnMeans.length && columnMeans[i]! >= bright;
+    if (on && start == null) start = i;
+    if (!on && start != null) {
+      if (i - start >= minWidth) runs.push({ start, end: i });
+      start = null;
+    }
+  }
+  if (runs.length < count) return null;
+  const picked = [...runs]
+    .sort((a, b) => b.end - b.start - (a.end - a.start))
+    .slice(0, count)
+    .sort((a, b) => a.start - b.start);
+  const widths = picked.map((run) => run.end - run.start);
+  const maxW = Math.max(...widths);
+  const minW = Math.min(...widths);
+  if (minW < 1 || maxW > minW * 3) return null;
+  return picked;
+}
+
+/** Bright cells in a row separated by dark gutters (dates, id + name). */
+export function findCellRow(
+  columnMeans: number[],
+  minCount = 2,
+  minWidth = 10,
+  bright = 220,
+): Array<{ start: number; end: number }> | null {
+  const runs: Array<{ start: number; end: number }> = [];
+  let start: number | null = null;
+  for (let i = 0; i <= columnMeans.length; i++) {
+    const on = i < columnMeans.length && columnMeans[i]! >= bright;
+    if (on && start == null) start = i;
+    if (!on && start != null) {
+      if (i - start >= minWidth) runs.push({ start, end: i });
+      start = null;
+    }
+  }
+  if (runs.length < minCount || runs.length > 4) return null;
+  return runs;
+}
+
+/** Short mid-gray bands between bright rows (repeating row gutters). */
+export function findHairlineDividers(
+  rowMeans: number[],
+  midLo = 190,
+  midHi = 225,
+  bright = 248,
+): number[] {
+  const lines: number[] = [];
+  let i = 0;
+  while (i < rowMeans.length) {
+    const value = rowMeans[i]!;
+    if (value >= midLo && value <= midHi) {
+      let j = i;
+      while (j < rowMeans.length && rowMeans[j]! >= midLo && rowMeans[j]! <= midHi) j++;
+      const len = j - i;
+      const prevBright = i === 0 || rowMeans[i - 1]! >= bright;
+      const nextBright = j >= rowMeans.length || rowMeans[j]! >= bright;
+      if (len >= 2 && len <= 5 && prevBright && nextBright) {
+        lines.push(i + Math.floor(len / 2));
+      }
+      i = j;
+    } else {
+      i++;
+    }
+  }
+  return lines;
+}
+
+/** Slice a tall rect into rows when hairlines repeat. */
+export function splitRowGutters(parent: Rect, rowMeans: number[]): Rect[] | null {
+  const lines = findHairlineDividers(rowMeans);
+  if (lines.length < 3) return null;
+  const gaps = lines.slice(1).map((y, i) => y - lines[i]!);
+  const median = [...gaps].sort((a, b) => a - b)[Math.floor(gaps.length / 2)]!;
+  if (median < 24 || median > 48) return null;
+  if (gaps.some((gap) => gap < median * 0.75 || gap > median * 1.25)) return null;
+  const bounds = [0, ...lines, parent.height];
+  const rows: Rect[] = [];
+  for (let i = 0; i < bounds.length - 1; i++) {
+    const y0 = bounds[i]!;
+    const height = bounds[i + 1]! - y0;
+    if (height < 16) continue;
+    rows.push({ x: parent.x, y: parent.y + y0, width: parent.width, height });
+  }
+  return rows.length >= 4 ? rows : null;
+}
+
+/** Split a rect on visible gutters: columns if short, rows if tall. */
+export function splitBoxGutters(
+  box: Rect,
+  columnMeans: number[],
+  rowMeans: number[],
+): Rect[] | null {
+  if (box.height <= 28 && box.width >= 48) {
+    const runs = findCellRow(columnMeans);
+    const span = runs ? runs.reduce((sum, run) => sum + (run.end - run.start), 0) : 0;
+    if (runs && runs.length >= 2 && span >= box.width * 0.5) {
+      return runs.map((run) => {
+        const x = box.x + Math.max(0, run.start - 1);
+        const right = box.x + Math.min(box.width, run.end + 1);
+        return { x, y: box.y, width: Math.max(1, right - x), height: box.height };
+      });
+    }
+  }
+  if (box.height >= 80) return splitRowGutters(box, rowMeans);
+  return null;
+}
+
+export function cellRunsToRects(
+  parent: Rect,
+  runs: Array<{ start: number; end: number }>,
+  inset = 2,
+): Rect[] {
+  const y = parent.y + inset;
+  const height = Math.max(1, parent.height - inset * 2);
+  return runs.map((run) => ({
+    x: parent.x + run.start,
+    y,
+    width: Math.max(1, run.end - run.start),
+    height,
+  }));
+}
+
+/** Value box relative to the match crop. Dropdowns drop the spinner on the right. */
 export function ocrRectFromBoxes(
   crop: Rect,
   fieldBoxes: Rect[],
@@ -56,19 +208,69 @@ export function ocrRectFromBoxes(
   };
 }
 
+/** Types that used to grow left by default. Apply now unions labelIds; includeLabel: true is the leftover. */
+const LABEL_CROP_TYPES = new Set(['field', 'dropdown']);
+
+export function includeLabelForType(type?: string, override?: boolean): boolean {
+  if (override != null) return override;
+  return LABEL_CROP_TYPES.has(type || 'field');
+}
+
+function columnMean(
+  png: { width: number; height: number; data: Buffer | Uint8Array },
+  x: number,
+  y0: number,
+  y1: number,
+): number {
+  const x0 = Math.round(x);
+  if (x0 < 0 || x0 >= png.width) return 0;
+  const top = Math.max(0, Math.round(y0));
+  const bottom = Math.min(png.height, Math.round(y1));
+  const rows = Math.max(1, bottom - top);
+  let sum = 0;
+  for (let y = top; y < bottom; y++) {
+    const i = (y * png.width + x0) * 4;
+    sum += (png.data[i]! + png.data[i + 1]! + png.data[i + 2]!) / 3;
+  }
+  return sum / rows;
+}
+
+/** First in-form x walking left from the field — stop before window chrome. */
+export function formLeftEdge(
+  png: { width: number; height: number; data: Buffer | Uint8Array },
+  rect: Rect,
+  dark = 40,
+): number | null {
+  const y0 = rect.y + 2;
+  const y1 = rect.y + rect.height - 2;
+  const start = Math.min(png.width - 1, Math.max(0, Math.round(rect.x) - 1));
+  for (let x = start; x >= 0; x--) {
+    if (columnMean(png, x, y0, y1) < dark) return x + 1;
+  }
+  return null;
+}
+
+/** Grow the crop left from the value box(es) to include the label. */
 export function expandLeftForLabel(
   boxes: DetectedBox[],
   fieldBoxes: DetectedBox[],
   pad = 8,
   maxLabel = 140,
+  png?: { width: number; height: number; data: Buffer | Uint8Array },
 ): Rect {
   const ids = new Set(fieldBoxes.map((box) => box.id));
   const union = unionRects(fieldBoxes);
-  const leftLimit = boxes
+  let leftLimit = union.x - maxLabel;
+  const neighbor = boxes
     .filter((box) => !ids.has(box.id))
     .filter((box) => box.x + box.width <= union.x + 2)
     .filter((box) => box.y < union.y + union.height && box.y + box.height > union.y)
-    .reduce((max, box) => Math.max(max, box.x + box.width), union.x - maxLabel);
+    .reduce((max, box) => Math.max(max, box.x + box.width), leftLimit);
+  leftLimit = Math.max(leftLimit, neighbor);
+  if (png) {
+    const edge = formLeftEdge(png, union);
+    if (edge != null) leftLimit = Math.max(leftLimit, edge);
+  }
   const x = Math.max(0, Math.min(union.x - pad, Math.max(leftLimit + 4, union.x - maxLabel)));
   return {
     x,
@@ -86,6 +288,58 @@ function overlapArea(a: Rect, b: Rect): number {
 
 function score(box: Rect): number {
   return -Math.abs(box.height - 18) * 10 + box.width * 0.01;
+}
+
+export function containedRatio(inner: Rect, outer: Rect): number {
+  const area = inner.width * inner.height;
+  return area ? overlapArea(inner, outer) / area : 0;
+}
+
+/** Drop a container that already has inner cells. Keep the inners. */
+export function splitMergedFields(boxes: Rect[], minKids = 2): Rect[] {
+  const parents = boxes.filter((parent) => {
+    const kids = boxes.filter((box) => box !== parent && containedRatio(box, parent) >= 0.7);
+    if (kids.length < minKids || kids.length > 24) return false;
+    const fieldKids = kids.filter((box) => box.height >= 12 && box.height <= 28 && box.width >= 14);
+    if (parent.height <= 50 && parent.width >= parent.height * 8 && fieldKids.length >= 2) return true;
+    const parentArea = parent.width * parent.height;
+    const kidArea = kids.reduce((sum, box) => sum + box.width * box.height, 0);
+    const maxKid = Math.max(...kids.map((box) => box.width * box.height));
+    if (maxKid > parentArea * 0.85) return false;
+    if (kidArea < parentArea * 0.35) return false;
+    const union = unionRects(kids);
+    return union.width >= parent.width * 0.5 || union.height >= parent.height * 0.5;
+  });
+  if (!parents.length) return boxes;
+  const out: Rect[] = [];
+  for (const box of boxes) {
+    if (parents.includes(box)) continue;
+    const parent = parents.find((p) => containedRatio(box, p) >= 0.7);
+    if (parent) {
+      const padX = Math.min(2, Math.max(0, box.x - parent.x));
+      const padY = Math.min(2, Math.max(0, box.y - parent.y));
+      out.push({
+        x: box.x - padX,
+        y: box.y - padY,
+        width: box.width + padX * 2,
+        height: box.height + padY * 2,
+      });
+    } else {
+      out.push(box);
+    }
+  }
+  return out;
+}
+
+/** Drop boxes that sit mostly inside a larger box (text scraps inside a button). */
+export function dropNestedBoxes(boxes: Rect[], ratio = 0.7): Rect[] {
+  const sorted = [...boxes].sort((a, b) => b.width * b.height - a.width * a.height);
+  const kept: Rect[] = [];
+  for (const box of sorted) {
+    if (kept.some((outer) => containedRatio(box, outer) >= ratio)) continue;
+    kept.push(box);
+  }
+  return kept.sort((a, b) => a.y - b.y || a.x - b.x);
 }
 
 export function dedupeBoxes(raw: Rect[]): Rect[] {

--- a/packages/core/src/author/index.ts
+++ b/packages/core/src/author/index.ts
@@ -1,8 +1,8 @@
-export { detectScreen, detectBoxes, annotateBoxes } from './detect.js';
+export { detectScreen, detectBoxes, annotateBoxes, writeBoxes } from './detect.js';
 export type { DetectScreenResult, BoxesFile } from './detect.js';
 
 export { applyScreen } from './apply.js';
-export type { FirstPass, FirstPassElement, FirstPassPart, ApplyScreenResult, AppliedElement } from './apply.js';
+export type { FirstPass, FirstPassElement, FirstPassPart, FirstPassSection, ApplyScreenResult, AppliedElement, AppliedSection } from './apply.js';
 
 export { writeScreenCatalog, readScreenCatalog, screenCatalogSource } from './catalog.js';
 export type { ScreenCatalog } from './catalog.js';
@@ -11,3 +11,5 @@ export { showAnnotated } from './show.js';
 
 export { kebab, unionRects, insetRect } from './geometry.js';
 export type { DetectedBox } from './geometry.js';
+
+export type { DetectedLabel } from './labels.js';

--- a/packages/core/src/author/labels.test.ts
+++ b/packages/core/src/author/labels.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { clusterOcrWords, labelsFromOcr } from './labels.js';
+
+describe('clusterOcrWords', () => {
+  it('joins adjacent words on one line', () => {
+    const joined = clusterOcrWords([
+      { text: 'Customer', confidence: 90, x: 10, y: 10, width: 60, height: 12 },
+      { text: 'Number:', confidence: 88, x: 76, y: 10, width: 55, height: 12 },
+    ]);
+    expect(joined).toHaveLength(1);
+    expect(joined[0]!.text).toBe('Customer Number:');
+    expect(joined[0]!.width).toBe(121);
+  });
+
+  it('does not join a word on the next row', () => {
+    const joined = clusterOcrWords([
+      { text: 'Name:', confidence: 90, x: 10, y: 10, width: 40, height: 12 },
+      { text: 'Address:', confidence: 90, x: 10, y: 40, width: 50, height: 12 },
+    ]);
+    expect(joined.map((item) => item.text)).toEqual(['Name:', 'Address:']);
+  });
+});
+
+describe('labelsFromOcr', () => {
+  const field = { id: 1, x: 200, y: 10, width: 80, height: 18 };
+
+  it('keeps a label sitting to the left of a field', () => {
+    const labels = labelsFromOcr(
+      [{ text: 'Email:', confidence: 90, x: 140, y: 12, width: 48, height: 12 }],
+      [field],
+    );
+    expect(labels).toEqual([
+      { id: 1, x: 140, y: 12, width: 48, height: 12, text: 'Email:', confidence: 90 },
+    ]);
+  });
+
+  it('drops text that lives inside a button', () => {
+    const button = { id: 2, x: 10, y: 10, width: 90, height: 28 };
+    const labels = labelsFromOcr(
+      [{ text: 'Save', confidence: 95, x: 30, y: 16, width: 40, height: 12 }],
+      [button],
+    );
+    expect(labels).toEqual([]);
+  });
+
+  it('drops punctuation-only glyphs', () => {
+    const labels = labelsFromOcr(
+      [{ text: '/', confidence: 90, x: 10, y: 10, width: 8, height: 12 }],
+      [field],
+    );
+    expect(labels).toEqual([]);
+  });
+
+  it('keeps a long low-confidence caption with slashes', () => {
+    const checkbox = { id: 1, x: 324, y: 344, width: 14, height: 18 };
+    const labels = labelsFromOcr(
+      [
+        { text: 'New/Used', confidence: 0, x: 227, y: 348, width: 54, height: 8 },
+        { text: 'Other:', confidence: 0, x: 285, y: 348, width: 33, height: 8 },
+      ],
+      [checkbox],
+    );
+    expect(labels).toEqual([
+      { id: 1, x: 227, y: 348, width: 91, height: 8, text: 'New/Used Other:', confidence: 0 },
+    ]);
+  });
+
+  it('drops a single letter and a /dd/ date scrap', () => {
+    expect(labelsFromOcr(
+      [{ text: 'I', confidence: 90, x: 10, y: 10, width: 8, height: 12 }],
+      [field],
+    )).toEqual([]);
+    expect(labelsFromOcr(
+      [{ text: '/dd/', confidence: 90, x: 10, y: 40, width: 20, height: 10 }],
+      [field],
+    )).toEqual([]);
+  });
+
+  it('drops OCR scraps whose center sits inside a field', () => {
+    const cell = { id: 4, x: 640, y: 344, width: 20, height: 18 };
+    expect(labelsFromOcr(
+      [{ text: '(Y/Y', confidence: 80, x: 640, y: 344, width: 18, height: 10 }],
+      [cell],
+    )).toEqual([]);
+  });
+
+  it('keeps a checkbox caption even when the box sits inside the label', () => {
+    const checkbox = { id: 3, x: 70, y: 10, width: 15, height: 18 };
+    const labels = labelsFromOcr(
+      [{ text: 'Do Not Call:', confidence: 90, x: 10, y: 12, width: 80, height: 12 }],
+      [checkbox],
+    );
+    expect(labels).toEqual([
+      { id: 1, x: 10, y: 12, width: 80, height: 12, text: 'Do Not Call:', confidence: 90 },
+    ]);
+  });
+});

--- a/packages/core/src/author/labels.ts
+++ b/packages/core/src/author/labels.ts
@@ -1,0 +1,121 @@
+import { containedRatio, unionRects, type DetectedBox } from './geometry.js';
+
+export interface DetectedLabel {
+  id: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  text: string;
+  confidence?: number;
+}
+
+export interface OcrWord {
+  text: string;
+  confidence: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+function cleanText(text: string): string {
+  return String(text || '').replace(/\s+/g, ' ').trim();
+}
+
+function centerInside(inner: { x: number; y: number; width: number; height: number }, outer: { x: number; y: number; width: number; height: number }): boolean {
+  const cx = inner.x + inner.width / 2;
+  const cy = inner.y + inner.height / 2;
+  return cx >= outer.x && cx <= outer.x + outer.width && cy >= outer.y && cy <= outer.y + outer.height;
+}
+
+function letterCount(text: string): number {
+  return (cleanText(text).match(/[A-Za-z]/g) || []).length;
+}
+
+/** Join words that sit on one line with a small gap ("Customer" + "Number:"). */
+export function clusterOcrWords(words: OcrWord[], maxGap = 16): OcrWord[] {
+  const sorted = [...words].sort((a, b) => a.y - b.y || a.x - b.x);
+  const groups: OcrWord[][] = [];
+  for (const word of sorted) {
+    const group = groups[groups.length - 1];
+    if (!group) {
+      groups.push([word]);
+      continue;
+    }
+    const prev = group[group.length - 1]!;
+    const sameRow = word.y < prev.y + prev.height && word.y + word.height > prev.y;
+    const gap = word.x - (prev.x + prev.width);
+    if (sameRow && gap >= -3 && gap <= maxGap) group.push(word);
+    else groups.push([word]);
+  }
+  return groups.map((group) => {
+    const union = unionRects(group);
+    return {
+      text: cleanText(group.map((item) => item.text).join(' ')),
+      confidence: Math.min(...group.map((item) => item.confidence)),
+      x: union.x,
+      y: union.y,
+      width: union.width,
+      height: union.height,
+    };
+  });
+}
+
+/** Turn OCR words into label boxes the AI can join to controls. Drops chrome inside fields/buttons. */
+export function labelsFromOcr(words: OcrWord[], boxes: DetectedBox[]): DetectedLabel[] {
+  const usable = words.filter((word) => {
+    if (word.width < 4 || word.height < 5 || word.height > 48) return false;
+    const letters = letterCount(word.text);
+    if (letters < 1) return false;
+    const conf = word.confidence ?? 100;
+    if (conf >= 30) return true;
+    // Slashes in "New/Used/Other:" often come back as confidence 0.
+    return letters >= 4 && word.width >= 24;
+  });
+  const clustered = clusterOcrWords(usable);
+  const kept = clustered.filter((label) => {
+    const text = cleanText(label.text);
+    if (letterCount(text) < 2 || text.length > 80) return false;
+    if (/^\/?[A-Za-z]{1,2}\/?$/.test(text)) return false;
+    if (label.width > 420) return false;
+    if (boxes.some((box) => containedRatio(label, box) >= 0.55 || centerInside(label, box))) return false;
+    // Checkboxes often sit inside the caption bbox; only drop if a field/button is inside.
+    if (boxes.some((box) => box.width >= 40 && containedRatio(box, label) >= 0.45)) return false;
+    return true;
+  });
+  return kept
+    .sort((a, b) => a.y - b.y || a.x - b.x)
+    .map((label, i) => ({
+      id: i + 1,
+      x: Math.round(label.x),
+      y: Math.round(label.y),
+      width: Math.max(1, Math.round(label.width)),
+      height: Math.max(1, Math.round(label.height)),
+      text: cleanText(label.text),
+      confidence: label.confidence,
+    }));
+}
+
+export function tessBBox(bbox: { x0?: number; y0?: number; x1?: number; y1?: number; x?: number; y?: number; width?: number; height?: number } | undefined): OcrWord | null {
+  if (!bbox) return null;
+  let x: number;
+  let y: number;
+  let width: number;
+  let height: number;
+  if (bbox.x0 != null && bbox.y0 != null && bbox.x1 != null && bbox.y1 != null) {
+    x = bbox.x0;
+    y = bbox.y0;
+    width = bbox.x1 - bbox.x0;
+    height = bbox.y1 - bbox.y0;
+  } else if (bbox.width != null && bbox.height != null && bbox.x != null && bbox.y != null) {
+    x = bbox.x;
+    y = bbox.y;
+    width = bbox.width;
+    height = bbox.height;
+  } else {
+    return null;
+  }
+  if (width < 1 || height < 1) return null;
+  return { text: '', confidence: 0, x, y, width, height };
+}

--- a/packages/core/src/field-extractor.ts
+++ b/packages/core/src/field-extractor.ts
@@ -315,27 +315,17 @@ export class FieldExtractor {
       const blankSection = this.visionUtil.matchTemplate(this.blankForm!, sectionTemplate);
       const filledSection = this.visionUtil.matchTemplate(this.filledForm!, sectionTemplate);
       sectionTemplate.delete();
-      // Extract from section title's Y downward (full width) so fields below the title are included
-      const blankSectionRect = {
-        x: 0,
-        y: blankSection.rect.y,
-        width: this.blankForm!.cols,
-        height: this.blankForm!.rows - blankSection.rect.y,
-      };
-      const filledSectionRect = {
-        x: 0,
-        y: filledSection.rect.y,
-        width: this.filledForm!.cols,
-        height: this.filledForm!.rows - filledSection.rect.y,
-      };
+      // Search the element inside the matched section crop (dropdown+field strip, not full-width-below).
+      const blankSectionRect = blankSection.rect;
+      const filledSectionRect = filledSection.rect;
       const sectionBlank = this.visionUtil.extractROI(this.blankForm!, blankSectionRect);
       const sectionFilled = this.visionUtil.extractROI(this.filledForm!, filledSectionRect);
       if (sectionBlank.rows >= template.rows && sectionBlank.cols >= template.cols
         && sectionFilled.rows >= template.rows && sectionFilled.cols >= template.cols) {
         sourceBlank = sectionBlank;
         sourceFilled = sectionFilled;
-        blankOrigin = { x: 0, y: blankSection.rect.y, width: blankSectionRect.width, height: blankSectionRect.height };
-        filledOrigin = { x: 0, y: filledSection.rect.y, width: filledSectionRect.width, height: filledSectionRect.height };
+        blankOrigin = blankSectionRect;
+        filledOrigin = filledSectionRect;
       } else {
         sectionBlank.delete();
         sectionFilled.delete();

--- a/packages/core/src/utils/ocr.ts
+++ b/packages/core/src/utils/ocr.ts
@@ -200,14 +200,23 @@ export class OCRUtil {
     this.worker = await createWorker(language);
   }
 
-  private ocrParams(options: { charset?: string; psm?: string } = {}): Record<string, string> {
-    return {
+  private ocrParams(options: { charset?: string; psm?: string; dpi?: string; whitelist?: boolean } = {}): Record<string, string> {
+    const params: Record<string, string> = {
       tessedit_pageseg_mode: options.psm ?? '7',
-      tessedit_char_whitelist: options.charset
-        || 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789@._- /',
-      user_defined_dpi: '300',
+      user_defined_dpi: options.dpi ?? '300',
       preserve_interword_spaces: '1',
     };
+    if (options.whitelist === false) {
+      // Empty string means "allow nothing" in Tesseract. Use a broad set so
+      // a leftover field whitelist cannot stick, without blocking letters.
+      params.tessedit_char_whitelist =
+        'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789' +
+        ` ~!@#$%^&*()-_=+[]{}|;:'",.<>/?\\\``;
+    } else {
+      params.tessedit_char_whitelist = options.charset
+        || 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789@._- /';
+    }
+    return params;
   }
 
   private async ensureWorker(): Promise<Worker> {
@@ -250,6 +259,50 @@ export class OCRUtil {
         bbox: line.bbox,
       })) || [],
     };
+  }
+
+  /**
+   * Full-page word boxes for authoring (labels next to controls).
+   * Sparse text mode, no charset whitelist.
+   */
+  async extractPageWords(imageBuffer: Buffer): Promise<Array<{
+    text: string;
+    confidence: number;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }>> {
+    const worker = await this.ensureWorker();
+    await worker.setParameters(this.ocrParams({
+      psm: '11',
+      dpi: '96',
+      whitelist: false,
+    }));
+    const { data } = await worker.recognize(imageBuffer, {}, { text: true, blocks: true });
+    const words = [];
+    for (const block of data.blocks || []) {
+      for (const para of block.paragraphs || []) {
+        for (const line of para.lines || []) {
+          for (const word of line.words || []) {
+            const bbox = word.bbox;
+            if (!bbox || bbox.x0 == null || bbox.y0 == null || bbox.x1 == null || bbox.y1 == null) continue;
+            const width = bbox.x1 - bbox.x0;
+            const height = bbox.y1 - bbox.y0;
+            if (width < 3 || height < 5) continue;
+            words.push({
+              text: String(word.text || ''),
+              confidence: Number(word.confidence) || 0,
+              x: bbox.x0,
+              y: bbox.y0,
+              width,
+              height,
+            });
+          }
+        }
+      }
+    }
+    return words;
   }
 
   async terminate(): Promise<void> {

--- a/packages/core/tests/author-detect.spec.ts
+++ b/packages/core/tests/author-detect.spec.ts
@@ -4,7 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { configure } from '../src/configure.js';
-import { detectScreen } from '../src/author/detect.js';
+import { detectScreen, writeBoxes } from '../src/author/detect.js';
 import { showAnnotated } from '../src/author/show.js';
 
 const fixtureBlank = path.join(
@@ -23,7 +23,27 @@ test('detectScreen writes boxes.json and boxes-annotated.png', async () => {
   expect(fs.existsSync(result.boxesPath)).toBe(true);
   expect(fs.existsSync(result.annotatedPath)).toBe(true);
   expect(result.boxes.length).toBeGreaterThan(0);
+  expect(Array.isArray(result.labels)).toBe(true);
   expect(result.width).toBeGreaterThan(0);
+  const saved = JSON.parse(fs.readFileSync(result.boxesPath, 'utf8'));
+  expect(saved.labels).toEqual(result.labels);
+});
+
+test('writeBoxes keeps given ids and does not re-run detect', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-write-boxes-'));
+  const name = 'html-login';
+  fs.mkdirSync(path.join(root, name), { recursive: true });
+  fs.copyFileSync(fixtureBlank, path.join(root, name, 'blank.png'));
+  await configure({ storage: { root } });
+
+  const result = await writeBoxes(name, [
+    { id: 7, x: 10, y: 12, width: 40, height: 18 },
+    { id: 3, x: 80, y: 12, width: 40, height: 18 },
+  ]);
+  expect(result.boxes.map((box) => box.id)).toEqual([3, 7]);
+  const saved = JSON.parse(fs.readFileSync(result.boxesPath, 'utf8'));
+  expect(saved.boxes.map((box) => box.id)).toEqual([3, 7]);
+  expect(fs.existsSync(result.annotatedPath)).toBe(true);
 });
 
 test('showAnnotated puts the PNG on the page', async ({ page }) => {

--- a/packages/tools/QAWOLF_AUTHOR.md
+++ b/packages/tools/QAWOLF_AUTHOR.md
@@ -63,9 +63,10 @@ After `detectScreen(name)`, do not guess paths. Use the return value:
 ```ts
 const detected = await author.detectScreen('customer-info');
 // detected.dir            — folder on FUSE
-// detected.annotatedPath  — PNG with box IDs drawn on the blank
+// detected.annotatedPath  — PNG with red box IDs and gold L{id} labels
 // detected.boxesPath      — boxes.json
 // detected.boxes          — [{ id, x, y, width, height }, ...]
+// detected.labels         — [{ id, x, y, width, height, text }, ...]
 ```
 
 ## Inspect the annotated PNG (required before naming)
@@ -75,11 +76,11 @@ Raw FUSE bytes are not a visual. `showAnnotated` opens the PNG in a **new tab** 
 ```ts
 const viewer = await author.showAnnotated(page, detected.annotatedPath);
 await viewer.bringToFront();
-// inspect the viewer tab's flow screenshot — red boxes + numeric IDs
+// inspect the viewer tab's flow screenshot — red boxes + gold L{id} labels
 await viewer.close();
 ```
 
-Also read `detected.boxes` / `detected.boxesPath` for the id list. Do not invent ids or coordinates.
+Also read `detected.boxes`, `detected.labels`, and `detected.boxesPath`. Do not invent ids or coordinates. Join a control with `boxIds` plus the `labelIds` that caption it (any side).
 
 ## Loop
 
@@ -102,12 +103,14 @@ await author.applyScreen('customer-info', {
       type: 'field',
       section: null,
       boxIds: [12],
+      labelIds: [3],
     },
     {
       name: 'fullName',
       type: 'field',
       section: null,
       boxIds: [14, 15, 16],
+      labelIds: [5],
       parts: [
         { name: 'firstName', boxId: 14 },
         { name: 'middleInitial', boxId: 15 },
@@ -127,15 +130,17 @@ await author.applyScreen('customer-info', {
 | `screen.width` / `height` | number | copy from `detected.width` / `detected.height` |
 | `notes` | `string[]` | optional observations |
 | `unknowns` | `string[]` | **human-readable reasons only.** A control with no box, a missing layout variant, or a box you cannot read. Never put coordinates here. Example: `"phone extension: no box"`. Use `[]` if everything was assigned. |
-| `sections` | `[]` | **Always `[]` for now.** `applyScreen` ignores this. Do not invent section crops. Only revisit if two fields are still interchangeable after including their labels. |
+| `sections` | optional | Dropdown glued to a value field: one `{name}Section` with **both** `boxIds`, then two elements that share that `section` (not parts). Apply uses the union as the match crop. Otherwise `[]`. |
 | `elements` | array | one entry per named control |
 | `elements[].name` | string | camelCase |
-| `elements[].type` | string | `field` \| `button` \| `checkbox` \| `radio` \| `dropdown` \| `tab` \| `label` \| `icon` \| `message` \| `other` |
-| `elements[].section` | `null` | always `null` until sections are supported |
+| `elements[].type` | string | `field` \| `button` \| `checkbox` \| `radio` \| `dropdown` \| `tab` \| `label` \| `icon` \| `message` \| `other`. Crop is the union of `boxIds` + `labelIds`. Type from the screenshot; do not assume wider = field. |
+| `elements[].includeLabel` | optional boolean | Legacy left-grow when Detect missed the caption. Prefer `labelIds`. |
+| `elements[].section` | string or `null` | `{row}Section` name when used; otherwise `null` |
 | `elements[].boxIds` | `number[]` | **only ids from `detected.boxes`**. One or more boxes. |
-| `elements[].parts` | optional | shared-label rows: `{ name: camelCase, boxId: number }[]` matching ids in `boxIds` |
+| `elements[].labelIds` | `number[]` | **only ids from `detected.labels`**. Caption may be left, top, right, or below. Omit for buttons whose text is inside the box. |
+| `elements[].parts` | optional | Same-kind cells of one control only (`{ name, boxId }[]`: dates, name row, phones). Never for a dropdown+field pair. Names-only parts only if Detect still merged the cells into one box. |
 
-Rules: assign, do not draw. Skip chrome (taskbar, desktop icons, window title). Do not invent coordinates. Do not use `as` or `as const` in authored files.
+Rules: assign, do not draw. Skip chrome (taskbar, desktop icons, window title). Do not invent coordinates. Do not grow left by default. Do not use `as` or `as const` in authored files.
 
 5. **Catalog (not a flow)** — after apply succeeds, write `src/helpers/screens.generated.ts` in the repo with your file-write tool. Do not call `writeScreenCatalog` and do not mkdir `/app/generatedProgram`. If the file already exists, keep every other screen and add/replace only the one you just authored: add it to `ScreenName`, add a key on the `ElementName` map, add a key on `screens`. Element names must match `elements[].name` from the first-pass you applied. No `as` / `as const`.
 

--- a/packages/tools/ai-first-pass-prompt.md
+++ b/packages/tools/ai-first-pass-prompt.md
@@ -7,11 +7,11 @@ This is authoring only. Do not invent runtime matchers or API calls.
 ## Inputs
 
 1. **blank** and one or more **filled** shots (same width and height)
-2. **boxes.json** — rectangles from `tools/detect-boxes.mjs` (OpenCV). Each has `id, x, y, width, height`
-3. **boxes-annotated.png** — the blank with those IDs drawn on it
+2. **boxes.json** — `boxes` (controls) and `labels` (OCR captions). Each has `id, x, y, width, height`. Labels also have `text`.
+3. **boxes-annotated.png** — red box IDs and gold `L{id}` label IDs on the blank
 4. Optional **focus** — only assign these controls
 
-Do not invent coordinates. Only use `boxIds` from `boxes.json`. If a control has no box, put it in `unknowns`.
+Do not invent coordinates. Only use `boxIds` from `boxes` and `labelIds` from `labels`. If a control has no box, put it in `unknowns`.
 
 Extra filled shots are layout variants (e.g. Individual unchecked). If a variant is missing, list it under `unknowns`.
 
@@ -31,6 +31,7 @@ Return **only** JSON:
       "type": "field",
       "section": null,
       "boxIds": [12, 13, 14],
+      "labelIds": [4],
       "parts": [
         { "name": "firstName", "boxId": 12 },
         { "name": "middleInitial", "boxId": 13 },
@@ -45,18 +46,39 @@ Return **only** JSON:
 
 ## Rules
 
-1. **Assign, do not draw.** Every element is one or more detected boxes. The apply step builds the match crop (boxes + label to the left) and insets `parts` inside each box (no border).
+1. **Assign, do not draw.** Join existing rectangles. Apply crops the **union** of `boxIds` plus `labelIds`. Labels may sit left, above, right, or below the control — pick the gold `L{id}` that captions it. Buttons with text inside the red box usually need no `labelIds`. Do **not** assume the caption is to the left. Prefer `labelIds` over `"includeLabel": true` (legacy left-grow when Detect missed the caption).
 
-2. **Fields first. Sections only if two assignments would still be interchangeable** after each includes its label. Usually `sections` is `[]`.
+2. **Dropdown glued to a field → section, not parts.** Two different controls (a list/combo and a value box) that sit on one row need a shared match region so the small one is not ambiguous. Emit a section named `{row}Section` with **both** `boxIds`, then **two elements** that share `"section": "thatName"`. No `parts`. Type each box from the screenshot: combo/list vs value cell. Do not assume wider = field or left = dropdown. Apply crops the section as that union and uses it as each member’s match template so the small box is not a tiny needle.
 
-3. **Shared-label rows** (Name, City/State, phones): one element, several `boxIds`, `parts` for each inner box.
+   ```json
+   { "name": "primaryContactSection", "boxIds": [34, 35] }
+   { "name": "primaryContactMethod", "type": "dropdown", "section": "primaryContactSection", "boxIds": [34], "labelIds": [23] }
+   { "name": "primaryContactField", "type": "field", "section": "primaryContactSection", "boxIds": [35] }
+   { "name": "warrantyRepairSection", "boxIds": [57, 58] }
+   { "name": "warrantyRepair", "type": "dropdown", "section": "warrantyRepairSection", "boxIds": [57] }
+   { "name": "warrantyCode", "type": "field", "section": "warrantyRepairSection", "boxIds": [58] }
+   ```
 
-4. **Split at the assertion boundary.** If tests need first / middle / last, emit those `parts`.
+3. **Parts are only same-kind cells of one control.** Detect may emit one box per cell (mm / dd / yy, first / MI / last, phone segments). That is one element, several `boxIds`, `parts` with a `boxId` for each cell. Do not invent coordinates. Do not use parts for a dropdown+field pair.
+
+   ```json
+   { "name": "inService", "type": "field", "boxIds": [58, 59, 60], "labelIds": [20], "parts": [
+     { "name": "month", "boxId": 58 }, { "name": "day", "boxId": 59 }, { "name": "year", "boxId": 60 }
+   ]}
+   ```
+
+   Names-only parts (no `boxId`) only if Detect still left **one** merged box. Apply then finds inner cells from the blank.
+
+4. **Shared-label rows** (Name, City/State, phones): same as rule 3 — one element, several `boxIds`, one shared `labelIds` entry, `parts` with a `boxId` for each inner box.
 
 5. **Look at filled shots** to see which boxes received values. Crops still come from the blank.
 
-6. **Skip chrome:** browser tabs, desktop icons, window title, footer buttons unless asked.
+6. **Skip OS chrome:** desktop icons, browser tabs, the OS window title bar. Keep in-window controls — footer buttons, a close X the human drew, and other app buttons.
 
 7. **Names** are camelCase. Screen folder names stay kebab-case.
 
 8. Skip a box you cannot read. Do not reuse IDs from a previous screenshot.
+
+## After you write the file
+
+Write `first-pass.json` next to `boxes.json` (under `~/.smart-vision/screens/{name}/`). TM v2 applies automatically when that file is newer than `index.json`, including on Reload. Tell the user to Reload in TM v2. Do not tell them to Apply.

--- a/packages/tools/apply-first-pass.mjs
+++ b/packages/tools/apply-first-pass.mjs
@@ -13,6 +13,7 @@ import {
   insetRect,
   ocrRectFromBoxes,
   relativeToCrop,
+  unionRects,
 } from './detect-boxes.mjs';
 
 const TYPE_ENUM = {
@@ -48,9 +49,12 @@ function titleCase(folder) {
 
 export function applyFirstPass(screenDir) {
   const blank = fs.readFileSync(path.join(screenDir, 'blank.png'));
-  const boxes = JSON.parse(fs.readFileSync(path.join(screenDir, 'boxes.json'), 'utf8')).boxes;
+  const boxesFile = JSON.parse(fs.readFileSync(path.join(screenDir, 'boxes.json'), 'utf8'));
+  const boxes = boxesFile.boxes || [];
+  const labels = boxesFile.labels || [];
   const pass = JSON.parse(fs.readFileSync(path.join(screenDir, 'first-pass.json'), 'utf8'));
   const byId = new Map(boxes.map((box) => [box.id, box]));
+  const byLabel = new Map(labels.map((label) => [label.id, label]));
   const tmplDir = path.join(screenDir, 'templates');
   fs.rmSync(tmplDir, { recursive: true, force: true });
   fs.mkdirSync(tmplDir, { recursive: true });
@@ -58,9 +62,19 @@ export function applyFirstPass(screenDir) {
   const elements = [];
   for (const el of pass.elements || []) {
     const fieldBoxes = (el.boxIds || []).map((id) => byId.get(id)).filter(Boolean);
-    const crop = fieldBoxes.length
-      ? expandLeftForLabel(boxes, fieldBoxes)
-      : el.crop;
+    const labelRects = (el.labelIds || []).map((id) => byLabel.get(id)).filter(Boolean);
+    const joined = [...fieldBoxes, ...labelRects];
+    let crop;
+    if (labelRects.length && joined.length) {
+      const union = unionRects(joined);
+      crop = { x: Math.max(0, union.x - 4), y: Math.max(0, union.y - 4), width: union.width + 8, height: union.height + 8 };
+    } else if (el.includeLabel === true && fieldBoxes.length) {
+      crop = expandLeftForLabel(boxes, fieldBoxes);
+    } else if (fieldBoxes.length) {
+      crop = unionRects(fieldBoxes);
+    } else {
+      crop = el.crop;
+    }
     if (!crop) continue;
     const filename = `${kebab(el.name)}.png`;
     fs.writeFileSync(path.join(tmplDir, filename), cropPng(blank, crop.x, crop.y, crop.width, crop.height));
@@ -78,6 +92,7 @@ export function applyFirstPass(screenDir) {
       width: crop.width,
       height: crop.height,
       boxIds: el.boxIds,
+      labelIds: el.labelIds,
       charset: el.charset,
       options: el.options,
       ocrRect: fieldBoxes.length ? ocrRectFromBoxes(crop, fieldBoxes, el.type || 'field') : undefined,

--- a/packages/tools/detect-boxes.mjs
+++ b/packages/tools/detect-boxes.mjs
@@ -172,6 +172,12 @@ export function ocrRectFromBoxes(crop, fieldBoxes, type = 'field', pad = 2) {
   };
 }
 
+export function includeLabelForType(type, override) {
+  if (override != null) return override;
+  const t = type || 'field';
+  return t === 'field' || t === 'dropdown';
+}
+
 export function expandLeftForLabel(boxes, fieldBoxes, pad = 8, maxLabel = 140) {
   const ids = new Set(fieldBoxes.map((box) => box.id));
   const union = unionRects(fieldBoxes);

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -7,7 +7,8 @@
     "smart-vision": "./template-manager-server.mjs"
   },
   "scripts": {
-    "start": "node template-manager-server.mjs"
+    "start": "node template-manager-server.mjs",
+    "start:v2": "node tm-v2/server.mjs"
   },
   "keywords": [
     "playwright",

--- a/packages/tools/tm-v2/index.html
+++ b/packages/tools/tm-v2/index.html
@@ -16,6 +16,19 @@
   button:hover { filter: brightness(1.12); }
   #status { color: #8c8; flex: 1; min-width: 120px; }
   #status.err { color: #f88; }
+  #toast { position: fixed; right: 16px; bottom: 16px; max-width: 360px; background: #4a2020; color: #fcc; border: 1px solid #c66; padding: 10px 12px; border-radius: 6px; display: none; z-index: 20; }
+  .layout { display: grid; grid-template-columns: 360px 1fr; min-height: 0; }
+  aside { overflow: auto; padding: 12px; border-right: 1px solid #333; background: #181818; }
+  main { overflow: auto; background: #000; }
+  .row { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 8px; }
+  .tree { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; margin: 0 0 12px; }
+  .tree details { margin-left: 12px; }
+  .tree > details { margin-left: 0; }
+  .tree summary, .tree .file { cursor: pointer; padding: 2px 4px; border-radius: 3px; }
+  .tree summary:hover, .tree .file:hover { background: #2a2a2a; }
+  .tree .active { background: #243a24; color: #cfc; }
+  .tree .local { color: #8c8; }
+  .push-off { opacity: 0.55; }
   .layout { display: grid; grid-template-columns: 360px 1fr; min-height: 0; }
   aside { overflow: auto; padding: 12px; border-right: 1px solid #333; background: #181818; }
   main { overflow: auto; background: #000; }
@@ -40,16 +53,17 @@
   <input id="gcs" type="text" spellcheck="false">
   <button id="saveSettings" type="button">Save URI</button>
   <button id="pullAll" type="button">Pull GCS</button>
-  <button id="pushAll" type="button">Push GCS</button>
+  <button id="pushAll" class="push-off" type="button" title="GCS write disabled">Push GCS</button>
   <span id="status"></span>
 </header>
+<div id="toast"></div>
 <div class="layout">
 <aside>
   <div class="row">
-    <select id="screen"></select>
-    <button id="pullOne" type="button">Pull</button>
-    <button id="pushOne" type="button">Push</button>
+    <button id="pullOne" type="button">Pull selected</button>
+    <button id="pushOne" class="push-off" type="button" title="GCS write disabled">Push</button>
   </div>
+  <div id="tree" class="tree"></div>
   <div class="row">
     <button id="detect" class="primary" type="button">Detect</button>
     <button id="apply" class="primary" type="button">Apply</button>
@@ -75,8 +89,9 @@
 </div>
 <script>
 const statusEl = document.getElementById('status');
+const toastEl = document.getElementById('toast');
 const gcs = document.getElementById('gcs');
-const screenSel = document.getElementById('screen');
+const treeEl = document.getElementById('tree');
 const boxesBody = document.getElementById('boxes');
 const list = document.getElementById('list');
 const blank = document.getElementById('blank');
@@ -85,10 +100,23 @@ const showDetected = document.getElementById('showDetected');
 const showAnnotated = document.getElementById('showAnnotated');
 const meta = document.getElementById('meta');
 let state = { name: '', elements: [], boxes: [], width: 0, height: 0, names: {} };
+let selectedScreen = '';
 
 function setStatus(msg, err) {
   statusEl.textContent = msg;
   statusEl.className = err ? 'err' : '';
+}
+
+function toast(msg) {
+  toastEl.textContent = msg;
+  toastEl.style.display = 'block';
+  setStatus(msg, true);
+  clearTimeout(toast.t);
+  toast.t = setTimeout(() => { toastEl.style.display = 'none'; }, 4000);
+}
+
+function gcsWriteBlocked() {
+  toast('GCS write/delete is disabled. Pull and local detect/apply only.');
 }
 
 async function api(path, opts) {
@@ -98,25 +126,51 @@ async function api(path, opts) {
   return body;
 }
 
-function fillScreens(names, selected) {
-  const current = selected || screenSel.value;
-  screenSel.innerHTML = names.map((n) => '<option' + (n === current ? ' selected' : '') + '>' + n + '</option>').join('');
+function mergeListing(remote, local) {
+  const dirs = [...new Set([...(remote.dirs || []), ...(local.dirs || [])])].sort();
+  const files = [...new Set([...(remote.files || []), ...(local.files || [])])].sort();
+  const localSet = new Set([...(local.dirs || []), ...(local.files || [])]);
+  return { dirs, files, localSet };
+}
+
+function listingHtml(rel, merged) {
+  let html = '';
+  for (const dir of merged.dirs) {
+    const path = rel ? rel + '/' + dir : dir;
+    const screen = path.split('/')[0];
+    const active = screen === selectedScreen && path === screen ? ' active' : '';
+    const local = merged.localSet.has(dir) ? ' local' : '';
+    html += '<details data-path="' + path + '"><summary class="dir' + active + local + '" data-screen="' + screen + '">' + dir + '/</summary></details>';
+  }
+  for (const file of merged.files) {
+    html += '<div class="file' + (merged.localSet.has(file) ? ' local' : '') + '">' + file + '</div>';
+  }
+  return html;
+}
+
+async function renderTree() {
+  const root = await api('/api/ls?path=');
+  treeEl.innerHTML = listingHtml('', mergeListing(root.remote, root.local));
+}
+
+function highlightTree() {
+  treeEl.querySelectorAll('summary.dir').forEach((el) => {
+    el.classList.toggle('active', el.dataset.screen === selectedScreen && el.parentElement.dataset.path === selectedScreen);
+  });
+}
+
+function currentScreen() {
+  return selectedScreen || '';
 }
 
 async function loadSettings() {
   const s = await api('/api/settings');
   gcs.value = s.gcsUri;
-  fillScreens(s.localScreens || [], screenSel.value);
-}
-
-async function refreshRemote() {
-  const remote = await api('/api/remote');
-  const local = (await api('/api/settings')).localScreens || [];
-  fillScreens([...new Set([...remote.screens, ...local])].sort(), screenSel.value);
 }
 
 async function loadScreen(name) {
   if (!name) return;
+  selectedScreen = name;
   const data = await api('/api/screen?name=' + encodeURIComponent(name));
   state = {
     name,
@@ -136,9 +190,12 @@ async function loadScreen(name) {
   }
   meta.textContent = (data.width ? data.width + '×' + data.height : 'no detect yet') +
     ' · ' + state.boxes.length + ' boxes · ' + state.elements.length + ' crops';
+  if (!data.hasBlank) setStatus(name + ' is not in the local cache — Pull selected', true);
+  else setStatus(name);
   renderImage();
   renderBoxes();
   renderElements();
+  highlightTree();
 }
 
 function renderImage() {
@@ -209,7 +266,24 @@ blank.addEventListener('load', paint);
 window.addEventListener('resize', paint);
 showDetected.addEventListener('change', paint);
 showAnnotated.addEventListener('change', renderImage);
-screenSel.addEventListener('change', () => loadScreen(screenSel.value));
+
+treeEl.addEventListener('click', (e) => {
+  const sum = e.target.closest('summary[data-screen]');
+  if (!sum) return;
+  const screen = sum.dataset.screen;
+  if (screen && screen !== selectedScreen) loadScreen(screen).catch((err) => setStatus(err.message, true));
+});
+treeEl.addEventListener('toggle', async (e) => {
+  const details = e.target;
+  if (details.tagName !== 'DETAILS' || !details.open || details.dataset.loaded) return;
+  const rel = details.dataset.path;
+  if (!rel) return;
+  try {
+    const listing = await api('/api/ls?path=' + encodeURIComponent(rel));
+    details.insertAdjacentHTML('beforeend', listingHtml(rel, mergeListing(listing.remote, listing.local)) || '<div class="muted">empty</div>');
+    details.dataset.loaded = '1';
+  } catch (err) { setStatus(err.message, true); }
+}, true);
 
 boxesBody.addEventListener('input', (e) => {
   const id = Number(e.target.dataset.id);
@@ -228,46 +302,38 @@ document.getElementById('saveSettings').onclick = async () => {
   try {
     await api('/api/settings', { method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ gcsUri: gcs.value }) });
     setStatus('saved URI');
-    await refreshRemote();
+    await renderTree();
   } catch (err) { setStatus(err.message, true); }
 };
 document.getElementById('pullAll').onclick = async () => {
   try {
     setStatus('pulling…');
     const out = await api('/api/pull', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' });
-    fillScreens(out.localScreens);
     setStatus('pulled ' + out.localScreens.length + ' local screens');
-    if (screenSel.value) await loadScreen(screenSel.value);
+    await renderTree();
+    if (currentScreen()) await loadScreen(currentScreen());
   } catch (err) { setStatus(err.message, true); }
 };
-document.getElementById('pushAll').onclick = async () => {
-  try {
-    setStatus('pushing…');
-    await api('/api/push', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' });
-    setStatus('pushed cache → GCS');
-  } catch (err) { setStatus(err.message, true); }
-};
+document.getElementById('pushAll').onclick = () => gcsWriteBlocked();
 document.getElementById('pullOne').onclick = async () => {
   try {
-    setStatus('pulling ' + screenSel.value + '…');
-    await api('/api/pull', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ name: screenSel.value }) });
-    setStatus('pulled ' + screenSel.value);
-    await loadScreen(screenSel.value);
+    const name = currentScreen();
+    if (!name) throw new Error('select a screen folder first');
+    setStatus('pulling ' + name + '…');
+    await api('/api/pull', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ name }) });
+    setStatus('pulled ' + name);
+    await loadScreen(name);
   } catch (err) { setStatus(err.message, true); }
 };
-document.getElementById('pushOne').onclick = async () => {
-  try {
-    setStatus('pushing ' + screenSel.value + '…');
-    await api('/api/push', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ name: screenSel.value }) });
-    setStatus('pushed ' + screenSel.value);
-  } catch (err) { setStatus(err.message, true); }
-};
+document.getElementById('pushOne').onclick = () => gcsWriteBlocked();
 document.getElementById('detect').onclick = async () => {
   try {
+    const name = currentScreen();
+    if (!name) throw new Error('select a screen folder first');
     setStatus('detecting…');
-    await api('/api/detect?name=' + encodeURIComponent(screenSel.value), { method: 'POST' });
-    setStatus('detected ' + screenSel.value);
-    await loadScreen(screenSel.value);
+    await api('/api/detect?name=' + encodeURIComponent(name), { method: 'POST' });
+    setStatus('detected ' + name);
+    await loadScreen(name);
   } catch (err) { setStatus(err.message, true); }
 };
 document.getElementById('apply').onclick = async () => {
@@ -296,8 +362,7 @@ document.getElementById('saveEls').onclick = async () => {
 };
 
 loadSettings()
-  .then(refreshRemote)
-  .then(() => { if (screenSel.value) return loadScreen(screenSel.value); })
+  .then(renderTree)
   .catch((err) => setStatus(err.message, true));
 </script>
 </body>

--- a/packages/tools/tm-v2/index.html
+++ b/packages/tools/tm-v2/index.html
@@ -8,82 +8,123 @@
   body { margin: 0; font: 13px/1.4 system-ui, sans-serif; background: #111; color: #eee; display: grid; grid-template-rows: auto 1fr; height: 100vh; }
   header { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; padding: 10px 12px; background: #1b1b1b; border-bottom: 1px solid #333; }
   header h1 { font-size: 14px; margin: 0 8px 0 0; white-space: nowrap; }
+  #draftTools, #catalogTools { display: flex; gap: 6px; align-items: center; }
+  #draftTools[hidden], #catalogTools[hidden] { display: none; }
   input[type=text], input[type=number], select, button { font: inherit; }
   input[type=text], select { background: #222; color: #eee; border: 1px solid #444; padding: 6px 8px; border-radius: 4px; }
-  #gcs { width: min(520px, 40vw); }
+  #gcs { width: min(420px, 32vw); }
   button { background: #333; color: #eee; border: 1px solid #555; padding: 6px 10px; border-radius: 4px; cursor: pointer; }
-  button.primary { background: #3d6d3d; border-color: #5a9; }
+  button.primary, button.current { background: #3d6d3d; border-color: #5a9; }
   button:hover { filter: brightness(1.12); }
+  button:disabled { opacity: 0.45; cursor: not-allowed; filter: none; }
   #status { color: #8c8; flex: 1; min-width: 120px; }
   #status.err { color: #f88; }
   #toast { position: fixed; right: 16px; bottom: 16px; max-width: 360px; background: #4a2020; color: #fcc; border: 1px solid #c66; padding: 10px 12px; border-radius: 6px; display: none; z-index: 20; }
-  .layout { display: grid; grid-template-columns: 360px 1fr; min-height: 0; }
-  aside { overflow: auto; padding: 12px; border-right: 1px solid #333; background: #181818; }
-  main { overflow: auto; background: #000; }
+  .layout { display: grid; grid-template-columns: 280px 1fr; min-height: 0; }
+  aside { overflow: hidden; padding: 10px 8px 12px; border-right: 1px solid #333; background: #181818; display: flex; flex-direction: column; min-height: 0; }
+  .tree { flex: 1; overflow: auto; min-height: 80px; margin: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; }
+  .reset-wrap { position: relative; display: flex; gap: 0; }
+  .reset-wrap > button:first-child { border-radius: 4px 0 0 4px; }
+  .reset-wrap > button:last-of-type { border-radius: 0 4px 4px 0; border-left: none; padding: 6px 8px; }
+  .reset-menu { position: absolute; right: 0; top: 100%; margin-top: 4px; background: #222; border: 1px solid #555; border-radius: 4px; min-width: 180px; display: none; z-index: 30; }
+  .reset-menu.open { display: block; }
+  .reset-menu button { display: block; width: 100%; text-align: left; background: none; border: none; border-radius: 0; }
+  #pop { position: absolute; z-index: 8; width: min(320px, 90vw); background: #1c1c1c; border: 1px solid #444; border-radius: 8px; padding: 10px; box-shadow: 0 8px 24px #000a; pointer-events: auto; }
+  #pop[hidden] { display: none; }
+  #pop canvas { display: block; max-width: 100%; height: auto; background: #000; border: 1px solid #333; image-rendering: pixelated; }
+  #popJson { margin: 8px 0 0; max-height: 140px; overflow: auto; padding: 8px; background: #111; border: 1px solid #2a2a2a; border-radius: 4px; font: 11px/1.35 ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre; color: #ddd; }
+  main { overflow: auto; background: #000; position: relative; }
   .row { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 8px; }
-  .tree { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; margin: 0 0 12px; }
-  .tree details { margin-left: 12px; }
-  .tree > details { margin-left: 0; }
-  .tree summary, .tree .file { cursor: pointer; padding: 2px 4px; border-radius: 3px; }
-  .tree summary:hover, .tree .file:hover { background: #2a2a2a; }
+  .tree-kids { margin-left: 12px; padding-left: 12px; border-left: 1px solid #3a3a3a; }
+  .tree-row { display: flex; align-items: center; gap: 4px; padding: 3px 4px; border-radius: 3px; cursor: pointer; }
+  .tree-row:hover { background: #2a2a2a; }
+  .tree-row .name { user-select: none; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .tree-row .twist { width: 1.2em; padding: 0; margin: 0; background: none; border: none; color: #888; cursor: pointer; font: inherit; line-height: 1; flex-shrink: 0; }
+  .tree-row .twist-spacer { width: 1.2em; flex-shrink: 0; }
   .tree .active { background: #243a24; color: #cfc; }
-  .tree .local { color: #8c8; }
+  .tree .local .name { color: #8c8; }
+  .view-pills { display: flex; gap: 3px; margin-left: 6px; flex-shrink: 0; }
+  .view-pill { width: 16px; height: 11px; padding: 0; border-radius: 3px; background: transparent; filter: none; }
+  .view-pill:hover { filter: none; }
+  .view-pill.source { border-color: #e55; }
+  .view-pill.source.on { background: #e55; border-color: #e55; }
+  .view-pill.draft { border-color: #e90; }
+  .view-pill.draft.on { background: #e90; border-color: #e90; }
+  .view-pill.catalog { border-color: #3a8; }
+  .view-pill.catalog.on { background: #3a8; border-color: #3a8; }
   .push-off { opacity: 0.55; }
-  .layout { display: grid; grid-template-columns: 360px 1fr; min-height: 0; }
-  aside { overflow: auto; padding: 12px; border-right: 1px solid #333; background: #181818; }
-  main { overflow: auto; background: #000; }
-  .row { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 8px; }
   .stage { position: relative; display: inline-block; }
   .stage img { display: block; max-width: 100%; height: auto; }
-  .box, .el-box { position: absolute; pointer-events: none; }
+  #overlays { position: absolute; inset: 0; pointer-events: none; }
+  .box, .el-box, .label-box, .section-box { position: absolute; }
+  .box, .el-box { pointer-events: auto; cursor: pointer; }
   .box { border: 2px solid #f44; }
+  .label-box { border: 1px dashed #e90; background: rgba(238,153,0,.12); pointer-events: none; }
+  .box.draw { border-style: dashed; background: rgba(255,68,68,.15); pointer-events: none; }
   .el-box { border: 2px solid #6af; background: rgba(80,160,255,.12); }
-  .el { border: 1px solid #333; padding: 8px; margin-bottom: 8px; border-radius: 4px; }
-  label { display: flex; justify-content: space-between; gap: 8px; margin: 4px 0; }
-  label input { width: 96px; background: #222; color: #eee; border: 1px solid #444; padding: 2px 4px; }
-  table { width: 100%; border-collapse: collapse; margin: 8px 0; }
-  td, th { text-align: left; padding: 3px 4px; border-bottom: 1px solid #2a2a2a; }
+  .section-box { border: 2px solid #a6f; background: rgba(170,100,255,.1); pointer-events: none; }
+  .box:hover, .el-box:hover, .box.on, .el-box.on { outline: 2px solid #ffe08a; outline-offset: 0; z-index: 4; }
+  .stage.draw-mode { cursor: crosshair; }
+  .stage.erase-mode { cursor: cell; }
+  .stage.drawing { cursor: crosshair; user-select: none; }
+  .stage.erase-mode.drawing { cursor: cell; }
+  .box.erase { border-color: #fa6; background: rgba(255,100,40,.22); }
+  .inspect-parts { display: flex; flex-wrap: wrap; gap: 8px; margin: 8px 0; }
+  .inspect-part { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+  .inspect-part canvas { max-width: 100%; }
+  .inspect-part span { color: #aaa; font-size: 11px; }
+  #pop dl { margin: 8px 0 0; display: grid; grid-template-columns: 52px 1fr; gap: 4px 8px; }
+  #pop dt { color: #888; }
+  #pop dd { margin: 0; word-break: break-word; }
   .muted { color: #888; }
-  .id { color: #f88; font-weight: 600; }
 </style>
 </head>
 <body>
 <header>
+  <div id="draftTools" hidden>
+    <button id="detect" class="primary" type="button">Detect</button>
+    <button id="toolDraw" type="button">Draw</button>
+    <button id="toolErase" type="button">Erase</button>
+  </div>
+  <div id="catalogTools" hidden>
+    <button id="copyPrompt" class="primary" type="button">Copy prompt</button>
+    <button id="reloadScreen" type="button">Reload</button>
+    <button id="copyRevise" type="button">Copy revision</button>
+  </div>
   <h1>TM v2</h1>
   <input id="gcs" type="text" spellcheck="false">
   <button id="saveSettings" type="button">Save URI</button>
   <button id="pullAll" type="button">Pull GCS</button>
   <button id="pushAll" class="push-off" type="button" title="GCS write disabled">Push GCS</button>
+  <div class="reset-wrap">
+    <button id="resetOne" type="button">Reset</button>
+    <button id="resetMenuBtn" type="button" aria-label="reset options">▾</button>
+    <div class="reset-menu" id="resetMenu">
+      <button id="resetAll" type="button">Reset all screens</button>
+    </div>
+  </div>
   <span id="status"></span>
 </header>
 <div id="toast"></div>
 <div class="layout">
 <aside>
-  <div class="row">
-    <button id="pullOne" type="button">Pull selected</button>
-    <button id="pushOne" class="push-off" type="button" title="GCS write disabled">Push</button>
-  </div>
   <div id="tree" class="tree"></div>
-  <div class="row">
-    <button id="detect" class="primary" type="button">Detect</button>
-    <button id="apply" class="primary" type="button">Apply</button>
-    <button id="saveEls" type="button">Save crops</button>
-  </div>
-  <label class="muted"><input type="checkbox" id="showDetected" checked> detected boxes</label>
-  <label class="muted"><input type="checkbox" id="showAnnotated"> annotated PNG</label>
-  <p class="muted" id="meta"></p>
-  <h3>Detected IDs</h3>
-  <table>
-    <thead><tr><th>id</th><th>name</th></tr></thead>
-    <tbody id="boxes"></tbody>
-  </table>
-  <h3>Applied crops</h3>
-  <div id="list"></div>
 </aside>
-<main>
+<main id="main">
   <div class="stage" id="stage">
     <img id="blank" alt="screen">
     <div id="overlays"></div>
+  </div>
+  <div id="pop" hidden>
+    <canvas id="popCanvas"></canvas>
+    <div class="inspect-parts" id="popParts"></div>
+    <dl>
+      <dt>name</dt><dd id="popName"></dd>
+      <dt>type</dt><dd id="popType"></dd>
+      <dt>section</dt><dd id="popSection"></dd>
+      <dt>parts</dt><dd id="popPartNames"></dd>
+    </dl>
+    <pre id="popJson"></pre>
   </div>
 </main>
 </div>
@@ -92,15 +133,20 @@ const statusEl = document.getElementById('status');
 const toastEl = document.getElementById('toast');
 const gcs = document.getElementById('gcs');
 const treeEl = document.getElementById('tree');
-const boxesBody = document.getElementById('boxes');
-const list = document.getElementById('list');
 const blank = document.getElementById('blank');
 const overlays = document.getElementById('overlays');
-const showDetected = document.getElementById('showDetected');
-const showAnnotated = document.getElementById('showAnnotated');
-const meta = document.getElementById('meta');
-let state = { name: '', elements: [], boxes: [], width: 0, height: 0, names: {} };
+const mainEl = document.getElementById('main');
+const popEl = document.getElementById('pop');
+let cacheDir = '';
+let view = 'source';
+let state = { name: '', elements: [], sections: [], boxes: [], labels: [], width: 0, height: 0, names: {}, firstPass: null };
 let selectedScreen = '';
+let selectedFile = '';
+let hoverKey = '';
+let pinnedKey = '';
+let draw = null;
+let savingBoxes = false;
+let detectTool = 'draw';
 
 function setStatus(msg, err) {
   statusEl.textContent = msg;
@@ -133,17 +179,38 @@ function mergeListing(remote, local) {
   return { dirs, files, localSet };
 }
 
+function viewPillsHtml(screen) {
+  if (screen !== selectedScreen) return '';
+  return '<span class="view-pills">' +
+    '<button type="button" class="view-pill source' + (view === 'source' ? ' on' : '') + '" data-view="source" title="Source" aria-label="Source"></button>' +
+    '<button type="button" class="view-pill draft' + (view === 'draft' ? ' on' : '') + '" data-view="draft" title="Draft" aria-label="Draft"></button>' +
+    '<button type="button" class="view-pill catalog' + (view === 'catalog' ? ' on' : '') + '" data-view="catalog" title="Catalog" aria-label="Catalog"></button>' +
+    '</span>';
+}
+
 function listingHtml(rel, merged) {
   let html = '';
   for (const dir of merged.dirs) {
     const path = rel ? rel + '/' + dir : dir;
     const screen = path.split('/')[0];
-    const active = screen === selectedScreen && path === screen ? ' active' : '';
+    const isRoot = !rel;
+    const active = isRoot && path === selectedScreen ? ' active' : '';
     const local = merged.localSet.has(dir) ? ' local' : '';
-    html += '<details data-path="' + path + '"><summary class="dir' + active + local + '" data-screen="' + screen + '">' + dir + '/</summary></details>';
+    html += '<div class="tree-node" data-path="' + path + '">' +
+      '<div class="tree-row dir' + active + local + '" data-screen="' + screen + '">' +
+      '<button type="button" class="twist" aria-expanded="false" aria-label="expand">▸</button>' +
+      '<span class="name">' + dir + '/</span>' +
+      (isRoot ? viewPillsHtml(screen) : '') +
+      '</div>' +
+      '<div class="tree-kids" hidden></div></div>';
   }
   for (const file of merged.files) {
-    html += '<div class="file' + (merged.localSet.has(file) ? ' local' : '') + '">' + file + '</div>';
+    const path = rel ? rel + '/' + file : file;
+    const screen = path.split('/')[0];
+    const active = path === selectedFile ? ' active' : '';
+    html += '<div class="tree-row file' + active + (merged.localSet.has(file) ? ' local' : '') + '" data-path="' + path + '" data-screen="' + screen + '">' +
+      '<span class="twist-spacer"></span>' +
+      '<span class="name">' + file + '</span></div>';
   }
   return html;
 }
@@ -154,8 +221,18 @@ async function renderTree() {
 }
 
 function highlightTree() {
-  treeEl.querySelectorAll('summary.dir').forEach((el) => {
-    el.classList.toggle('active', el.dataset.screen === selectedScreen && el.parentElement.dataset.path === selectedScreen);
+  treeEl.querySelectorAll('.tree-row').forEach((el) => {
+    if (el.classList.contains('file')) {
+      el.classList.toggle('active', Boolean(selectedFile) && el.dataset.path === selectedFile);
+      return;
+    }
+    const path = el.parentElement && el.parentElement.dataset.path;
+    el.classList.toggle('active', path === selectedScreen && !selectedFile);
+    if (path && !path.includes('/')) {
+      const existing = el.querySelector('.view-pills');
+      if (existing) existing.remove();
+      if (path === selectedScreen) el.insertAdjacentHTML('beforeend', viewPillsHtml(path));
+    }
   });
 }
 
@@ -163,22 +240,321 @@ function currentScreen() {
   return selectedScreen || '';
 }
 
+function inferView() {
+  if (state.elements.length) return 'catalog';
+  if (state.boxes.length) return 'draft';
+  return 'source';
+}
+
+function setView(next) {
+  view = next || 'source';
+  if (view !== 'source' && selectedFile) {
+    selectedFile = '';
+    renderImage();
+  }
+  syncDetectTool();
+  document.getElementById('draftTools').hidden = view !== 'draft';
+  document.getElementById('catalogTools').hidden = view !== 'catalog';
+  const detectLabel = state.boxes.length ? 'Re-detect' : 'Detect';
+  document.getElementById('detect').textContent = detectLabel;
+  document.getElementById('detect').disabled = !currentScreen();
+  document.getElementById('copyPrompt').disabled = !currentScreen() || !state.boxes.length;
+  document.getElementById('copyRevise').disabled = !(view === 'catalog' && pinnedKey);
+  document.getElementById('resetOne').disabled = !currentScreen();
+  highlightTree();
+  if (view !== 'catalog') hidePop();
+  updateMeta();
+  paint();
+  if (view === 'catalog') renderPop();
+}
+
+async function expandNode(node, open) {
+  const kids = node.querySelector(':scope > .tree-kids');
+  const twist = node.querySelector(':scope > .tree-row .twist');
+  if (!kids) return kids;
+  if (!node.dataset.loaded) {
+    const listing = await api('/api/ls?path=' + encodeURIComponent(node.dataset.path));
+    kids.innerHTML = listingHtml(node.dataset.path, mergeListing(listing.remote, listing.local)) || '<div class="muted">empty</div>';
+    node.dataset.loaded = '1';
+  }
+  if (open !== undefined) {
+    kids.hidden = !open;
+    if (twist) {
+      twist.textContent = kids.hidden ? '▸' : '▾';
+      twist.setAttribute('aria-expanded', String(!kids.hidden));
+    }
+  }
+  return kids;
+}
+
 async function loadSettings() {
   const s = await api('/api/settings');
   gcs.value = s.gcsUri;
+  cacheDir = s.cacheDir || '';
 }
 
-async function loadScreen(name) {
+function screenRoot(name) {
+  return (cacheDir ? cacheDir + '/' + name : '~/.smart-vision/screens/' + name);
+}
+
+function namingPrompt(name) {
+  const root = screenRoot(name);
+  return [
+    'Name the detected boxes for smart-vision screen "' + name + '".',
+    '',
+    'Follow packages/tools/ai-first-pass-prompt.md.',
+    '',
+    'Read:',
+    '- ' + root + '/boxes.json',
+    '- ' + root + '/boxes-annotated.png',
+    '- ' + root + '/blank.png',
+  ].join('\n');
+}
+
+function revisionPrompt(name) {
+  const info = inspectInfo(pinnedKey);
+  const root = screenRoot(name);
+  const selected = info
+    ? 'I selected crop "' + info.name + '" (type: ' + (info.type || '—') + ').'
+    : 'Revise names I disagree with.';
+  return [
+    'Revise first-pass naming for smart-vision screen "' + name + '".',
+    '',
+    selected,
+    '',
+    'Follow packages/tools/ai-first-pass-prompt.md.',
+    '',
+    'Read:',
+    '- ' + root + '/first-pass.json',
+    '- ' + root + '/boxes.json',
+    '- ' + root + '/boxes-annotated.png',
+    '- ' + root + '/blank.png',
+  ].join('\n');
+}
+
+function updateMeta() {
+  const detect = document.getElementById('detect');
+  const nLabels = (state.labels || []).length;
+  detect.title = state.boxes.length
+    ? state.boxes.length + ' boxes' + (nLabels ? ', ' + nLabels + ' labels' : '') + '. Draw to add, Erase to remove. Re-detect replaces drawn boxes.'
+    : 'No boxes yet — Detect, or draw on the screenshot.';
+  const prompt = document.getElementById('copyPrompt');
+  if (!state.boxes.length) prompt.title = 'Detect boxes in Draft first, then copy the prompt.';
+  else if (state.elements.length) prompt.title = state.elements.length + ' crops. Reload after the AI writes first-pass.json.';
+  else prompt.title = 'Copy, paste in Cursor, then Reload — apply runs automatically.';
+}
+
+function unionRect(rects) {
+  const x = Math.min(...rects.map((r) => r.x));
+  const y = Math.min(...rects.map((r) => r.y));
+  const right = Math.max(...rects.map((r) => r.x + r.width));
+  const bottom = Math.max(...rects.map((r) => r.y + r.height));
+  return { x, y, width: right - x, height: bottom - y };
+}
+
+function boxesForIds(ids) {
+  return (ids || []).map((id) => state.boxes.find((box) => box.id === id)).filter(Boolean);
+}
+
+function partScreenRects(el, parent) {
+  const parts = el && el.parts || [];
+  if (!parts.length || !parent) return [];
+  if (parts[0].x != null && parts[0].width != null) {
+    return parts.map((p) => ({
+      name: p.name,
+      x: parent.x + p.x,
+      y: parent.y + p.y,
+      width: p.width,
+      height: p.height,
+    }));
+  }
+  if (parts.every((p) => p.boxId != null)) {
+    return parts.map((p) => {
+      const box = state.boxes.find((b) => b.id === p.boxId);
+      return box ? { name: p.name, x: box.x, y: box.y, width: box.width, height: box.height } : null;
+    }).filter(Boolean);
+  }
+  const n = parts.length;
+  return parts.map((p, i) => {
+    const x = parent.x + Math.round(parent.width * i / n);
+    const next = parent.x + Math.round(parent.width * (i + 1) / n);
+    return { name: p.name, x, y: parent.y, width: Math.max(1, next - x), height: parent.height };
+  });
+}
+
+function namedElementForBox(id) {
+  const fromPass = (state.firstPass && state.firstPass.elements || []).find((el) => (el.boxIds || []).includes(id));
+  if (fromPass) return fromPass;
+  return (state.elements || []).find((el) => (el.boxIds || []).includes(id));
+}
+
+function catalogSection(el) {
+  if (!el || !el.section) return null;
+  const listed = (state.sections || []).find((sec) => sec.filename === el.section || sec.name === el.section);
+  if (listed && listed.width) return listed;
+  const fromPass = (state.firstPass && state.firstPass.sections || []).find((sec) => sec.name === el.section || (listed && sec.name === listed.name));
+  if (!fromPass) return listed || null;
+  const rects = boxesForIds(fromPass.boxIds);
+  if (!rects.length) return listed || { name: fromPass.name };
+  return { name: fromPass.name, filename: el.section, ...unionRect(rects) };
+}
+
+function inspectInfo(key) {
+  if (!key) return null;
+  if (key.startsWith('box:')) {
+    const id = Number(key.slice(4));
+    const box = state.boxes.find((b) => b.id === id);
+    if (!box) return null;
+    const el = namedElementForBox(id);
+    const part = el && (el.parts || []).find((p) => p.boxId === id);
+    const fieldBoxes = el ? boxesForIds(el.boxIds) : [box];
+    const parent = fieldBoxes.length ? unionRect(fieldBoxes) : box;
+    return {
+      kind: 'box',
+      id,
+      name: part ? el.name + '.' + part.name : (el && el.name) || state.names[id] || '',
+      type: (el && el.type) || '',
+      section: (el && el.section) || '',
+      boxIds: el && el.boxIds ? el.boxIds.join(', ') : String(id),
+      partNames: el && el.parts ? el.parts.map((p) => p.name + (p.boxId != null ? '#' + p.boxId : '')).join(', ') : '',
+      rect: box,
+      parent,
+      parts: partScreenRects(el, parent),
+    };
+  }
+  if (key.startsWith('crop:')) {
+    const name = key.slice(5);
+    const el = state.elements.find((item) => item.name === name);
+    if (!el) return null;
+    const own = { x: el.x, y: el.y, width: el.width, height: el.height };
+    const section = catalogSection(el);
+    const parent = section && section.width ? { x: section.x, y: section.y, width: section.width, height: section.height } : own;
+    const inner = (el.parts || []).length ? partScreenRects(el, own) : (section && section.width ? [{ ...own, name: el.name }] : []);
+    return {
+      kind: 'crop',
+      id: (el.boxIds || [])[0] || '',
+      name: el.name,
+      type: el.type || 'crop',
+      section: (section && section.name) || el.section || '',
+      boxIds: (el.boxIds || []).join(', '),
+      partNames: (el.parts || []).map((p) => p.name).join(', '),
+      rect: own,
+      parent,
+      parts: inner,
+    };
+  }
+  return null;
+}
+
+function drawSourceRect(canvas, rect, maxW, overlays) {
+  if (!canvas || !rect || !blank.naturalWidth) return;
+  const pad = 6;
+  const sx = Math.max(0, rect.x - pad);
+  const sy = Math.max(0, rect.y - pad);
+  const sw = Math.min(blank.naturalWidth - sx, rect.width + pad * 2);
+  const sh = Math.min(blank.naturalHeight - sy, rect.height + pad * 2);
+  const scale = Math.min(2, maxW / sw);
+  canvas.width = Math.max(1, Math.round(sw * scale));
+  canvas.height = Math.max(1, Math.round(sh * scale));
+  const ctx = canvas.getContext('2d');
+  ctx.imageSmoothingEnabled = false;
+  ctx.drawImage(blank, sx, sy, sw, sh, 0, 0, canvas.width, canvas.height);
+  ctx.strokeStyle = '#f44';
+  ctx.lineWidth = 1;
+  ctx.strokeRect((rect.x - sx) * scale, (rect.y - sy) * scale, rect.width * scale, rect.height * scale);
+  if (overlays && overlays.length) {
+    ctx.strokeStyle = '#6af';
+    for (const part of overlays) {
+      ctx.strokeRect((part.x - sx) * scale, (part.y - sy) * scale, part.width * scale, part.height * scale);
+    }
+  }
+}
+
+function hidePop() {
+  popEl.hidden = true;
+}
+
+function catalogElement(key) {
+  if (!key || !key.startsWith('crop:')) return null;
+  return state.elements.find((item) => item.name === key.slice(5)) || null;
+}
+
+function placePop(key) {
+  const hit = overlays.querySelector('[data-key="' + CSS.escape(key) + '"]');
+  if (!hit) {
+    hidePop();
+    return;
+  }
+  popEl.hidden = false;
+  const hr = hit.getBoundingClientRect();
+  const mr = mainEl.getBoundingClientRect();
+  let left = hr.right - mr.left + mainEl.scrollLeft + 8;
+  let top = hr.top - mr.top + mainEl.scrollTop;
+  const maxLeft = mainEl.scrollLeft + Math.max(8, mainEl.clientWidth - popEl.offsetWidth - 8);
+  const maxTop = mainEl.scrollTop + Math.max(8, mainEl.clientHeight - popEl.offsetHeight - 8);
+  if (left > maxLeft) left = hr.left - mr.left + mainEl.scrollLeft - popEl.offsetWidth - 8;
+  popEl.style.left = Math.max(mainEl.scrollLeft + 8, Math.min(left, maxLeft)) + 'px';
+  popEl.style.top = Math.max(mainEl.scrollTop + 8, Math.min(top, maxTop)) + 'px';
+}
+
+function renderPop() {
+  if (view !== 'catalog') {
+    hidePop();
+    return;
+  }
+  const key = pinnedKey || hoverKey;
+  const info = inspectInfo(key);
+  const el = catalogElement(key);
+  document.getElementById('copyRevise').disabled = !pinnedKey;
+  if (!info || !el) {
+    hidePop();
+    return;
+  }
+  document.getElementById('popName').textContent = info.name || 'unnamed';
+  document.getElementById('popType').textContent = info.type || '—';
+  document.getElementById('popSection').textContent = info.section || '—';
+  document.getElementById('popPartNames').textContent = info.partNames || '—';
+  document.getElementById('popJson').textContent = JSON.stringify(el, null, 2);
+  const parent = info.parent && info.parent.width ? info.parent : info.rect;
+  drawSourceRect(document.getElementById('popCanvas'), parent, 280, info.parts);
+  const partsEl = document.getElementById('popParts');
+  partsEl.innerHTML = '';
+  for (const part of info.parts) {
+    const wrap = document.createElement('div');
+    wrap.className = 'inspect-part';
+    const canvas = document.createElement('canvas');
+    const label = document.createElement('span');
+    label.textContent = part.name;
+    wrap.appendChild(canvas);
+    wrap.appendChild(label);
+    partsEl.appendChild(wrap);
+    drawSourceRect(canvas, part, 140, []);
+  }
+  placePop(key);
+}
+
+async function copyText(text, ok) {
+  await navigator.clipboard.writeText(text);
+  setStatus(ok);
+}
+
+async function loadScreen(name, opts = {}) {
   if (!name) return;
   selectedScreen = name;
+  if (!opts.keepFile) selectedFile = '';
+  pinnedKey = '';
+  hoverKey = '';
   const data = await api('/api/screen?name=' + encodeURIComponent(name));
   state = {
     name,
     elements: data.elements || [],
+    sections: data.sections || [],
     boxes: data.boxes || [],
+    labels: data.labels || [],
     width: data.width || 0,
     height: data.height || 0,
     names: {},
+    firstPass: data.firstPass || null,
   };
   for (const el of state.elements) {
     for (const id of el.boxIds || []) state.names[id] = el.name;
@@ -188,114 +564,301 @@ async function loadScreen(name) {
       for (const id of el.boxIds || []) state.names[id] = el.name;
     }
   }
-  meta.textContent = (data.width ? data.width + '×' + data.height : 'no detect yet') +
-    ' · ' + state.boxes.length + ' boxes · ' + state.elements.length + ' crops';
   if (!data.hasBlank) setStatus(name + ' is not in the local cache — Pull selected', true);
-  else setStatus(name);
-  renderImage();
-  renderBoxes();
-  renderElements();
+  else if (data.applied) setStatus((opts.status || name) + ' — applied first-pass.json');
+  else setStatus(opts.status || name);
+  updateMeta();
+  if (!opts.skipImage) renderImage();
   highlightTree();
+  if (!opts.keepView) setView(opts.view || inferView());
+  else setView(view);
 }
 
 function renderImage() {
-  const src = showAnnotated.checked ? '/file/annotated' : '/file/blank';
-  blank.src = src + '?name=' + encodeURIComponent(state.name) + '&t=' + Date.now();
-}
-
-function renderBoxes() {
-  boxesBody.innerHTML = state.boxes.map((box) => {
-    const val = state.names[box.id] || '';
-    return '<tr><td class="id">' + box.id + '</td><td><input data-id="' + box.id + '" value="' + val + '" placeholder="name"></td></tr>';
-  }).join('');
-  paint();
-}
-
-function renderElements() {
-  list.innerHTML = state.elements.map((el) => {
-    return '<div class="el"><strong>' + el.name + '</strong>' +
-      '<label>x <input data-name="' + el.name + '" data-k="x" type="number" value="' + el.x + '"></label>' +
-      '<label>y <input data-name="' + el.name + '" data-k="y" type="number" value="' + el.y + '"></label>' +
-      '<label>w <input data-name="' + el.name + '" data-k="width" type="number" value="' + el.width + '"></label>' +
-      '<label>h <input data-name="' + el.name + '" data-k="height" type="number" value="' + el.height + '"></label></div>';
-  }).join('') || '<p class="muted">No index.json yet. Detect → name IDs → Apply.</p>';
-  paint();
-}
-
-function paint() {
-  const scaleX = blank.clientWidth / (blank.naturalWidth || state.width || 1);
-  const scaleY = blank.clientHeight / (blank.naturalHeight || state.height || 1);
-  let html = '';
-  if (showDetected.checked) {
-    for (const box of state.boxes) {
-      html += '<div class="box" style="left:' + (box.x * scaleX) + 'px;top:' + (box.y * scaleY) + 'px;width:' + (box.width * scaleX) + 'px;height:' + (box.height * scaleY) + 'px"></div>';
-    }
+  if (selectedFile) {
+    blank.src = '/file?path=' + encodeURIComponent(selectedFile) + '&t=' + Date.now();
+    return;
   }
-  for (const el of state.elements) {
-    html += '<div class="el-box" style="left:' + (el.x * scaleX) + 'px;top:' + (el.y * scaleY) + 'px;width:' + (el.width * scaleX) + 'px;height:' + (el.height * scaleY) + 'px"></div>';
-  }
-  overlays.innerHTML = html;
+  blank.src = '/file/blank?name=' + encodeURIComponent(state.name) + '&t=' + Date.now();
 }
 
-function firstPassFromNames() {
-  const grouped = {};
-  for (const box of state.boxes) {
-    const n = (state.names[box.id] || '').trim();
-    if (!n) continue;
-    if (!grouped[n]) grouped[n] = [];
-    grouped[n].push(box.id);
-  }
-  const assigned = new Set();
-  const elements = Object.entries(grouped).map(([name, boxIds]) => {
-    boxIds.forEach((id) => assigned.add(id));
-    return { name, type: 'field', section: null, boxIds };
-  });
-  const unknowns = state.boxes
-    .filter((box) => !assigned.has(box.id))
-    .map((box) => 'box ' + box.id + ': unassigned');
+function overlayMode() {
+  if (view === 'catalog') return 'crops';
+  if (view === 'draft') return 'boxes';
+  return 'none';
+}
+
+function syncDetectTool() {
+  const on = view === 'draft';
+  document.getElementById('stage').classList.toggle('draw-mode', on && detectTool === 'draw');
+  document.getElementById('stage').classList.toggle('erase-mode', on && detectTool === 'erase');
+  document.getElementById('toolDraw').classList.toggle('current', detectTool === 'draw');
+  document.getElementById('toolErase').classList.toggle('current', detectTool === 'erase');
+  document.getElementById('toolDraw').setAttribute('aria-pressed', detectTool === 'draw' ? 'true' : 'false');
+  document.getElementById('toolErase').setAttribute('aria-pressed', detectTool === 'erase' ? 'true' : 'false');
+}
+
+function stageToImage(e) {
+  const r = blank.getBoundingClientRect();
+  const nw = blank.naturalWidth || state.width || 1;
+  const nh = blank.naturalHeight || state.height || 1;
+  if (!r.width || !r.height) return { x: 0, y: 0 };
   return {
-    screen: { name: state.name, width: state.width, height: state.height },
-    notes: [],
-    unknowns,
-    sections: [],
-    elements,
+    x: Math.max(0, Math.min(nw, ((e.clientX - r.left) / r.width) * nw)),
+    y: Math.max(0, Math.min(nh, ((e.clientY - r.top) / r.height) * nh)),
   };
 }
 
-blank.addEventListener('load', paint);
-window.addEventListener('resize', paint);
-showDetected.addEventListener('change', paint);
-showAnnotated.addEventListener('change', renderImage);
+function normalizeDraw(d) {
+  const x = Math.min(d.x0, d.x1);
+  const y = Math.min(d.y0, d.y1);
+  return { x, y, width: Math.abs(d.x1 - d.x0), height: Math.abs(d.y1 - d.y0) };
+}
 
-treeEl.addEventListener('click', (e) => {
-  const sum = e.target.closest('summary[data-screen]');
-  if (!sum) return;
-  const screen = sum.dataset.screen;
-  if (screen && screen !== selectedScreen) loadScreen(screen).catch((err) => setStatus(err.message, true));
-});
-treeEl.addEventListener('toggle', async (e) => {
-  const details = e.target;
-  if (details.tagName !== 'DETAILS' || !details.open || details.dataset.loaded) return;
-  const rel = details.dataset.path;
-  if (!rel) return;
+function nextBoxId() {
+  return state.boxes.reduce((max, box) => Math.max(max, Number(box.id) || 0), 0) + 1;
+}
+
+async function persistBoxes(boxes, status) {
+  const name = currentScreen();
+  if (!name) throw new Error('select a screen first');
+  const result = await api('/api/boxes?name=' + encodeURIComponent(name), {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ boxes }),
+  });
+  state.boxes = result.boxes;
+  state.labels = result.labels || state.labels || [];
+  state.width = result.width;
+  state.height = result.height;
+  setStatus(status || (state.boxes.length + ' boxes'));
+  setView(view);
+}
+
+async function addManualBox(rect) {
+  if (savingBoxes) return;
+  savingBoxes = true;
   try {
-    const listing = await api('/api/ls?path=' + encodeURIComponent(rel));
-    details.insertAdjacentHTML('beforeend', listingHtml(rel, mergeListing(listing.remote, listing.local)) || '<div class="muted">empty</div>');
-    details.dataset.loaded = '1';
-  } catch (err) { setStatus(err.message, true); }
-}, true);
+    const box = {
+      id: nextBoxId(),
+      x: Math.round(rect.x),
+      y: Math.round(rect.y),
+      width: Math.round(rect.width),
+      height: Math.round(rect.height),
+    };
+    await persistBoxes([...state.boxes, box], 'added box ' + box.id);
+    pinnedKey = '';
+    hoverKey = '';
+  } finally {
+    savingBoxes = false;
+  }
+}
 
-boxesBody.addEventListener('input', (e) => {
-  const id = Number(e.target.dataset.id);
-  if (!id) return;
-  state.names[id] = e.target.value;
+function rectsOverlap(a, b) {
+  return a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y;
+}
+
+function boxAtPoint(x, y) {
+  const hits = state.boxes.filter((box) => x >= box.x && x <= box.x + box.width && y >= box.y && y <= box.y + box.height);
+  hits.sort((a, b) => a.width * a.height - b.width * b.height);
+  return hits[0] || null;
+}
+
+async function eraseBoxes(rect, click) {
+  if (savingBoxes) return;
+  const lasso = rect.width >= 12 && rect.height >= 12;
+  const remove = lasso
+    ? state.boxes.filter((box) => rectsOverlap(box, rect))
+    : [boxAtPoint(click.x, click.y)].filter(Boolean);
+  if (!remove.length) {
+    paint();
+    return;
+  }
+  const ids = new Set(remove.map((box) => box.id));
+  savingBoxes = true;
+  try {
+    if (pinnedKey && pinnedKey.startsWith('box:') && ids.has(Number(pinnedKey.slice(4)))) pinnedKey = '';
+    hoverKey = '';
+    const label = remove.length === 1 ? 'deleted box ' + remove[0].id : 'deleted ' + remove.length + ' boxes';
+    await persistBoxes(state.boxes.filter((box) => !ids.has(box.id)), label);
+  } finally {
+    savingBoxes = false;
+  }
+}
+
+function markActive() {
+  const active = pinnedKey || hoverKey;
+  overlays.querySelectorAll('[data-key]').forEach((el) => {
+    el.classList.toggle('on', el.dataset.key === active);
+  });
+}
+
+function paint() {
+  if (!state.name) {
+    overlays.innerHTML = '';
+    return;
+  }
+  if (overlayMode() === 'none') {
+    overlays.innerHTML = '';
+    hidePop();
+    return;
+  }
+  const scaleX = blank.clientWidth / (blank.naturalWidth || state.width || 1);
+  const scaleY = blank.clientHeight / (blank.naturalHeight || state.height || 1);
+  let html = '';
+  if (overlayMode() === 'crops') {
+    for (const sec of state.sections || []) {
+      if (!sec.width) continue;
+      html += '<div class="section-box" style="left:' + (sec.x * scaleX) + 'px;top:' + (sec.y * scaleY) + 'px;width:' + (sec.width * scaleX) + 'px;height:' + (sec.height * scaleY) + 'px"></div>';
+    }
+    const crops = [...state.elements].sort((a, b) => a.width * a.height - b.width * b.height);
+    for (const el of crops) {
+      html += '<div class="el-box" data-key="crop:' + el.name + '" style="left:' + (el.x * scaleX) + 'px;top:' + (el.y * scaleY) + 'px;width:' + (el.width * scaleX) + 'px;height:' + (el.height * scaleY) + 'px"></div>';
+    }
+  } else {
+    const boxes = [...state.boxes].sort((a, b) => a.width * a.height - b.width * b.height);
+    for (const label of state.labels || []) {
+      html += '<div class="label-box" style="left:' + (label.x * scaleX) + 'px;top:' + (label.y * scaleY) + 'px;width:' + (label.width * scaleX) + 'px;height:' + (label.height * scaleY) + 'px"></div>';
+    }
+    for (const box of boxes) {
+      html += '<div class="box" data-key="box:' + box.id + '" style="left:' + (box.x * scaleX) + 'px;top:' + (box.y * scaleY) + 'px;width:' + (box.width * scaleX) + 'px;height:' + (box.height * scaleY) + 'px"></div>';
+    }
+  }
+  if (draw) {
+    const preview = normalizeDraw(draw);
+    html += '<div class="box draw' + (detectTool === 'erase' ? ' erase' : '') + '" style="left:' + (preview.x * scaleX) + 'px;top:' + (preview.y * scaleY) + 'px;width:' + (preview.width * scaleX) + 'px;height:' + (preview.height * scaleY) + 'px"></div>';
+  }
+  overlays.innerHTML = html;
+  markActive();
+}
+
+blank.addEventListener('load', () => {
+  paint();
+  if (view === 'catalog') renderPop();
+});
+blank.addEventListener('error', () => {
+  overlays.innerHTML = '';
+  setStatus((selectedFile || selectedScreen || 'file') + ' is not in the local cache — Pull selected', true);
+});
+window.addEventListener('resize', paint);
+
+let popHide = 0;
+function cancelHidePop() {
+  clearTimeout(popHide);
+}
+function scheduleHidePop() {
+  cancelHidePop();
+  popHide = setTimeout(() => {
+    if (pinnedKey) return;
+    hoverKey = '';
+    renderPop();
+    markActive();
+  }, 180);
+}
+overlays.addEventListener('pointerover', (e) => {
+  if (view !== 'catalog') return;
+  const hit = e.target.closest('[data-key]');
+  if (!hit) return;
+  cancelHidePop();
+  hoverKey = hit.dataset.key;
+  renderPop();
+  markActive();
+});
+overlays.addEventListener('pointerout', (e) => {
+  if (e.relatedTarget && (e.currentTarget.contains(e.relatedTarget) || popEl.contains(e.relatedTarget))) return;
+  scheduleHidePop();
+});
+popEl.addEventListener('pointerenter', cancelHidePop);
+popEl.addEventListener('pointerleave', () => {
+  if (!pinnedKey) scheduleHidePop();
+});
+overlays.addEventListener('click', (e) => {
+  if (view === 'draft' && detectTool === 'erase') return;
+  if (view !== 'catalog') return;
+  const hit = e.target.closest('[data-key]');
+  if (!hit) return;
+  pinnedKey = hit.dataset.key === pinnedKey ? '' : hit.dataset.key;
+  hoverKey = hit.dataset.key;
+  renderPop();
+  markActive();
 });
 
-list.addEventListener('input', (e) => {
-  const el = state.elements.find((x) => x.name === e.target.dataset.name);
-  if (!el) return;
-  el[e.target.dataset.k] = Number(e.target.value);
+const stage = document.getElementById('stage');
+blank.draggable = false;
+stage.addEventListener('pointerdown', (e) => {
+  if (view !== 'draft') return;
+  if (e.button !== 0) return;
+  if (detectTool === 'draw' && e.target.closest('[data-key]')) return;
+  if (!blank.naturalWidth) return;
+  e.preventDefault();
+  const p = stageToImage(e);
+  draw = { x0: p.x, y0: p.y, x1: p.x, y1: p.y };
+  stage.classList.add('drawing');
+  try { stage.setPointerCapture(e.pointerId); } catch (_) {}
   paint();
+});
+stage.addEventListener('pointermove', (e) => {
+  if (!draw) return;
+  const p = stageToImage(e);
+  draw.x1 = p.x;
+  draw.y1 = p.y;
+  paint();
+});
+async function finishDraw() {
+  if (!draw) return;
+  const box = normalizeDraw(draw);
+  const click = { x: draw.x0, y: draw.y0 };
+  draw = null;
+  stage.classList.remove('drawing');
+  try {
+    if (detectTool === 'erase') await eraseBoxes(box, click);
+    else if (box.width >= 12 && box.height >= 12) await addManualBox(box);
+    else paint();
+  } catch (err) {
+    setStatus(err.message, true);
+    paint();
+  }
+}
+stage.addEventListener('pointerup', finishDraw);
+stage.addEventListener('pointercancel', () => {
+  draw = null;
+  stage.classList.remove('drawing');
+  paint();
+});
+
+treeEl.addEventListener('click', async (e) => {
+  const pill = e.target.closest('.view-pill');
+  if (pill && pill.dataset.view) {
+    e.stopPropagation();
+    pinnedKey = '';
+    hoverKey = '';
+    setView(pill.dataset.view);
+    return;
+  }
+  const twist = e.target.closest('.twist');
+  if (twist) {
+    const node = twist.closest('.tree-node');
+    if (!node) return;
+    const kids = node.querySelector(':scope > .tree-kids');
+    try {
+      await expandNode(node, Boolean(kids && kids.hidden));
+    } catch (err) {
+      setStatus(err.message, true);
+    }
+    return;
+  }
+  const fileRow = e.target.closest('.tree-row.file');
+  if (fileRow && fileRow.dataset.path) {
+    const screen = fileRow.dataset.screen;
+    selectedFile = fileRow.dataset.path;
+    if (screen) {
+      loadScreen(screen, { keepFile: true, view: 'source', status: fileRow.dataset.path }).catch((err) => setStatus(err.message, true));
+    }
+    return;
+  }
+  const dirRow = e.target.closest('.tree-row.dir');
+  const name = dirRow && dirRow.dataset.screen;
+  if (name) loadScreen(name).catch((err) => setStatus(err.message, true));
 });
 
 document.getElementById('saveSettings').onclick = async () => {
@@ -311,58 +874,109 @@ document.getElementById('pullAll').onclick = async () => {
     const out = await api('/api/pull', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' });
     setStatus('pulled ' + out.localScreens.length + ' local screens');
     await renderTree();
-    if (currentScreen()) await loadScreen(currentScreen());
+    if (currentScreen()) await loadScreen(currentScreen(), { keepView: true });
   } catch (err) { setStatus(err.message, true); }
 };
 document.getElementById('pushAll').onclick = () => gcsWriteBlocked();
-document.getElementById('pullOne').onclick = async () => {
+document.getElementById('copyPrompt').onclick = async () => {
   try {
     const name = currentScreen();
-    if (!name) throw new Error('select a screen folder first');
-    setStatus('pulling ' + name + '…');
-    await api('/api/pull', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ name }) });
-    setStatus('pulled ' + name);
-    await loadScreen(name);
+    if (!name) throw new Error('select a screen first');
+    if (!state.boxes.length) throw new Error('add at least one box in Draft first');
+    await copyText(namingPrompt(name), 'prompt copied — paste it in Cursor');
   } catch (err) { setStatus(err.message, true); }
 };
-document.getElementById('pushOne').onclick = () => gcsWriteBlocked();
+document.getElementById('reloadScreen').onclick = async () => {
+  try {
+    const name = currentScreen();
+    if (!name) throw new Error('select a screen first');
+    await loadScreen(name);
+    await renderTree();
+  } catch (err) { setStatus(err.message, true); }
+};
+document.getElementById('copyRevise').onclick = async () => {
+  try {
+    const name = currentScreen();
+    if (!name) throw new Error('select a screen first');
+    if (!pinnedKey) throw new Error('click a crop first');
+    await copyText(revisionPrompt(name), 'revision prompt copied — paste it in Cursor');
+  } catch (err) { setStatus(err.message, true); }
+};
+async function runDetect() {
+  const name = currentScreen();
+  if (!name) throw new Error('select a screen first');
+  setStatus('detecting…');
+  const result = await api('/api/detect?name=' + encodeURIComponent(name), { method: 'POST' });
+  const n = (result.boxes || []).length;
+  const nLabels = (result.labels || []).length;
+  const status = n
+    ? 'detected ' + n + ' boxes' + (nLabels ? ', ' + nLabels + ' labels' : '') + ' — Draw to add, Erase to remove'
+    : 'no empty fields — drag on the screenshot to add boxes';
+  await loadScreen(name, { view: 'draft', status });
+}
 document.getElementById('detect').onclick = async () => {
-  try {
-    const name = currentScreen();
-    if (!name) throw new Error('select a screen folder first');
-    setStatus('detecting…');
-    await api('/api/detect?name=' + encodeURIComponent(name), { method: 'POST' });
-    setStatus('detected ' + name);
-    await loadScreen(name);
-  } catch (err) { setStatus(err.message, true); }
+  try { await runDetect(); } catch (err) { setStatus(err.message, true); }
 };
-document.getElementById('apply').onclick = async () => {
-  try {
-    const pass = firstPassFromNames();
-    if (!pass.elements.length) throw new Error('name at least one box ID before apply');
-    await api('/api/first-pass?name=' + encodeURIComponent(state.name), {
-      method: 'PUT',
+document.getElementById('toolDraw').onclick = () => {
+  detectTool = 'draw';
+  syncDetectTool();
+};
+document.getElementById('toolErase').onclick = () => {
+  detectTool = 'erase';
+  syncDetectTool();
+};
+async function resetLocal({ all }) {
+  const name = currentScreen();
+  if (all) {
+    if (!confirm('Reset all local screens? Keeps only blank.png in each folder.')) return;
+    const out = await api('/api/reset', {
+      method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(pass),
+      body: JSON.stringify({ all: true }),
     });
-    const out = await api('/api/apply?name=' + encodeURIComponent(state.name), { method: 'POST' });
-    setStatus('applied ' + out.elements.join(', '));
-    await loadScreen(state.name);
-  } catch (err) { setStatus(err.message, true); }
-};
-document.getElementById('saveEls').onclick = async () => {
-  try {
-    await api('/api/elements?name=' + encodeURIComponent(state.name), {
-      method: 'PUT',
+    setStatus('reset ' + (out.reset || []).length + ' screens');
+  } else {
+    if (!name) throw new Error('select a screen first');
+    if (!confirm('Reset ' + name + '? Keeps only blank.png.')) return;
+    await api('/api/reset', {
+      method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ elements: state.elements }),
+      body: JSON.stringify({ name }),
     });
-    setStatus('saved crops');
-  } catch (err) { setStatus(err.message, true); }
+    setStatus('reset ' + name);
+  }
+  document.getElementById('resetMenu').classList.remove('open');
+  await renderTree();
+  if (name) await loadScreen(name, { view: 'source' });
+}
+document.getElementById('resetOne').onclick = async () => {
+  try { await resetLocal({ all: false }); } catch (err) { setStatus(err.message, true); }
 };
+document.getElementById('resetMenuBtn').onclick = (e) => {
+  e.stopPropagation();
+  document.getElementById('resetMenu').classList.toggle('open');
+};
+document.getElementById('resetAll').onclick = async () => {
+  try { await resetLocal({ all: true }); } catch (err) { setStatus(err.message, true); }
+};
+document.addEventListener('click', (e) => {
+  if (!e.target.closest('.reset-wrap')) document.getElementById('resetMenu').classList.remove('open');
+});
+stage.addEventListener('click', (e) => {
+  if (view !== 'catalog') return;
+  if (e.target.closest('[data-key]')) return;
+  pinnedKey = '';
+  hoverKey = '';
+  renderPop();
+  markActive();
+});
+mainEl.addEventListener('scroll', () => {
+  if (view === 'catalog' && !popEl.hidden) renderPop();
+});
 
 loadSettings()
   .then(renderTree)
+  .then(() => setView('source'))
   .catch((err) => setStatus(err.message, true));
 </script>
 </body>

--- a/packages/tools/tm-v2/index.html
+++ b/packages/tools/tm-v2/index.html
@@ -1,0 +1,304 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>smart-vision TM v2</title>
+<style>
+  * { box-sizing: border-box; }
+  body { margin: 0; font: 13px/1.4 system-ui, sans-serif; background: #111; color: #eee; display: grid; grid-template-rows: auto 1fr; height: 100vh; }
+  header { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; padding: 10px 12px; background: #1b1b1b; border-bottom: 1px solid #333; }
+  header h1 { font-size: 14px; margin: 0 8px 0 0; white-space: nowrap; }
+  input[type=text], input[type=number], select, button { font: inherit; }
+  input[type=text], select { background: #222; color: #eee; border: 1px solid #444; padding: 6px 8px; border-radius: 4px; }
+  #gcs { width: min(520px, 40vw); }
+  button { background: #333; color: #eee; border: 1px solid #555; padding: 6px 10px; border-radius: 4px; cursor: pointer; }
+  button.primary { background: #3d6d3d; border-color: #5a9; }
+  button:hover { filter: brightness(1.12); }
+  #status { color: #8c8; flex: 1; min-width: 120px; }
+  #status.err { color: #f88; }
+  .layout { display: grid; grid-template-columns: 360px 1fr; min-height: 0; }
+  aside { overflow: auto; padding: 12px; border-right: 1px solid #333; background: #181818; }
+  main { overflow: auto; background: #000; }
+  .row { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 8px; }
+  .stage { position: relative; display: inline-block; }
+  .stage img { display: block; max-width: 100%; height: auto; }
+  .box, .el-box { position: absolute; pointer-events: none; }
+  .box { border: 2px solid #f44; }
+  .el-box { border: 2px solid #6af; background: rgba(80,160,255,.12); }
+  .el { border: 1px solid #333; padding: 8px; margin-bottom: 8px; border-radius: 4px; }
+  label { display: flex; justify-content: space-between; gap: 8px; margin: 4px 0; }
+  label input { width: 96px; background: #222; color: #eee; border: 1px solid #444; padding: 2px 4px; }
+  table { width: 100%; border-collapse: collapse; margin: 8px 0; }
+  td, th { text-align: left; padding: 3px 4px; border-bottom: 1px solid #2a2a2a; }
+  .muted { color: #888; }
+  .id { color: #f88; font-weight: 600; }
+</style>
+</head>
+<body>
+<header>
+  <h1>TM v2</h1>
+  <input id="gcs" type="text" spellcheck="false">
+  <button id="saveSettings" type="button">Save URI</button>
+  <button id="pullAll" type="button">Pull GCS</button>
+  <button id="pushAll" type="button">Push GCS</button>
+  <span id="status"></span>
+</header>
+<div class="layout">
+<aside>
+  <div class="row">
+    <select id="screen"></select>
+    <button id="pullOne" type="button">Pull</button>
+    <button id="pushOne" type="button">Push</button>
+  </div>
+  <div class="row">
+    <button id="detect" class="primary" type="button">Detect</button>
+    <button id="apply" class="primary" type="button">Apply</button>
+    <button id="saveEls" type="button">Save crops</button>
+  </div>
+  <label class="muted"><input type="checkbox" id="showDetected" checked> detected boxes</label>
+  <label class="muted"><input type="checkbox" id="showAnnotated"> annotated PNG</label>
+  <p class="muted" id="meta"></p>
+  <h3>Detected IDs</h3>
+  <table>
+    <thead><tr><th>id</th><th>name</th></tr></thead>
+    <tbody id="boxes"></tbody>
+  </table>
+  <h3>Applied crops</h3>
+  <div id="list"></div>
+</aside>
+<main>
+  <div class="stage" id="stage">
+    <img id="blank" alt="screen">
+    <div id="overlays"></div>
+  </div>
+</main>
+</div>
+<script>
+const statusEl = document.getElementById('status');
+const gcs = document.getElementById('gcs');
+const screenSel = document.getElementById('screen');
+const boxesBody = document.getElementById('boxes');
+const list = document.getElementById('list');
+const blank = document.getElementById('blank');
+const overlays = document.getElementById('overlays');
+const showDetected = document.getElementById('showDetected');
+const showAnnotated = document.getElementById('showAnnotated');
+const meta = document.getElementById('meta');
+let state = { name: '', elements: [], boxes: [], width: 0, height: 0, names: {} };
+
+function setStatus(msg, err) {
+  statusEl.textContent = msg;
+  statusEl.className = err ? 'err' : '';
+}
+
+async function api(path, opts) {
+  const res = await fetch(path, opts);
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(body.error || res.statusText);
+  return body;
+}
+
+function fillScreens(names, selected) {
+  const current = selected || screenSel.value;
+  screenSel.innerHTML = names.map((n) => '<option' + (n === current ? ' selected' : '') + '>' + n + '</option>').join('');
+}
+
+async function loadSettings() {
+  const s = await api('/api/settings');
+  gcs.value = s.gcsUri;
+  fillScreens(s.localScreens || [], screenSel.value);
+}
+
+async function refreshRemote() {
+  const remote = await api('/api/remote');
+  const local = (await api('/api/settings')).localScreens || [];
+  fillScreens([...new Set([...remote.screens, ...local])].sort(), screenSel.value);
+}
+
+async function loadScreen(name) {
+  if (!name) return;
+  const data = await api('/api/screen?name=' + encodeURIComponent(name));
+  state = {
+    name,
+    elements: data.elements || [],
+    boxes: data.boxes || [],
+    width: data.width || 0,
+    height: data.height || 0,
+    names: {},
+  };
+  for (const el of state.elements) {
+    for (const id of el.boxIds || []) state.names[id] = el.name;
+  }
+  if (data.firstPass && data.firstPass.elements) {
+    for (const el of data.firstPass.elements) {
+      for (const id of el.boxIds || []) state.names[id] = el.name;
+    }
+  }
+  meta.textContent = (data.width ? data.width + '×' + data.height : 'no detect yet') +
+    ' · ' + state.boxes.length + ' boxes · ' + state.elements.length + ' crops';
+  renderImage();
+  renderBoxes();
+  renderElements();
+}
+
+function renderImage() {
+  const src = showAnnotated.checked ? '/file/annotated' : '/file/blank';
+  blank.src = src + '?name=' + encodeURIComponent(state.name) + '&t=' + Date.now();
+}
+
+function renderBoxes() {
+  boxesBody.innerHTML = state.boxes.map((box) => {
+    const val = state.names[box.id] || '';
+    return '<tr><td class="id">' + box.id + '</td><td><input data-id="' + box.id + '" value="' + val + '" placeholder="name"></td></tr>';
+  }).join('');
+  paint();
+}
+
+function renderElements() {
+  list.innerHTML = state.elements.map((el) => {
+    return '<div class="el"><strong>' + el.name + '</strong>' +
+      '<label>x <input data-name="' + el.name + '" data-k="x" type="number" value="' + el.x + '"></label>' +
+      '<label>y <input data-name="' + el.name + '" data-k="y" type="number" value="' + el.y + '"></label>' +
+      '<label>w <input data-name="' + el.name + '" data-k="width" type="number" value="' + el.width + '"></label>' +
+      '<label>h <input data-name="' + el.name + '" data-k="height" type="number" value="' + el.height + '"></label></div>';
+  }).join('') || '<p class="muted">No index.json yet. Detect → name IDs → Apply.</p>';
+  paint();
+}
+
+function paint() {
+  const scaleX = blank.clientWidth / (blank.naturalWidth || state.width || 1);
+  const scaleY = blank.clientHeight / (blank.naturalHeight || state.height || 1);
+  let html = '';
+  if (showDetected.checked) {
+    for (const box of state.boxes) {
+      html += '<div class="box" style="left:' + (box.x * scaleX) + 'px;top:' + (box.y * scaleY) + 'px;width:' + (box.width * scaleX) + 'px;height:' + (box.height * scaleY) + 'px"></div>';
+    }
+  }
+  for (const el of state.elements) {
+    html += '<div class="el-box" style="left:' + (el.x * scaleX) + 'px;top:' + (el.y * scaleY) + 'px;width:' + (el.width * scaleX) + 'px;height:' + (el.height * scaleY) + 'px"></div>';
+  }
+  overlays.innerHTML = html;
+}
+
+function firstPassFromNames() {
+  const grouped = {};
+  for (const box of state.boxes) {
+    const n = (state.names[box.id] || '').trim();
+    if (!n) continue;
+    if (!grouped[n]) grouped[n] = [];
+    grouped[n].push(box.id);
+  }
+  const assigned = new Set();
+  const elements = Object.entries(grouped).map(([name, boxIds]) => {
+    boxIds.forEach((id) => assigned.add(id));
+    return { name, type: 'field', section: null, boxIds };
+  });
+  const unknowns = state.boxes
+    .filter((box) => !assigned.has(box.id))
+    .map((box) => 'box ' + box.id + ': unassigned');
+  return {
+    screen: { name: state.name, width: state.width, height: state.height },
+    notes: [],
+    unknowns,
+    sections: [],
+    elements,
+  };
+}
+
+blank.addEventListener('load', paint);
+window.addEventListener('resize', paint);
+showDetected.addEventListener('change', paint);
+showAnnotated.addEventListener('change', renderImage);
+screenSel.addEventListener('change', () => loadScreen(screenSel.value));
+
+boxesBody.addEventListener('input', (e) => {
+  const id = Number(e.target.dataset.id);
+  if (!id) return;
+  state.names[id] = e.target.value;
+});
+
+list.addEventListener('input', (e) => {
+  const el = state.elements.find((x) => x.name === e.target.dataset.name);
+  if (!el) return;
+  el[e.target.dataset.k] = Number(e.target.value);
+  paint();
+});
+
+document.getElementById('saveSettings').onclick = async () => {
+  try {
+    await api('/api/settings', { method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ gcsUri: gcs.value }) });
+    setStatus('saved URI');
+    await refreshRemote();
+  } catch (err) { setStatus(err.message, true); }
+};
+document.getElementById('pullAll').onclick = async () => {
+  try {
+    setStatus('pulling…');
+    const out = await api('/api/pull', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' });
+    fillScreens(out.localScreens);
+    setStatus('pulled ' + out.localScreens.length + ' local screens');
+    if (screenSel.value) await loadScreen(screenSel.value);
+  } catch (err) { setStatus(err.message, true); }
+};
+document.getElementById('pushAll').onclick = async () => {
+  try {
+    setStatus('pushing…');
+    await api('/api/push', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' });
+    setStatus('pushed cache → GCS');
+  } catch (err) { setStatus(err.message, true); }
+};
+document.getElementById('pullOne').onclick = async () => {
+  try {
+    setStatus('pulling ' + screenSel.value + '…');
+    await api('/api/pull', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ name: screenSel.value }) });
+    setStatus('pulled ' + screenSel.value);
+    await loadScreen(screenSel.value);
+  } catch (err) { setStatus(err.message, true); }
+};
+document.getElementById('pushOne').onclick = async () => {
+  try {
+    setStatus('pushing ' + screenSel.value + '…');
+    await api('/api/push', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ name: screenSel.value }) });
+    setStatus('pushed ' + screenSel.value);
+  } catch (err) { setStatus(err.message, true); }
+};
+document.getElementById('detect').onclick = async () => {
+  try {
+    setStatus('detecting…');
+    await api('/api/detect?name=' + encodeURIComponent(screenSel.value), { method: 'POST' });
+    setStatus('detected ' + screenSel.value);
+    await loadScreen(screenSel.value);
+  } catch (err) { setStatus(err.message, true); }
+};
+document.getElementById('apply').onclick = async () => {
+  try {
+    const pass = firstPassFromNames();
+    if (!pass.elements.length) throw new Error('name at least one box ID before apply');
+    await api('/api/first-pass?name=' + encodeURIComponent(state.name), {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(pass),
+    });
+    const out = await api('/api/apply?name=' + encodeURIComponent(state.name), { method: 'POST' });
+    setStatus('applied ' + out.elements.join(', '));
+    await loadScreen(state.name);
+  } catch (err) { setStatus(err.message, true); }
+};
+document.getElementById('saveEls').onclick = async () => {
+  try {
+    await api('/api/elements?name=' + encodeURIComponent(state.name), {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ elements: state.elements }),
+    });
+    setStatus('saved crops');
+  } catch (err) { setStatus(err.message, true); }
+};
+
+loadSettings()
+  .then(refreshRemote)
+  .then(() => { if (screenSel.value) return loadScreen(screenSel.value); })
+  .catch((err) => setStatus(err.message, true));
+</script>
+</body>
+</html>

--- a/packages/tools/tm-v2/server.mjs
+++ b/packages/tools/tm-v2/server.mjs
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+/**
+ * Template Manager v2 — GCS screens (QA Wolf team-storage).
+ * Uses `gcloud storage` (gcloud auth login). Does not replace the v1 manager.
+ *
+ *   pnpm tm:v2
+ *   open http://127.0.0.1:2021
+ */
+import http from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { PNG } from 'pngjs';
+import { configure } from '@rickcedwhat/playwright-smart-vision';
+import { applyScreen, detectScreen } from '@rickcedwhat/playwright-smart-vision/author';
+
+const TOOLS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const HTML_FILE = path.join(TOOLS_DIR, 'index.html');
+const HOME = path.join(os.homedir(), '.smart-vision');
+const SETTINGS_FILE = path.join(HOME, 'tm-v2.json');
+const CACHE_DIR = path.join(HOME, 'screens');
+const DEFAULT_GCS = 'gs://qawolf-prod-team-storage/clzn2wsor00hcda0ickzd3544/screens';
+const PORT = Number(process.env.PORT) || 2021;
+
+function normalizeGcs(raw) {
+  const uri = String(raw || '').trim().replace(/\/+$/, '');
+  if (!uri.startsWith('gs://')) {
+    throw new Error('GCS URI must start with gs://');
+  }
+  return uri;
+}
+
+function readSettings() {
+  try {
+    const raw = JSON.parse(fs.readFileSync(SETTINGS_FILE, 'utf8'));
+    return { gcsUri: normalizeGcs(raw.gcsUri || DEFAULT_GCS) };
+  } catch {
+    return { gcsUri: DEFAULT_GCS };
+  }
+}
+
+function writeSettings(next) {
+  fs.mkdirSync(HOME, { recursive: true });
+  fs.writeFileSync(SETTINGS_FILE, `${JSON.stringify(next, null, 2)}\n`);
+}
+
+function assertScreenName(name) {
+  if (!name || name.includes('..') || name.includes('/') || name.includes('\\')) {
+    throw new Error(`invalid screen name: ${JSON.stringify(name)}`);
+  }
+  return name;
+}
+
+function screenDir(name) {
+  return path.join(CACHE_DIR, assertScreenName(name));
+}
+
+function cropPng(pngBuffer, x, y, width, height) {
+  const png = PNG.sync.read(pngBuffer);
+  const sx = Math.max(0, Math.round(x));
+  const sy = Math.max(0, Math.round(y));
+  const sw = Math.max(1, Math.min(png.width - sx, Math.round(width)));
+  const sh = Math.max(1, Math.min(png.height - sy, Math.round(height)));
+  const out = new PNG({ width: sw, height: sh });
+  for (let row = 0; row < sh; row++) {
+    const src = ((sy + row) * png.width + sx) * 4;
+    out.data.set(png.data.subarray(src, src + sw * 4), row * sw * 4);
+  }
+  return PNG.sync.write(out);
+}
+
+function kebab(name) {
+  return name
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase();
+}
+
+function runGcloud(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('gcloud', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('error', () => {
+      reject(new Error('gcloud not found — install the Google Cloud SDK and run gcloud auth login'));
+    });
+    child.on('close', (code) => {
+      if (code !== 0) reject(new Error(stderr.trim() || stdout.trim() || `gcloud exited ${code}`));
+      else resolve(stdout);
+    });
+  });
+}
+
+function listRemoteScreens(gcsUri) {
+  return runGcloud(['storage', 'ls', `${gcsUri}/`]).then((stdout) => {
+    const prefix = `${gcsUri}/`;
+    const names = new Set();
+    for (const line of stdout.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith(prefix)) continue;
+      const rest = trimmed.slice(prefix.length).replace(/\/+$/, '');
+      if (!rest || rest.includes('/') || rest.endsWith(':')) continue;
+      if (!/^[a-zA-Z0-9._-]+$/.test(rest)) continue;
+      if (rest.includes('.')) continue;
+      names.add(rest);
+    }
+    return [...names].sort();
+  });
+}
+
+function listLocalScreens() {
+  if (!fs.existsSync(CACHE_DIR)) return [];
+  return fs
+    .readdirSync(CACHE_DIR)
+    .filter((name) => fs.existsSync(path.join(CACHE_DIR, name, 'blank.png')))
+    .sort();
+}
+
+async function rsync(src, dest, { deleteUnmatched = false } = {}) {
+  if (!src.startsWith('gs://')) fs.mkdirSync(src, { recursive: true });
+  if (!dest.startsWith('gs://')) fs.mkdirSync(dest, { recursive: true });
+  const args = ['storage', 'rsync', '-r'];
+  if (deleteUnmatched) args.push('--delete-unmatched-destination-objects');
+  args.push(src, dest);
+  await runGcloud(args);
+}
+
+async function ensureConfigured() {
+  fs.mkdirSync(CACHE_DIR, { recursive: true });
+  await configure({ storage: { root: CACHE_DIR } });
+}
+
+function send(res, status, body, type = 'application/json') {
+  const payload = typeof body === 'string' || Buffer.isBuffer(body) ? body : `${JSON.stringify(body)}\n`;
+  res.writeHead(status, { 'content-type': type });
+  res.end(payload);
+}
+
+function sendFile(res, file, type) {
+  if (!fs.existsSync(file)) {
+    send(res, 404, { error: 'not found' });
+    return;
+  }
+  send(res, 200, fs.readFileSync(file), type);
+}
+
+async function readBody(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+async function handle(req, res) {
+  const url = new URL(req.url || '/', 'http://127.0.0.1');
+  const name = url.searchParams.get('name') || '';
+
+  if (req.method === 'GET' && url.pathname === '/') {
+    sendFile(res, HTML_FILE, 'text/html; charset=utf-8');
+    return;
+  }
+
+  if (req.method === 'GET' && url.pathname === '/api/settings') {
+    send(res, 200, { ...readSettings(), cacheDir: CACHE_DIR, localScreens: listLocalScreens() });
+    return;
+  }
+
+  if (req.method === 'PUT' && url.pathname === '/api/settings') {
+    const body = JSON.parse(await readBody(req));
+    const settings = { gcsUri: normalizeGcs(body.gcsUri) };
+    writeSettings(settings);
+    send(res, 200, { ...settings, cacheDir: CACHE_DIR });
+    return;
+  }
+
+  if (req.method === 'GET' && url.pathname === '/api/remote') {
+    const names = await listRemoteScreens(readSettings().gcsUri);
+    send(res, 200, { screens: names });
+    return;
+  }
+
+  if (req.method === 'POST' && url.pathname === '/api/pull') {
+    const body = JSON.parse(await readBody(req) || '{}');
+    const gcsUri = readSettings().gcsUri;
+    const screen = body.name ? assertScreenName(body.name) : '';
+    if (screen) await rsync(`${gcsUri}/${screen}`, screenDir(screen));
+    else await rsync(gcsUri, CACHE_DIR);
+    send(res, 200, { ok: true, localScreens: listLocalScreens() });
+    return;
+  }
+
+  if (req.method === 'POST' && url.pathname === '/api/push') {
+    const body = JSON.parse(await readBody(req) || '{}');
+    const gcsUri = readSettings().gcsUri;
+    const screen = body.name ? assertScreenName(body.name) : '';
+    if (screen) {
+      await rsync(screenDir(screen), `${gcsUri}/${screen}`, { deleteUnmatched: true });
+    } else {
+      await rsync(CACHE_DIR, gcsUri);
+    }
+    send(res, 200, { ok: true });
+    return;
+  }
+
+  if (req.method === 'GET' && url.pathname === '/api/screen' && name) {
+    const dir = screenDir(name);
+    const indexPath = path.join(dir, 'index.json');
+    const boxesPath = path.join(dir, 'boxes.json');
+    const firstPassPath = path.join(dir, 'first-pass.json');
+    let width = 0;
+    let height = 0;
+    let elements = [];
+    let boxes = [];
+    let firstPass = null;
+    if (fs.existsSync(indexPath)) {
+      const index = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+      elements = index.elements || [];
+    }
+    if (fs.existsSync(boxesPath)) {
+      const file = JSON.parse(fs.readFileSync(boxesPath, 'utf8'));
+      boxes = file.boxes || [];
+      width = file.width || 0;
+      height = file.height || 0;
+    }
+    if (fs.existsSync(firstPassPath)) {
+      firstPass = JSON.parse(fs.readFileSync(firstPassPath, 'utf8'));
+    }
+    send(res, 200, {
+      name,
+      width,
+      height,
+      elements,
+      boxes,
+      firstPass,
+      hasBlank: fs.existsSync(path.join(dir, 'blank.png')),
+      hasAnnotated: fs.existsSync(path.join(dir, 'boxes-annotated.png')),
+    });
+    return;
+  }
+
+  if (req.method === 'POST' && url.pathname === '/api/detect' && name) {
+    await ensureConfigured();
+    const result = await detectScreen(assertScreenName(name));
+    send(res, 200, {
+      name,
+      width: result.width,
+      height: result.height,
+      boxes: result.boxes,
+    });
+    return;
+  }
+
+  if (req.method === 'PUT' && url.pathname === '/api/first-pass' && name) {
+    const dir = screenDir(name);
+    const firstPass = JSON.parse(await readBody(req));
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'first-pass.json'), `${JSON.stringify(firstPass, null, 2)}\n`);
+    send(res, 200, { saved: name });
+    return;
+  }
+
+  if (req.method === 'POST' && url.pathname === '/api/apply' && name) {
+    await ensureConfigured();
+    const firstPassPath = path.join(screenDir(name), 'first-pass.json');
+    if (!fs.existsSync(firstPassPath)) {
+      send(res, 400, { error: 'no first-pass.json — assign names first' });
+      return;
+    }
+    const result = applyScreen(assertScreenName(name));
+    send(res, 200, {
+      name,
+      elements: result.elements.map((el) => el.name),
+    });
+    return;
+  }
+
+  if (req.method === 'PUT' && url.pathname === '/api/elements' && name) {
+    const dir = screenDir(name);
+    const blankPath = path.join(dir, 'blank.png');
+    if (!fs.existsSync(blankPath)) {
+      send(res, 400, { error: 'no blank.png — pull this screen first' });
+      return;
+    }
+    const body = JSON.parse(await readBody(req));
+    const elements = body.elements || [];
+    const blank = fs.readFileSync(blankPath);
+    const tmplDir = path.join(dir, 'templates');
+    fs.mkdirSync(tmplDir, { recursive: true });
+    const written = [];
+    for (const el of elements) {
+      const filename = el.filename || `${kebab(el.name)}.png`;
+      fs.writeFileSync(path.join(tmplDir, filename), cropPng(blank, el.x, el.y, el.width, el.height));
+      written.push({ ...el, filename });
+    }
+    const indexPath = path.join(dir, 'index.json');
+    const prev = fs.existsSync(indexPath) ? JSON.parse(fs.readFileSync(indexPath, 'utf8')) : {};
+    fs.writeFileSync(
+      indexPath,
+      `${JSON.stringify({ name: prev.name || name, sections: prev.sections || [], elements: written }, null, 2)}\n`,
+    );
+    send(res, 200, { saved: name, count: written.length });
+    return;
+  }
+
+  if (req.method === 'GET' && url.pathname === '/file/blank' && name) {
+    sendFile(res, path.join(screenDir(name), 'blank.png'), 'image/png');
+    return;
+  }
+  if (req.method === 'GET' && url.pathname === '/file/annotated' && name) {
+    sendFile(res, path.join(screenDir(name), 'boxes-annotated.png'), 'image/png');
+    return;
+  }
+
+  send(res, 404, { error: 'not found' });
+}
+
+const server = http.createServer((req, res) => {
+  handle(req, res).catch((err) => {
+    send(res, 500, { error: err instanceof Error ? err.message : String(err) });
+  });
+});
+
+fs.mkdirSync(CACHE_DIR, { recursive: true });
+if (!fs.existsSync(SETTINGS_FILE)) writeSettings({ gcsUri: DEFAULT_GCS });
+
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`Template Manager v2: http://127.0.0.1:${PORT}`);
+  console.log(`Local cache: ${CACHE_DIR}`);
+  console.log(`GCS: ${readSettings().gcsUri}`);
+  console.log('v1 manager is unchanged (pnpm dev, port 2020)');
+});

--- a/packages/tools/tm-v2/server.mjs
+++ b/packages/tools/tm-v2/server.mjs
@@ -14,7 +14,7 @@ import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { PNG } from 'pngjs';
 import { configure } from '@rickcedwhat/playwright-smart-vision';
-import { applyScreen, detectScreen } from '@rickcedwhat/playwright-smart-vision/author';
+import { applyScreen, detectScreen, writeBoxes } from '@rickcedwhat/playwright-smart-vision/author';
 
 const TOOLS_DIR = path.dirname(fileURLToPath(import.meta.url));
 const HTML_FILE = path.join(TOOLS_DIR, 'index.html');
@@ -55,6 +55,20 @@ function assertScreenName(name) {
 
 function screenDir(name) {
   return path.join(CACHE_DIR, assertScreenName(name));
+}
+
+function safeCachePath(rel) {
+  const clean = String(rel || '')
+    .replace(/\\/g, '/')
+    .replace(/^\/+|\/+$/g, '');
+  const parts = clean.split('/');
+  if (!clean || parts.some((part) => !part || part === '.' || part === '..')) {
+    throw new Error('invalid path');
+  }
+  if (!parts.every((part) => /^[a-zA-Z0-9._-]+$/.test(part))) {
+    throw new Error('invalid path');
+  }
+  return path.join(CACHE_DIR, ...parts);
 }
 
 function cropPng(pngBuffer, x, y, width, height) {
@@ -165,6 +179,28 @@ async function ensureConfigured() {
   await configure({ storage: { root: CACHE_DIR } });
 }
 
+function resetScreenDir(name) {
+  const dir = screenDir(name);
+  if (!fs.existsSync(dir)) return false;
+  for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (ent.name === 'blank.png') continue;
+    fs.rmSync(path.join(dir, ent.name), { recursive: true, force: true });
+  }
+  return true;
+}
+
+function applyIfFirstPassNewer(name) {
+  const dir = screenDir(name);
+  const firstPassPath = path.join(dir, 'first-pass.json');
+  const indexPath = path.join(dir, 'index.json');
+  if (!fs.existsSync(firstPassPath)) return false;
+  if (fs.existsSync(indexPath) && fs.statSync(indexPath).mtimeMs >= fs.statSync(firstPassPath).mtimeMs) {
+    return false;
+  }
+  applyScreen(assertScreenName(name));
+  return true;
+}
+
 function send(res, status, body, type = 'application/json') {
   const payload = typeof body === 'string' || Buffer.isBuffer(body) ? body : `${JSON.stringify(body)}\n`;
   res.writeHead(status, { 'content-type': type });
@@ -190,7 +226,8 @@ async function handle(req, res) {
   const name = url.searchParams.get('name') || '';
 
   if (req.method === 'GET' && url.pathname === '/') {
-    sendFile(res, HTML_FILE, 'text/html; charset=utf-8');
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8', 'cache-control': 'no-store' });
+    res.end(fs.readFileSync(HTML_FILE));
     return;
   }
 
@@ -240,21 +277,27 @@ async function handle(req, res) {
 
   if (req.method === 'GET' && url.pathname === '/api/screen' && name) {
     const dir = screenDir(name);
+    await ensureConfigured();
+    const applied = applyIfFirstPassNewer(assertScreenName(name));
     const indexPath = path.join(dir, 'index.json');
     const boxesPath = path.join(dir, 'boxes.json');
     const firstPassPath = path.join(dir, 'first-pass.json');
     let width = 0;
     let height = 0;
     let elements = [];
+    let sections = [];
     let boxes = [];
+    let labels = [];
     let firstPass = null;
     if (fs.existsSync(indexPath)) {
       const index = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
       elements = index.elements || [];
+      sections = index.sections || [];
     }
     if (fs.existsSync(boxesPath)) {
       const file = JSON.parse(fs.readFileSync(boxesPath, 'utf8'));
       boxes = file.boxes || [];
+      labels = file.labels || [];
       width = file.width || 0;
       height = file.height || 0;
     }
@@ -266,10 +309,13 @@ async function handle(req, res) {
       width,
       height,
       elements,
+      sections,
       boxes,
+      labels,
       firstPass,
       hasBlank: fs.existsSync(path.join(dir, 'blank.png')),
       hasAnnotated: fs.existsSync(path.join(dir, 'boxes-annotated.png')),
+      applied,
     });
     return;
   }
@@ -282,6 +328,21 @@ async function handle(req, res) {
       width: result.width,
       height: result.height,
       boxes: result.boxes,
+      labels: result.labels,
+    });
+    return;
+  }
+
+  if (req.method === 'PUT' && url.pathname === '/api/boxes' && name) {
+    await ensureConfigured();
+    const body = JSON.parse(await readBody(req) || '{}');
+    const result = await writeBoxes(assertScreenName(name), body.boxes || []);
+    send(res, 200, {
+      name,
+      width: result.width,
+      height: result.height,
+      boxes: result.boxes,
+      labels: result.labels,
     });
     return;
   }
@@ -291,7 +352,26 @@ async function handle(req, res) {
     const firstPass = JSON.parse(await readBody(req));
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(path.join(dir, 'first-pass.json'), `${JSON.stringify(firstPass, null, 2)}\n`);
+    await ensureConfigured();
+    applyIfFirstPassNewer(assertScreenName(name));
     send(res, 200, { saved: name });
+    return;
+  }
+
+  if (req.method === 'POST' && url.pathname === '/api/reset') {
+    const body = JSON.parse(await readBody(req) || '{}');
+    if (body.all) {
+      const names = listLocalScreens();
+      for (const screen of names) resetScreenDir(screen);
+      send(res, 200, { ok: true, reset: names });
+      return;
+    }
+    const screen = assertScreenName(body.name || name);
+    if (!resetScreenDir(screen)) {
+      send(res, 404, { error: 'screen not in local cache' });
+      return;
+    }
+    send(res, 200, { ok: true, reset: [screen] });
     return;
   }
 
@@ -338,6 +418,24 @@ async function handle(req, res) {
     return;
   }
 
+  if (req.method === 'GET' && url.pathname === '/file') {
+    const rel = url.searchParams.get('path') || '';
+    const file = safeCachePath(rel);
+    const types = {
+      '.png': 'image/png',
+      '.jpg': 'image/jpeg',
+      '.jpeg': 'image/jpeg',
+      '.gif': 'image/gif',
+      '.webp': 'image/webp',
+    };
+    const type = types[path.extname(file).toLowerCase()];
+    if (!type) {
+      send(res, 400, { error: 'not an image' });
+      return;
+    }
+    sendFile(res, file, type);
+    return;
+  }
   if (req.method === 'GET' && url.pathname === '/file/blank' && name) {
     sendFile(res, path.join(screenDir(name), 'blank.png'), 'image/png');
     return;

--- a/packages/tools/tm-v2/server.mjs
+++ b/packages/tools/tm-v2/server.mjs
@@ -101,20 +101,46 @@ function runGcloud(args) {
 }
 
 function listRemoteScreens(gcsUri) {
-  return runGcloud(['storage', 'ls', `${gcsUri}/`]).then((stdout) => {
-    const prefix = `${gcsUri}/`;
-    const names = new Set();
-    for (const line of stdout.split('\n')) {
-      const trimmed = line.trim();
-      if (!trimmed.startsWith(prefix)) continue;
-      const rest = trimmed.slice(prefix.length).replace(/\/+$/, '');
-      if (!rest || rest.includes('/') || rest.endsWith(':')) continue;
-      if (!/^[a-zA-Z0-9._-]+$/.test(rest)) continue;
-      if (rest.includes('.')) continue;
-      names.add(rest);
-    }
-    return [...names].sort();
-  });
+  return listGcsPrefix(gcsUri, '').then((listing) => listing.dirs);
+}
+
+function parseLs(stdout, gcsPrefix) {
+  const prefix = `${gcsPrefix.replace(/\/+$/, '')}/`;
+  const dirs = new Set();
+  const files = new Set();
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('gs://') || trimmed.endsWith(':')) continue;
+    if (!trimmed.startsWith(prefix)) continue;
+    const rest = trimmed.slice(prefix.length);
+    if (!rest) continue;
+    const parts = rest.replace(/\/+$/, '').split('/').filter(Boolean);
+    if (parts.length !== 1) continue;
+    const name = parts[0];
+    if (!/^[a-zA-Z0-9._-]+$/.test(name)) continue;
+    if (trimmed.endsWith('/')) dirs.add(name);
+    else files.add(name);
+  }
+  return { dirs: [...dirs].sort(), files: [...files].sort() };
+}
+
+async function listGcsPrefix(gcsUri, relPath) {
+  const base = relPath ? `${gcsUri}/${relPath}` : gcsUri;
+  const stdout = await runGcloud(['storage', 'ls', `${base}/`]);
+  return parseLs(stdout, base);
+}
+
+function listLocalPrefix(relPath) {
+  const dir = relPath ? path.join(CACHE_DIR, ...relPath.split('/')) : CACHE_DIR;
+  if (!fs.existsSync(dir)) return { dirs: [], files: [] };
+  const dirs = [];
+  const files = [];
+  for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (ent.name.startsWith('.')) continue;
+    if (ent.isDirectory()) dirs.push(ent.name);
+    else files.push(ent.name);
+  }
+  return { dirs: dirs.sort(), files: files.sort() };
 }
 
 function listLocalScreens() {
@@ -197,16 +223,18 @@ async function handle(req, res) {
     return;
   }
 
-  if (req.method === 'POST' && url.pathname === '/api/push') {
-    const body = JSON.parse(await readBody(req) || '{}');
+  if (req.method === 'GET' && url.pathname === '/api/ls') {
+    const rel = (url.searchParams.get('path') || '').replace(/^\/+|\/+$/g, '');
+    if (rel.includes('..')) throw new Error('invalid path');
     const gcsUri = readSettings().gcsUri;
-    const screen = body.name ? assertScreenName(body.name) : '';
-    if (screen) {
-      await rsync(screenDir(screen), `${gcsUri}/${screen}`, { deleteUnmatched: true });
-    } else {
-      await rsync(CACHE_DIR, gcsUri);
-    }
-    send(res, 200, { ok: true });
+    const remote = await listGcsPrefix(gcsUri, rel);
+    const local = listLocalPrefix(rel);
+    send(res, 200, { path: rel, remote, local });
+    return;
+  }
+
+  if (req.method === 'POST' && url.pathname === '/api/push') {
+    send(res, 403, { error: 'GCS write is disabled in TM v2 for now' });
     return;
   }
 


### PR DESCRIPTION
## Summary
- Template Manager v2 (`pnpm tm:v2`, port 2021) authors against a local cache of GCS team-storage screens. GCS writes stay disabled.
- Detect emits control boxes **and** OCR caption labels. First-pass joins them with `boxIds` + `labelIds`; apply unions those rects into the match crop.
- A dropdown glued to a small value cell is a **section** (shared match region) with two elements, not `parts`. Runtime searches the element inside the matched section rectangle so tiny empty cells are not ambiguous.

## Test plan
- [ ] `pnpm tm:v2` — explorer lists screens; Source / Draft / Catalog pills work
- [ ] Detect on `customer-info` writes `boxes.json` with red boxes and gold labels; Draw/Erase still only edits boxes
- [ ] After writing `first-pass.json`, Reload applies (no Apply button); Catalog shows purple section frames around primary contact and warranty pairs
- [ ] `element('primaryContactField')` and `element('warrantyCode')` match inside their sections (no `.part()`)
- [ ] `pnpm --filter @rickcedwhat/playwright-smart-vision test:unit`


Made with [Cursor](https://cursor.com)