### PR TITLE
feat: dblclick() and hover() on ScreenElement

### DIFF
--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -381,6 +381,27 @@ export class ScreenElement {
     });
   }
 
+  async dblclick(options?: { timeout?: number }): Promise<void> {
+    return ocrStep(`element('${this.label}').dblclick()`, async () => {
+      await this.ensureLocated(options?.timeout);
+      await this.withOverlay(async () => {
+        const rect = this.result.ocrLocation ?? this.result.location;
+        if (!this.page) throw new Error('Page not provided. Cannot double-click element.');
+        await this.page.mouse.dblclick(rect.x + rect.width / 2, rect.y + rect.height / 2);
+        this.live?.markDirty();
+      });
+    });
+  }
+
+  async hover(options?: { timeout?: number }): Promise<void> {
+    return ocrStep(`element('${this.label}').hover()`, async () => {
+      await this.ensureLocated(options?.timeout);
+      const rect = this.result.ocrLocation ?? this.result.location;
+      if (!this.page) throw new Error('Page not provided. Cannot hover element.');
+      await this.page.mouse.move(rect.x + rect.width / 2, rect.y + rect.height / 2);
+    });
+  }
+
   private async clickRect(rect: Rect): Promise<void> {
     if (!this.page) {
       throw new Error('Page not provided. Cannot click element.');

--- a/packages/core/tests/element-actions.spec.ts
+++ b/packages/core/tests/element-actions.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test';
+import { ScreenElement } from '../src/element.js';
+import type { ElementResult } from '../src/types.js';
+
+function makeResult(overrides?: Partial<ElementResult>): ElementResult {
+  return {
+    name: 'testEl',
+    location: { x: 100, y: 200, width: 80, height: 40 },
+    confidence: 1,
+    isEmpty: false,
+    ...overrides,
+  };
+}
+
+test.describe('ScreenElement actions', () => {
+  test('hover() moves mouse to element center', async ({ page }) => {
+    await page.goto('/');
+
+    await page.evaluate(() => {
+      (window as any).__lastMouseMove = null;
+      document.addEventListener('mousemove', (e) => {
+        (window as any).__lastMouseMove = { x: e.clientX, y: e.clientY };
+      });
+    });
+
+    const result = makeResult();
+    const el = new ScreenElement(result, page);
+    await el.hover();
+
+    const pos = await page.evaluate(() => (window as any).__lastMouseMove);
+    expect(pos).not.toBeNull();
+    // center of { x:100, y:200, width:80, height:40 } = (140, 220)
+    expect(pos.x).toBe(140);
+    expect(pos.y).toBe(220);
+  });
+
+  test('dblclick() fires dblclick event at element center', async ({ page }) => {
+    await page.goto('/');
+
+    await page.evaluate(() => {
+      (window as any).__dblclickPos = null;
+      document.addEventListener('dblclick', (e) => {
+        (window as any).__dblclickPos = { x: e.clientX, y: e.clientY };
+      });
+    });
+
+    const result = makeResult();
+    const el = new ScreenElement(result, page);
+    await el.dblclick();
+
+    const pos = await page.evaluate(() => (window as any).__dblclickPos);
+    expect(pos).not.toBeNull();
+    expect(pos.x).toBe(140);
+    expect(pos.y).toBe(220);
+  });
+
+  test('hover() uses ocrLocation when present', async ({ page }) => {
+    await page.goto('/');
+
+    await page.evaluate(() => {
+      (window as any).__lastMouseMove = null;
+      document.addEventListener('mousemove', (e) => {
+        (window as any).__lastMouseMove = { x: e.clientX, y: e.clientY };
+      });
+    });
+
+    const result = makeResult({ ocrLocation: { x: 50, y: 60, width: 60, height: 20 } });
+    const el = new ScreenElement(result, page);
+    await el.hover();
+
+    const pos = await page.evaluate(() => (window as any).__lastMouseMove);
+    // center of ocrLocation { x:50, y:60, width:60, height:20 } = (80, 70)
+    expect(pos.x).toBe(80);
+    expect(pos.y).toBe(70);
+  });
+
+  test('hover() throws when no page provided', async () => {
+    const el = new ScreenElement(makeResult());
+    await expect(el.hover()).rejects.toThrow('Page not provided');
+  });
+
+  test('dblclick() throws when no page provided', async () => {
+    const el = new ScreenElement(makeResult());
+    await expect(el.dblclick()).rejects.toThrow('Page not provided');
+  });
+});


### PR DESCRIPTION
Adds two new action methods to `ScreenElement`, following the same pattern as `click()`.

### `dblclick(options?: { timeout?: number })`
Waits for the element to be located, then fires `page.mouse.dblclick()` at the element center (preferring `ocrLocation` over `location`). Marks the screen dirty so the next OCR call re-captures.

### `hover(options?: { timeout?: number })`
Waits for the element to be located, then fires `page.mouse.move()` to the element center. No `markDirty` — hover is positioning, not a state-change action.

Both throw a clear error when `page` was not provided.

5 new tests in `tests/element-actions.spec.ts`, all passing.

Closes #2 (partially — check/uncheck/selectOption remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)