### PR TITLE
feat: unhover cursor before OCR capture (#46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,21 @@ Playwright Test fixture. Returns a `ScreenResult` bound to the current page.
 
 Same bound screen for QA Wolf flows (or any runner that is not `@playwright/test`). Requires `configure({ page, storage: { root } })`. Initializes OCR/OpenCV, loads the named screen from FUSE, and binds `ScreenResult`. Call `releaseOcrScreen()` when the flow finishes.
 
+### `configure({ unhoverBeforeCapture })`
+
+Before each live OCR screenshot (`waitFor`, `refresh`, locate), the library moves the mouse to `(8, 8)` so hover highlights do not break template matching. **Default: on.** Opt out globally or per screen:
+
+```ts
+await configure({
+  page,
+  storage: { root: process.env.TEAM_STORAGE_DIR + '/screens' },
+  unhoverBeforeCapture: false, // keep hover
+});
+
+// or one screen only:
+const service = await screen('service', { unhover: false });
+```
+
 ### `screen.element(name)` → `ScreenElement`
 
 Assertions mirror Playwright's locator API:

--- a/packages/core/src/configure.ts
+++ b/packages/core/src/configure.ts
@@ -12,6 +12,12 @@ interface GlobalConfig {
   storage?: StorageConfig;
   devtools?: boolean;
   page?: Page;
+  /**
+   * Move the mouse to a neutral corner before live OCR screenshots
+   * (`waitFor`, `refresh`, locate). Clears hover highlights that break
+   * template matching. Default: true.
+   */
+  unhoverBeforeCapture?: boolean;
 }
 
 let globalConfig: GlobalConfig = {};
@@ -20,12 +26,22 @@ export function getGlobalConfig(): GlobalConfig {
   return globalConfig;
 }
 
+/** Reset merged config (unit tests). */
+export function resetGlobalConfig(): void {
+  globalConfig = {};
+}
+
 /**
  * Configure storage root and optional devtools FAB.
  * Pass `page` to inject the FAB immediately (QA Wolf / non-fixture usage).
  * In fixture-based Playwright tests the FAB is injected automatically by the ocrScreen fixture.
  *
- * await configure({ storage: { root: process.env.TEAM_STORAGE_DIR + '/screens' }, devtools: true, page });
+ * await configure({
+ *   storage: { root: process.env.TEAM_STORAGE_DIR + '/screens' },
+ *   devtools: true,
+ *   page,
+ *   // unhoverBeforeCapture: false, // keep hover for a rare case
+ * });
  */
 export async function configure(config: GlobalConfig): Promise<void> {
   const { page, ...rest } = config;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export {
   screen,
 } from './screen.js';
 export type { BindOcrScreenOptions } from './screen.js';
+export { UNHOVER_POINT, unhoverBeforeCapture } from './unhover.js';
 
 export { defineScreen, screenAssetsDir } from './screen-config.js';
 export type { ScreenConfig } from './screen-config.js';

--- a/packages/core/src/screen-result.ts
+++ b/packages/core/src/screen-result.ts
@@ -4,6 +4,7 @@ import { ScreenElement, VISIBLE_CONFIDENCE, type MatchOptions, type WaitForOptio
 import type { Page } from '@playwright/test';
 import { ocrStep } from './ocr-step.js';
 import { hideOcrOverlay, overlayBoxesFromResult, showOcrOverlay } from './ocr-overlay.js';
+import { unhoverBeforeCapture } from './unhover.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -28,6 +29,8 @@ export type ScreenHost = {
   screen: ScreenConfig;
   shotDir: string;
   overlay?: boolean;
+  /** Override global unhoverBeforeCapture for this bind. */
+  unhover?: boolean;
 };
 
 async function extractComparison(
@@ -70,14 +73,20 @@ export class ScreenResult {
     extractor: ScreenExtractor,
     screen: ScreenConfig,
     shotDir: string,
-    options: { overlay?: boolean } = {},
+    options: { overlay?: boolean; unhover?: boolean } = {},
   ): ScreenResult {
     return new ScreenResult({
       elements: [],
       totalElements: 0,
       filledElements: 0,
       emptyElements: 0,
-    }, page, { extractor, screen, shotDir, ...(options.overlay !== undefined && { overlay: options.overlay }) });
+    }, page, {
+      extractor,
+      screen,
+      shotDir,
+      ...(options.overlay !== undefined && { overlay: options.overlay }),
+      ...(options.unhover !== undefined && { unhover: options.unhover }),
+    });
   }
 
   /**
@@ -277,6 +286,7 @@ export class ScreenResult {
   }
 
   private async captureLive(shot: string): Promise<void> {
+    await unhoverBeforeCapture(this.page!, this.host?.unhover);
     await this.page!.screenshot({ path: shot, timeout: 2_000 });
   }
 

--- a/packages/core/src/screen.ts
+++ b/packages/core/src/screen.ts
@@ -12,6 +12,11 @@ import { ensureCvReady } from './utils/vision.js';
 export interface BindOcrScreenOptions {
   shotDir?: string;
   overlay?: boolean;
+  /**
+   * Override `configure({ unhoverBeforeCapture })` for this screen.
+   * Default inherits global config (true when unset).
+   */
+  unhover?: boolean;
 }
 
 let sharedExtractor: FieldExtractor | null = null;
@@ -46,6 +51,7 @@ export function bindOcrScreen(
 ): ScreenResult {
   return ScreenResult.bind(page, extractor, config, shotDir, {
     ...(options.overlay !== undefined && { overlay: options.overlay }),
+    ...(options.unhover !== undefined && { unhover: options.unhover }),
   });
 }
 

--- a/packages/core/src/unhover.test.ts
+++ b/packages/core/src/unhover.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Page } from '@playwright/test';
+import { configure, resetGlobalConfig } from './configure.js';
+import { UNHOVER_POINT, unhoverBeforeCapture } from './unhover.js';
+
+function mockPage(move = vi.fn()) {
+  return { mouse: { move } } as unknown as Page;
+}
+
+describe('unhoverBeforeCapture', () => {
+  beforeEach(() => {
+    resetGlobalConfig();
+  });
+
+  it('moves to the neutral corner by default', async () => {
+    const move = vi.fn();
+    await unhoverBeforeCapture(mockPage(move));
+    expect(move).toHaveBeenCalledWith(UNHOVER_POINT.x, UNHOVER_POINT.y);
+  });
+
+  it('skips when configure({ unhoverBeforeCapture: false })', async () => {
+    await configure({ unhoverBeforeCapture: false });
+    const move = vi.fn();
+    await unhoverBeforeCapture(mockPage(move));
+    expect(move).not.toHaveBeenCalled();
+  });
+
+  it('per-call false overrides configure true', async () => {
+    await configure({ unhoverBeforeCapture: true });
+    const move = vi.fn();
+    await unhoverBeforeCapture(mockPage(move), false);
+    expect(move).not.toHaveBeenCalled();
+  });
+
+  it('per-call true overrides configure false', async () => {
+    await configure({ unhoverBeforeCapture: false });
+    const move = vi.fn();
+    await unhoverBeforeCapture(mockPage(move), true);
+    expect(move).toHaveBeenCalledWith(UNHOVER_POINT.x, UNHOVER_POINT.y);
+  });
+});

--- a/packages/core/src/unhover.ts
+++ b/packages/core/src/unhover.ts
@@ -1,0 +1,19 @@
+import type { Page } from '@playwright/test';
+import { getGlobalConfig } from './configure.js';
+
+/** Neutral corner used to clear hover/highlight before OCR screenshots. */
+export const UNHOVER_POINT = { x: 8, y: 8 } as const;
+
+/**
+ * Move the mouse off interactive content so template matching is not skewed by
+ * hover highlights. Enabled by default; pass `false` or
+ * `configure({ unhoverBeforeCapture: false })` to skip.
+ */
+export async function unhoverBeforeCapture(
+  page: Page,
+  override?: boolean,
+): Promise<void> {
+  const enabled = override ?? getGlobalConfig().unhoverBeforeCapture ?? true;
+  if (!enabled) return;
+  await page.mouse.move(UNHOVER_POINT.x, UNHOVER_POINT.y);
+}

--- a/packages/core/tests/screen.spec.ts
+++ b/packages/core/tests/screen.spec.ts
@@ -2,8 +2,25 @@ import { test, expect } from '@playwright/test';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import { configure } from '../src/configure.js';
 import { releaseOcrScreen, screen } from '../src/screen.js';
+
+const testsDir = path.dirname(fileURLToPath(import.meta.url));
+const loginBlank = path.join(testsDir, 'screens', 'html-login', 'blank.png');
+const loginUsername = path.join(testsDir, 'screens', 'html-login', 'templates', 'username.png');
+
+function writeMinimalScreen(root: string, name: string, element: string) {
+  const dir = path.join(root, name);
+  fs.mkdirSync(path.join(dir, 'templates'), { recursive: true });
+  fs.copyFileSync(loginBlank, path.join(dir, 'blank.png'));
+  fs.copyFileSync(loginUsername, path.join(dir, 'templates', `${element}.png`));
+  fs.writeFileSync(path.join(dir, 'index.json'), `${JSON.stringify({
+    name,
+    sections: [],
+    elements: [{ name: element, filename: `${element}.png`, type: 'icon' }],
+  })}\n`);
+}
 
 test.describe('screen()', () => {
   test('binds a named screen when configure({ page }) was called', async ({ page }) => {
@@ -21,6 +38,44 @@ test.describe('screen()', () => {
 
     const wolf01 = await screen('wolf01');
     expect(wolf01.element('service')).toBeTruthy();
+    await releaseOcrScreen();
+  });
+
+  test('waitFor moves the mouse to the unhover corner before screenshot', async ({ page }) => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-unhover-'));
+    writeMinimalScreen(tmp, 'desktop', 'kill');
+
+    const moves: Array<{ x: number; y: number }> = [];
+    const original = page.mouse.move.bind(page.mouse);
+    page.mouse.move = async (x: number, y: number, options?: Parameters<typeof page.mouse.move>[2]) => {
+      moves.push({ x, y });
+      return original(x, y, options);
+    };
+
+    await configure({ storage: { root: tmp }, page, unhoverBeforeCapture: true });
+    await page.goto('/');
+    const desktop = await screen('desktop');
+    await desktop.waitFor({ timeout: 1_500 }).catch(() => {});
+    expect(moves.some((m) => m.x === 8 && m.y === 8)).toBe(true);
+    await releaseOcrScreen();
+  });
+
+  test('unhover: false skips the mouse move', async ({ page }) => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-unhover-off-'));
+    writeMinimalScreen(tmp, 'desktop', 'kill');
+
+    const moves: Array<{ x: number; y: number }> = [];
+    const original = page.mouse.move.bind(page.mouse);
+    page.mouse.move = async (x: number, y: number, options?: Parameters<typeof page.mouse.move>[2]) => {
+      moves.push({ x, y });
+      return original(x, y, options);
+    };
+
+    await configure({ storage: { root: tmp }, page, unhoverBeforeCapture: false });
+    await page.goto('/');
+    const desktop = await screen('desktop');
+    await desktop.waitFor({ timeout: 1_500 }).catch(() => {});
+    expect(moves.some((m) => m.x === 8 && m.y === 8)).toBe(false);
     await releaseOcrScreen();
   });
 });

--- a/packages/tools/QAWOLF_AUTHOR.md
+++ b/packages/tools/QAWOLF_AUTHOR.md
@@ -188,6 +188,7 @@ await configure({
   page,
   storage: { root: process.env.TEAM_STORAGE_DIR + '/screens' },
 });
+// Live screenshots auto-unhover the cursor (opt out: unhoverBeforeCapture: false).
 const customerInfo = await screen('customer-info');
 await customerInfo.element('customerNumber').toHaveValue(expected);
 await releaseOcrScreen(); // optional at end of flow


### PR DESCRIPTION
## Summary
- Before each live OCR screenshot (`waitFor`, `refresh`, locate), move the mouse to `(8, 8)` so hover/highlight states (e.g. Autosoft Service menu) do not break template matching
- **Default on**; opt out with `configure({ unhoverBeforeCapture: false })` or `screen('service', { unhover: false })`
- Unit + Playwright tests cover default move and opt-out

Closes #46

## Test plan
- [x] `npm run typecheck`
- [x] `vitest run src/unhover.test.ts`
- [x] `npx playwright test tests/screen.spec.ts`
- [ ] Autosoft POC: drop manual `page.mouse.move(1, 1)` after Service click; confirm Customer Information still locates


Made with [Cursor](https://cursor.com)