### PR TITLE
feat(tm-v2): edit charset, swaps, and read in element popover

### DIFF
--- a/.cursor/skills/review-psv/SKILL.md
+++ b/.cursor/skills/review-psv/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: review-psv
+description: >-
+  Playwright Smart Vision review checklist. Use with Bugbot (/review-bugbot)
+  before marking a PSV PR ready, or when reviewing PSV diffs for OCR, TM, FUSE,
+  clipboard, or authoring issues.
+---
+
+# Review PSV (playwright-smart-vision)
+
+After implementing or before opening/merging a PR in this repo:
+
+1. Run typecheck + relevant unit/e2e tests.
+2. Run `/review-bugbot` on **branch changes** (default).
+3. Run `/review-security` if the diff touches auth, storage, clipboard, GCS, network, or dependencies.
+4. Fix clear Bugbot findings; leave intentional trade-offs noted in the PR.
+
+## Domain checklist (pass Custom Instructions to Bugbot when useful)
+
+- No `dist/` or deep imports in QA Wolf / public API examples — package root or documented subpaths only.
+- `configure({ page, storage })` + `screen(name)` for flows; `ocrScreen` fixture for Playwright Test.
+- Live capture path: unhover default (`unhoverBeforeCapture`) unless intentionally opted out.
+- Authoring: `applyScreen` must preserve or round-trip `charset`, `swaps`, `read`, `overflow` — do not wipe TM-authored options on re-apply.
+- FUSE/runtime layout: `{root}/{screen}/blank.png`, `index.json`, `templates/`; push must not delete remote objects.
+- Clipboard `read: "clipboard"` needs page + clipboard permissions; document Guacamole caveats.
+- Errors should distinguish “not located” vs “OCR empty string” when possible.
+- TM v2 lives at `/template-manager` on the hub (port 2020), not a separate 2021 server.
+
+## Bugbot prompt addition
+
+When launching Bugbot for this repo, prefer Custom Instructions:
+
+```text
+Apply the review-psv skill checklist. Focus on regressions in OCR/read options persistence, screen() API, and TM v2 authoring.
+```

--- a/packages/core/src/author/apply.ts
+++ b/packages/core/src/author/apply.ts
@@ -26,6 +26,10 @@ export interface FirstPassPart {
   /** Optional 0–1 span of the parent field union when boxId is omitted. */
   start?: number;
   end?: number;
+  charset?: string;
+  swaps?: Record<string, string | string[]>;
+  overflow?: string;
+  read?: string;
 }
 
 export interface FirstPassElement {
@@ -37,6 +41,10 @@ export interface FirstPassElement {
   labelIds?: number[];
   parts?: FirstPassPart[];
   charset?: string;
+  swaps?: Record<string, string | string[]>;
+  overflow?: string;
+  /** How to read the value: `ocr` (default) or `clipboard`. */
+  read?: string;
   options?: string[];
   /** If true and labelIds is empty, grow the crop left (legacy). Default is box-only. */
   includeLabel?: boolean;
@@ -75,10 +83,23 @@ export interface AppliedElement {
   boxIds?: number[];
   labelIds?: number[];
   charset?: string;
+  swaps?: Record<string, string | string[]>;
+  overflow?: string;
+  read?: string;
   options?: string[];
   section?: string;
   ocrRect?: { x: number; y: number; width: number; height: number };
-  parts?: Array<{ name: string; x: number; y: number; width: number; height: number }>;
+  parts?: Array<{
+    name: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    charset?: string;
+    swaps?: Record<string, string | string[]>;
+    overflow?: string;
+    read?: string;
+  }>;
 }
 
 export interface ApplyScreenResult {
@@ -168,7 +189,8 @@ function resolveParts(
   crop: { x: number; y: number; width: number; height: number },
   byId: Map<number, DetectedBox>,
   png?: { width: number; height: number; data: Buffer | Uint8Array },
-): Array<{ name: string; x: number; y: number; width: number; height: number }> {
+  prevParts?: AppliedElement['parts'],
+): NonNullable<AppliedElement['parts']> {
   if (!specs.length || !fieldBoxes.length) return [];
   const union = unionRects(fieldBoxes);
   const namesOnly = specs.every((part) => part.boxId == null);
@@ -180,7 +202,8 @@ function resolveParts(
   const even = namesOnly && !cells.length
     ? evenHorizontalSlices(insetRect(union, 2), specs.length)
     : [];
-  const out: Array<{ name: string; x: number; y: number; width: number; height: number }> = [];
+  const prevByName = new Map((prevParts || []).map((part) => [part.name, part]));
+  const out: NonNullable<AppliedElement['parts']> = [];
   for (let i = 0; i < specs.length; i++) {
     const part = specs[i]!;
     let rect;
@@ -197,9 +220,37 @@ function resolveParts(
     } else {
       continue;
     }
-    out.push({ name: part.name, ...relativeToCrop(rect, crop) });
+    const prev = prevByName.get(part.name);
+    const row: NonNullable<AppliedElement['parts']>[number] = {
+      name: part.name,
+      ...relativeToCrop(rect, crop),
+    };
+    const charset = part.charset ?? prev?.charset;
+    const swaps = part.swaps ?? prev?.swaps;
+    const overflow = part.overflow ?? prev?.overflow;
+    const read = part.read ?? prev?.read;
+    if (charset) row.charset = charset;
+    if (swaps) row.swaps = swaps;
+    if (overflow) row.overflow = overflow;
+    if (read) row.read = read;
+    out.push(row);
   }
   return out;
+}
+
+function readPreviousIndex(dir: string): Map<string, AppliedElement> {
+  const indexPath = path.join(dir, 'index.json');
+  if (!fs.existsSync(indexPath)) return new Map();
+  try {
+    const raw = JSON.parse(fs.readFileSync(indexPath, 'utf8')) as { elements?: AppliedElement[] };
+    return new Map((raw.elements || []).map((el) => [el.name, el]));
+  } catch {
+    return new Map();
+  }
+}
+
+function pickOption<T>(next: T | undefined, prev: T | undefined): T | undefined {
+  return next !== undefined ? next : prev;
 }
 
 /**
@@ -230,6 +281,7 @@ export function applyScreen(name: string, firstPass?: FirstPass): ApplyScreenRes
   const { boxes } = boxesFile;
   const labels = boxesFile.labels || [];
   const pass = JSON.parse(fs.readFileSync(firstPassPath, 'utf8')) as FirstPass;
+  const previous = readPreviousIndex(dir);
   const byId = new Map(boxes.map((box) => [box.id, box]));
   const byLabel = new Map(labels.map((label) => [label.id, label]));
   const tmplDir = path.join(dir, 'templates');
@@ -264,7 +316,8 @@ export function applyScreen(name: string, firstPass?: FirstPass): ApplyScreenRes
     if (!match) continue;
     const filename = `${kebab(el.name)}.png`;
     fs.writeFileSync(path.join(tmplDir, filename), cropPng(blank, match.x, match.y, match.width, match.height));
-    const parts = resolveParts(el.parts || [], fieldBoxes, match, byId, png);
+    const prev = previous.get(el.name);
+    const parts = resolveParts(el.parts || [], fieldBoxes, match, byId, png, prev?.parts);
     const shown = overlay || match;
 
     const applied: AppliedElement = {
@@ -278,7 +331,14 @@ export function applyScreen(name: string, firstPass?: FirstPass): ApplyScreenRes
     };
     if (el.boxIds?.length) applied.boxIds = el.boxIds;
     if (el.labelIds?.length) applied.labelIds = el.labelIds;
-    if (el.charset) applied.charset = el.charset;
+    const charset = pickOption(el.charset, prev?.charset);
+    const swaps = pickOption(el.swaps, prev?.swaps);
+    const overflow = pickOption(el.overflow, prev?.overflow);
+    const read = pickOption(el.read, prev?.read);
+    if (charset) applied.charset = charset;
+    if (swaps) applied.swaps = swaps;
+    if (overflow) applied.overflow = overflow;
+    if (read) applied.read = read;
     if (el.options?.length) applied.options = el.options;
     if (el.section) applied.section = sectionFile.get(el.section) || el.section;
     if (fieldBoxes.length) applied.ocrRect = ocrRectFromBoxes(match, fieldBoxes, el.type || 'field');

--- a/packages/core/src/author/author.test.ts
+++ b/packages/core/src/author/author.test.ts
@@ -141,6 +141,79 @@ describe('author apply + catalog', () => {
     expect(result.elements[0]!.x + result.elements[0]!.width).toBeGreaterThan(590 + 204);
   });
 
+  it('applyScreen writes swaps/read and preserves them across re-apply', () => {
+    applyScreen(name, {
+      screen: { name },
+      elements: [
+        {
+          name: 'username',
+          type: 'field',
+          boxIds: [1],
+          charset: 'alnum',
+          read: 'clipboard',
+          swaps: { '@': ['Q'] },
+          overflow: 'end',
+        },
+        { name: 'password', type: 'field', boxIds: [2] },
+      ],
+    });
+    const first = JSON.parse(fs.readFileSync(path.join(dir, 'index.json'), 'utf8'));
+    expect(first.elements[0]).toMatchObject({
+      name: 'username',
+      charset: 'alnum',
+      read: 'clipboard',
+      swaps: { '@': ['Q'] },
+      overflow: 'end',
+    });
+
+    // Re-apply without options on first-pass — prior index options must stick.
+    applyScreen(name, {
+      screen: { name },
+      elements: [
+        { name: 'username', type: 'field', boxIds: [1] },
+        { name: 'password', type: 'field', boxIds: [2] },
+      ],
+    });
+    const second = JSON.parse(fs.readFileSync(path.join(dir, 'index.json'), 'utf8'));
+    expect(second.elements[0]).toMatchObject({
+      charset: 'alnum',
+      read: 'clipboard',
+      swaps: { '@': ['Q'] },
+      overflow: 'end',
+    });
+    const loaded = loadScreen(name).elementConfigs.find((el) => el.name === 'username');
+    expect(loaded?.read).toBe('clipboard');
+    expect(loaded?.swaps).toEqual({ '@': ['Q'] });
+  });
+
+  it('patchElementOptions updates first-pass and index without wiping crops', async () => {
+    const { patchElementOptions } = await import('./options.js');
+    applyScreen(name, {
+      screen: { name },
+      elements: [
+        { name: 'username', type: 'field', boxIds: [1] },
+        { name: 'password', type: 'field', boxIds: [2] },
+      ],
+    });
+    const before = JSON.parse(fs.readFileSync(path.join(dir, 'index.json'), 'utf8'));
+    const result = patchElementOptions(name, 'username', {
+      charset: 'email',
+      read: 'clipboard',
+      swaps: { '@': ['C', 'Q'] },
+    });
+    expect(result.index).toMatchObject({ charset: 'email', read: 'clipboard' });
+    const after = JSON.parse(fs.readFileSync(path.join(dir, 'index.json'), 'utf8'));
+    expect(after.elements[0].filename).toBe(before.elements[0].filename);
+    expect(after.elements[0].x).toBe(before.elements[0].x);
+    const fp = JSON.parse(fs.readFileSync(path.join(dir, 'first-pass.json'), 'utf8'));
+    expect(fp.elements[0]).toMatchObject({
+      name: 'username',
+      charset: 'email',
+      read: 'clipboard',
+      swaps: { '@': ['C', 'Q'] },
+    });
+  });
+
   it('writeScreenCatalog emits typed screen/element names', () => {
     applyScreen(name, {
       screen: { name },

--- a/packages/core/src/author/index.ts
+++ b/packages/core/src/author/index.ts
@@ -4,6 +4,9 @@ export type { DetectScreenResult, BoxesFile } from './detect.js';
 export { applyScreen } from './apply.js';
 export type { FirstPass, FirstPassElement, FirstPassPart, FirstPassSection, ApplyScreenResult, AppliedElement, AppliedSection } from './apply.js';
 
+export { patchElementOptions, patchPartOptions } from './options.js';
+export type { ElementOptionsPatch } from './options.js';
+
 export { writeScreenCatalog, readScreenCatalog, screenCatalogSource, screenCatalogPath } from './catalog.js';
 export type { ScreenCatalog } from './catalog.js';
 

--- a/packages/core/src/author/options.ts
+++ b/packages/core/src/author/options.ts
@@ -1,0 +1,148 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { AppliedElement, FirstPass, FirstPassElement, FirstPassPart } from './apply.js';
+import { writeScreenCatalog } from './catalog.js';
+import { screenDir } from './storage.js';
+
+export interface ElementOptionsPatch {
+  charset?: string | null;
+  swaps?: Record<string, string | string[]> | null;
+  overflow?: string | null;
+  read?: string | null;
+}
+
+function normalizeSwaps(
+  swaps: Record<string, string | string[]> | null | undefined,
+): Record<string, string[]> | undefined {
+  if (swaps == null) return undefined;
+  const out: Record<string, string[]> = {};
+  for (const [from, to] of Object.entries(swaps)) {
+    const key = String(from);
+    if (!key) continue;
+    const list = (typeof to === 'string' ? [to] : [...to])
+      .map((item) => String(item))
+      .filter(Boolean);
+    if (list.length) out[key] = list;
+  }
+  return Object.keys(out).length ? out : undefined;
+}
+
+function applyPatchToRecord(
+  target: Record<string, unknown>,
+  patch: ElementOptionsPatch,
+): void {
+  if ('charset' in patch) {
+    if (patch.charset == null || patch.charset === '' || patch.charset === 'auto') {
+      delete target.charset;
+    } else {
+      target.charset = patch.charset;
+    }
+  }
+  if ('read' in patch) {
+    if (patch.read == null || patch.read === '' || patch.read === 'ocr') {
+      delete target.read;
+    } else {
+      target.read = patch.read;
+    }
+  }
+  if ('overflow' in patch) {
+    if (patch.overflow == null || patch.overflow === '') {
+      delete target.overflow;
+    } else {
+      target.overflow = patch.overflow;
+    }
+  }
+  if ('swaps' in patch) {
+    const swaps = normalizeSwaps(patch.swaps);
+    if (!swaps) delete target.swaps;
+    else target.swaps = swaps;
+  }
+}
+
+/**
+ * Update charset / swaps / read / overflow on one element without re-cropping templates.
+ * Writes both first-pass.json (survives AI re-apply merge) and index.json (runtime).
+ */
+export function patchElementOptions(
+  screenName: string,
+  elementName: string,
+  patch: ElementOptionsPatch,
+): { firstPass: FirstPassElement; index: AppliedElement } {
+  const dir = screenDir(screenName);
+  const firstPassPath = path.join(dir, 'first-pass.json');
+  const indexPath = path.join(dir, 'index.json');
+  if (!fs.existsSync(firstPassPath)) {
+    throw new Error(`patchElementOptions('${screenName}'): no first-pass.json`);
+  }
+  if (!fs.existsSync(indexPath)) {
+    throw new Error(`patchElementOptions('${screenName}'): no index.json — apply the screen first`);
+  }
+
+  const firstPass = JSON.parse(fs.readFileSync(firstPassPath, 'utf8')) as FirstPass;
+  const fpEl = (firstPass.elements || []).find((el) => el.name === elementName);
+  if (!fpEl) {
+    throw new Error(`patchElementOptions('${screenName}'): element "${elementName}" not in first-pass.json`);
+  }
+  applyPatchToRecord(fpEl as unknown as Record<string, unknown>, patch);
+  fs.writeFileSync(firstPassPath, `${JSON.stringify(firstPass, null, 2)}\n`);
+
+  const index = JSON.parse(fs.readFileSync(indexPath, 'utf8')) as {
+    name?: string;
+    sections?: unknown[];
+    elements: AppliedElement[];
+  };
+  const idxEl = (index.elements || []).find((el) => el.name === elementName);
+  if (!idxEl) {
+    throw new Error(`patchElementOptions('${screenName}'): element "${elementName}" not in index.json`);
+  }
+  applyPatchToRecord(idxEl as unknown as Record<string, unknown>, patch);
+  fs.writeFileSync(indexPath, `${JSON.stringify(index, null, 2)}\n`);
+  writeScreenCatalog();
+
+  return { firstPass: fpEl, index: idxEl };
+}
+
+/**
+ * Patch options on one named part of an element.
+ */
+export function patchPartOptions(
+  screenName: string,
+  elementName: string,
+  partName: string,
+  patch: ElementOptionsPatch,
+): { firstPass: FirstPassPart; index: NonNullable<AppliedElement['parts']>[number] } {
+  const dir = screenDir(screenName);
+  const firstPassPath = path.join(dir, 'first-pass.json');
+  const indexPath = path.join(dir, 'index.json');
+  if (!fs.existsSync(firstPassPath) || !fs.existsSync(indexPath)) {
+    throw new Error(`patchPartOptions('${screenName}'): need first-pass.json and index.json`);
+  }
+
+  const firstPass = JSON.parse(fs.readFileSync(firstPassPath, 'utf8')) as FirstPass;
+  const fpEl = (firstPass.elements || []).find((el) => el.name === elementName);
+  if (!fpEl) throw new Error(`element "${elementName}" not in first-pass.json`);
+  if (!fpEl.parts) fpEl.parts = [];
+  let fpPart = fpEl.parts.find((part) => part.name === partName);
+  if (!fpPart) {
+    fpPart = { name: partName };
+    fpEl.parts.push(fpPart);
+  }
+  applyPatchToRecord(fpPart as unknown as Record<string, unknown>, patch);
+  fs.writeFileSync(firstPassPath, `${JSON.stringify(firstPass, null, 2)}\n`);
+
+  const index = JSON.parse(fs.readFileSync(indexPath, 'utf8')) as {
+    elements: AppliedElement[];
+  };
+  const idxEl = (index.elements || []).find((el) => el.name === elementName);
+  if (!idxEl) throw new Error(`element "${elementName}" not in index.json`);
+  if (!idxEl.parts) idxEl.parts = [];
+  let idxPart = idxEl.parts.find((part) => part.name === partName);
+  if (!idxPart) {
+    throw new Error(`part "${partName}" not in index.json for "${elementName}" — re-apply first`);
+  }
+  applyPatchToRecord(idxPart as unknown as Record<string, unknown>, patch);
+  fs.writeFileSync(indexPath, `${JSON.stringify(index, null, 2)}\n`);
+  writeScreenCatalog();
+
+  return { firstPass: fpPart, index: idxPart };
+}

--- a/packages/core/src/configure.ts
+++ b/packages/core/src/configure.ts
@@ -82,11 +82,22 @@ interface StorageElement {
   section?: string;
   type?: string;
   ocrRect?: { x: number; y: number; width: number; height: number };
-  parts?: Array<{ name?: string; x: number; y: number; width: number; height: number; charset?: string }>;
+  parts?: Array<{
+    name?: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    charset?: string;
+    swaps?: Record<string, string[]>;
+    overflow?: string;
+    read?: string;
+  }>;
   charset?: string;
   options?: string[];
   overflow?: string;
   swaps?: Record<string, string[]>;
+  read?: string;
   variants?: Record<string, { filename: string }>;
   animated?: boolean;
 }
@@ -129,15 +140,22 @@ export function loadScreen(name: string): ScreenConfig {
     if (el.options?.length) cfg.options = el.options;
     if (el.overflow) cfg.overflow = el.overflow as ElementConfig['overflow'];
     if (el.swaps) cfg.swaps = el.swaps;
+    if (el.read) cfg.read = el.read as ElementConfig['read'];
     if (el.parts?.length) {
-      cfg.parts = el.parts.map((p): FieldPart => ({
-        name: p.name ?? '',
-        x: p.x,
-        y: p.y,
-        width: p.width,
-        height: p.height,
-        charset: p.charset,
-      }));
+      cfg.parts = el.parts.map((p): FieldPart => {
+        const part: FieldPart = {
+          name: p.name ?? '',
+          x: p.x,
+          y: p.y,
+          width: p.width,
+          height: p.height,
+        };
+        if (p.charset) part.charset = p.charset;
+        if (p.swaps) part.swaps = p.swaps;
+        if (p.overflow) part.overflow = p.overflow as FieldPart['overflow'];
+        if (p.read) part.read = p.read as FieldPart['read'];
+        return part;
+      });
     }
     if (el.variants) {
       cfg.variants = Object.fromEntries(

--- a/packages/tools/QAWOLF_AUTHOR.md
+++ b/packages/tools/QAWOLF_AUTHOR.md
@@ -140,8 +140,22 @@ await author.applyScreen('customer-info', {
 | `elements[].boxIds` | `number[]` | **only ids from `detected.boxes`**. One or more boxes. |
 | `elements[].labelIds` | `number[]` | **only ids from `detected.labels`**. Caption may be left, top, right, or below. Omit for buttons whose text is inside the box. |
 | `elements[].parts` | optional | Same-kind cells of one control only (`{ name, boxId }[]`: dates, name row, phones). Never for a dropdown+field pair. Names-only parts only if Detect still merged the cells into one box. |
+| `elements[].charset` | optional | OCR charset: `text` \| `digits` \| `alnum` \| `email` \| `vin`. Omit / `auto` = infer from field name. Prefer setting in TM v2 popover after apply. |
+| `elements[].swaps` | optional | OCR correction map, e.g. `{ "5": ["S"], "@": ["Q","C"] }`. Survives re-apply by element name. |
+| `elements[].read` | optional | `clipboard` for select-all + copy (needs clipboard permissions). Default is OCR. |
+| `elements[].overflow` | optional | e.g. `end` when the field crops trailing garbage after a known prefix. |
 
 Rules: assign, do not draw. Skip chrome (taskbar, desktop icons, window title). Do not invent coordinates. Do not grow left by default. Do not use `as` or `as const` in authored files.
+
+### OCR options in Template Manager (after apply)
+
+Open hub **Template Manager** (`/template-manager` on port 2020). In catalog view, click an element:
+
+- **Charset / Read / Overflow / Swaps** — form controls in the inspect popover. **Save options** writes both `first-pass.json` and `index.json` (no re-crop).
+- Re-running `applyScreen` **merges** prior charset/swaps/read/overflow by element (and part) name, so AI renames that omit those fields do not wipe TM tweaks.
+- Prefer the popover over hand-editing JSON. Raw element JSON stays under **Advanced / JSON**.
+
+`loadScreen` / `screen(name)` honor `read`, `swaps`, and charset from FUSE `index.json`. Clipboard read still needs `clipboard-read` / `clipboard-write` (and Guacamole may not expose a real clipboard).
 
 5. **Catalog** — `applyScreen` writes `{TEAM_STORAGE_DIR}/screens/generated.ts` (every applied screen, not just the one you named). After the flow, **copy that file** to `src/helpers/screens.generated.ts` in the repo with your file-write tool (overwrite the whole file). Do not invent names, do not merge by hand, do not call `writeScreenCatalog`, and do not mkdir `/app/generatedProgram`. No `as` / `as const`.
 

--- a/packages/tools/tm-v2/handler.mjs
+++ b/packages/tools/tm-v2/handler.mjs
@@ -9,7 +9,7 @@ import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { PNG } from 'pngjs';
 import { configure } from '@rickcedwhat/playwright-smart-vision';
-import { applyScreen, detectScreen, writeBoxes, writeScreenCatalog } from '@rickcedwhat/playwright-smart-vision/author';
+import { applyScreen, detectScreen, writeBoxes, writeScreenCatalog, patchElementOptions, patchPartOptions } from '@rickcedwhat/playwright-smart-vision/author';
 
 export const TM_V2_BASE = '/template-manager';
 
@@ -471,6 +471,30 @@ async function handleInternal(req, res, url) {
       boxes: result.boxes,
       labels: result.labels,
     });
+    return;
+  }
+
+  if (req.method === 'PUT' && url.pathname === '/api/element-options' && name) {
+    await ensureConfigured();
+    const body = JSON.parse(await readBody(req) || '{}');
+    const element = String(body.element || '');
+    if (!element) {
+      send(res, 400, { error: 'body.element is required' });
+      return;
+    }
+    const patch = {
+      ...('charset' in body && { charset: body.charset }),
+      ...('swaps' in body && { swaps: body.swaps }),
+      ...('overflow' in body && { overflow: body.overflow }),
+      ...('read' in body && { read: body.read }),
+    };
+    if (body.part) {
+      const result = patchPartOptions(assertScreenName(name), element, String(body.part), patch);
+      send(res, 200, { name, element, part: body.part, firstPass: result.firstPass, index: result.index });
+      return;
+    }
+    const result = patchElementOptions(assertScreenName(name), element, patch);
+    send(res, 200, { name, element, firstPass: result.firstPass, index: result.index });
     return;
   }
 

--- a/packages/tools/tm-v2/index.html
+++ b/packages/tools/tm-v2/index.html
@@ -29,7 +29,7 @@
   .reset-menu { position: absolute; right: 0; top: 100%; margin-top: 4px; background: #222; border: 1px solid #555; border-radius: 4px; min-width: 180px; display: none; z-index: 30; }
   .reset-menu.open { display: block; }
   .reset-menu button { display: block; width: 100%; text-align: left; background: none; border: none; border-radius: 0; }
-  #pop { position: absolute; z-index: 8; width: min(320px, 90vw); background: #1c1c1c; border: 1px solid #444; border-radius: 8px; padding: 10px; box-shadow: 0 8px 24px #000a; pointer-events: auto; }
+  #pop { position: absolute; z-index: 8; width: min(360px, 90vw); background: #1c1c1c; border: 1px solid #444; border-radius: 8px; padding: 10px; box-shadow: 0 8px 24px #000a; pointer-events: auto; }
   #pop[hidden] { display: none; }
   #pop canvas { display: block; max-width: 100%; height: auto; background: #000; border: 1px solid #333; image-rendering: pixelated; }
   #popJson { margin: 8px 0 0; max-height: 140px; overflow: auto; padding: 8px; background: #111; border: 1px solid #2a2a2a; border-radius: 4px; font: 11px/1.35 ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre; color: #ddd; }
@@ -106,6 +106,15 @@
   #pop dl { margin: 8px 0 0; display: grid; grid-template-columns: 52px 1fr; gap: 4px 8px; }
   #pop dt { color: #888; }
   #pop dd { margin: 0; word-break: break-word; }
+  #popOpts { margin-top: 10px; display: grid; gap: 8px; }
+  #popOpts label { display: flex; flex-direction: column; gap: 3px; color: #aaa; font-size: 11px; }
+  #popOpts select, #popOpts input { font: inherit; background: #222; color: #eee; border: 1px solid #444; padding: 5px 7px; border-radius: 4px; }
+  #popSwaps { display: flex; flex-direction: column; gap: 4px; }
+  .swap-row { display: grid; grid-template-columns: 48px 1fr auto; gap: 4px; align-items: center; }
+  .swap-row input { min-width: 0; }
+  #popOpts .row-actions { display: flex; gap: 6px; flex-wrap: wrap; }
+  #popOpts details { margin-top: 4px; }
+  #popOpts summary { cursor: pointer; color: #888; font-size: 11px; }
   .muted { color: #888; }
 </style>
 </head>
@@ -165,7 +174,35 @@
       <dt>section</dt><dd id="popSection"></dd>
       <dt>parts</dt><dd id="popPartNames"></dd>
     </dl>
-    <pre id="popJson"></pre>
+    <div id="popOpts">
+      <label>Charset
+        <select id="popCharset"></select>
+      </label>
+      <label>Read
+        <select id="popRead">
+          <option value="ocr">ocr (Tesseract)</option>
+          <option value="clipboard">clipboard (select-all + copy)</option>
+        </select>
+      </label>
+      <label>Overflow
+        <select id="popOverflow">
+          <option value="">none</option>
+          <option value="end">end (prefix + trailing garbage)</option>
+        </select>
+      </label>
+      <div>
+        <div class="muted" style="margin-bottom:4px">Swaps (expected → OCR glyphs)</div>
+        <div id="popSwaps"></div>
+        <div class="row-actions" style="margin-top:6px">
+          <button type="button" id="popAddSwap">Add swap</button>
+          <button type="button" id="popSaveOpts" class="primary">Save options</button>
+        </div>
+      </div>
+      <details>
+        <summary>Advanced / JSON</summary>
+        <pre id="popJson"></pre>
+      </details>
+    </div>
   </div>
 </main>
 </div>
@@ -539,6 +576,62 @@ function hidePop() {
   popEl.hidden = true;
 }
 
+const CHARSET_OPTIONS = [
+  { value: 'auto', label: 'Auto (from field name)' },
+  { value: 'text', label: 'Text' },
+  { value: 'digits', label: 'Digits' },
+  { value: 'alnum', label: 'Letters + digits' },
+  { value: 'email', label: 'Email' },
+  { value: 'vin', label: 'VIN / code' },
+];
+
+function fillCharsetSelect(select, selected) {
+  const current = selected || 'auto';
+  select.innerHTML = CHARSET_OPTIONS.map((opt) =>
+    `<option value="${opt.value}"${opt.value === current ? ' selected' : ''}>${opt.label}</option>`,
+  ).join('');
+}
+
+function swapsToRows(swaps) {
+  const rows = [];
+  if (!swaps || typeof swaps !== 'object') return rows;
+  for (const [from, to] of Object.entries(swaps)) {
+    rows.push({
+      from,
+      to: Array.isArray(to) ? to.join(',') : String(to ?? ''),
+    });
+  }
+  return rows;
+}
+
+function rowsToSwaps(container) {
+  const out = {};
+  for (const row of container.querySelectorAll('.swap-row')) {
+    const from = row.querySelector('[data-swap=from]').value.trim();
+    const to = row.querySelector('[data-swap=to]').value
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (from && to.length) out[from] = to;
+  }
+  return Object.keys(out).length ? out : null;
+}
+
+function renderSwapRows(container, swaps) {
+  const rows = swapsToRows(swaps);
+  if (!rows.length) rows.push({ from: '', to: '' });
+  container.innerHTML = '';
+  for (const row of rows) {
+    const el = document.createElement('div');
+    el.className = 'swap-row';
+    el.innerHTML =
+      `<input data-swap="from" type="text" maxlength="4" placeholder="@" value="${row.from.replace(/"/g, '&quot;')}">` +
+      `<input data-swap="to" type="text" placeholder="Q,C" value="${row.to.replace(/"/g, '&quot;')}">` +
+      `<button type="button" data-swap-remove title="Remove">×</button>`;
+    container.appendChild(el);
+  }
+}
+
 function catalogElement(key) {
   if (!key || !key.startsWith('crop:')) return null;
   return state.elements.find((item) => item.name === key.slice(5)) || null;
@@ -580,6 +673,11 @@ function renderPop() {
   document.getElementById('popSection').textContent = info.section || '—';
   document.getElementById('popPartNames').textContent = info.partNames || '—';
   document.getElementById('popJson').textContent = JSON.stringify(el, null, 2);
+  fillCharsetSelect(document.getElementById('popCharset'), el.charset || 'auto');
+  document.getElementById('popRead').value = el.read === 'clipboard' ? 'clipboard' : 'ocr';
+  document.getElementById('popOverflow').value = el.overflow || '';
+  renderSwapRows(document.getElementById('popSwaps'), el.swaps);
+  popEl.dataset.element = el.name;
   const parent = info.parent && info.parent.width ? info.parent : info.rect;
   drawSourceRect(document.getElementById('popCanvas'), parent, 280, info.parts);
   const partsEl = document.getElementById('popParts');
@@ -597,6 +695,55 @@ function renderPop() {
   }
   placePop(key);
 }
+
+document.getElementById('popAddSwap').addEventListener('click', () => {
+  const container = document.getElementById('popSwaps');
+  const el = document.createElement('div');
+  el.className = 'swap-row';
+  el.innerHTML =
+    `<input data-swap="from" type="text" maxlength="4" placeholder="@">` +
+    `<input data-swap="to" type="text" placeholder="Q,C">` +
+    `<button type="button" data-swap-remove title="Remove">×</button>`;
+  container.appendChild(el);
+});
+
+document.getElementById('popSwaps').addEventListener('click', (e) => {
+  const btn = e.target.closest('[data-swap-remove]');
+  if (!btn) return;
+  const row = btn.closest('.swap-row');
+  const container = document.getElementById('popSwaps');
+  row.remove();
+  if (!container.children.length) renderSwapRows(container, null);
+});
+
+document.getElementById('popSaveOpts').addEventListener('click', async () => {
+  const element = popEl.dataset.element;
+  if (!element || !state.name) return;
+  try {
+    const charset = document.getElementById('popCharset').value;
+    const read = document.getElementById('popRead').value;
+    const overflow = document.getElementById('popOverflow').value;
+    const swaps = rowsToSwaps(document.getElementById('popSwaps'));
+    const out = await api('/api/element-options?name=' + encodeURIComponent(state.name), {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        element,
+        charset,
+        read,
+        overflow: overflow || null,
+        swaps,
+      }),
+    });
+    const idx = state.elements.findIndex((item) => item.name === element);
+    // Replace wholesale so cleared charset/read/swaps do not linger from prior state.
+    if (idx >= 0) state.elements[idx] = out.index;
+    setStatus('Saved options for ' + element);
+    renderPop();
+  } catch (err) {
+    toast(err.message || String(err));
+  }
+});
 
 async function copyText(text, ok) {
   await navigator.clipboard.writeText(text);


### PR DESCRIPTION
## Summary
- TM v2 inspect popover: form controls for charset / read / overflow / swaps (JSON under Advanced); saves via `PUT /api/element-options`
- `applyScreen` round-trips and merges those options by element name so re-apply does not wipe TM tweaks; `loadScreen` honors `read` + part-level options
- `patchElementOptions` / `patchPartOptions` update first-pass + index without re-cropping; QAWOLF_AUTHOR docs + review-psv Bugbot checklist

Closes #48

## Test plan
- [ ] `pnpm --filter @rickcedwhat/playwright-smart-vision exec vitest run src/author/author.test.ts`
- [ ] In TM v2 catalog view, set charset/swaps/read on an element → Save → confirm `first-pass.json` and `index.json`
- [ ] Re-run apply (or Reload) without those fields in AI first-pass → prior options still present
- [ ] `screen(name)` / runtime uses `read: "clipboard"` and swaps from FUSE index


Made with [Cursor](https://cursor.com)