### PR TITLE
feat: Charset strategy — named charsets with bundled swaps

### DIFF
--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -23,8 +23,9 @@ export type HaveTextOptions = {
   /** Expected glyph → OCR glyphs allowed in its place, e.g. `{ '@': ['Q', 'C'], '5': 'S' }`. */
   swaps?: OcrSwaps;
   /**
-   * Charset to use for this assertion — name of a charset registered in `init()` or an inline
-   * `Charset` object. Its bundled swaps are applied unless explicit `swaps` are also set.
+   * Charset to use for this assertion — name registered in `init()` or an inline `Charset` object.
+   * Only the bundled `swaps` are applied at assertion time; `chars` has no effect here because
+   * OCR extraction already ran. For `chars` to take effect, set `charset` on the element config.
    * Explicit `swaps` always win over `charset.swaps`.
    */
   charset?: string | Charset;

--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -2,6 +2,8 @@ import type { ElementResult, Rect, ElementType } from './types.js';
 import type { Page } from '@playwright/test';
 import {
   ocrTextMatches,
+  resolveCharsetSwaps,
+  type Charset,
   type FieldRead,
   type OcrOverflow,
   type OcrSwaps,
@@ -20,6 +22,12 @@ export type HaveTextOptions = {
   timeout?: number;
   /** Expected glyph → OCR glyphs allowed in its place, e.g. `{ '@': ['Q', 'C'], '5': 'S' }`. */
   swaps?: OcrSwaps;
+  /**
+   * Charset to use for this assertion — name of a charset registered in `init()` or an inline
+   * `Charset` object. Its bundled swaps are applied unless explicit `swaps` are also set.
+   * Explicit `swaps` always win over `charset.swaps`.
+   */
+  charset?: string | Charset;
   /** Clip handling. Prefer setting this on the screen config. */
   overflow?: OcrOverflow;
   overflowSlop?: number;
@@ -513,7 +521,10 @@ export class ScreenElement {
   private resolvedMatch(options?: HaveTextOptions): MatchOptions {
     const fromConfig = this.live?.matchOptions(this.rootName, this.partName) ?? {};
     const match: MatchOptions = {};
-    const swaps = options?.swaps ?? fromConfig.swaps;
+    // Priority: explicit call-site swaps > call-site charset swaps > config swaps (which already
+    // incorporates the element config's charset bundled swaps as a fallback).
+    const callCharsetSwaps = options?.charset ? resolveCharsetSwaps(options.charset) : undefined;
+    const swaps = options?.swaps ?? callCharsetSwaps ?? fromConfig.swaps;
     const overflow = options?.overflow ?? fromConfig.overflow;
     const read = options?.read ?? fromConfig.read;
     if (swaps) match.swaps = swaps;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,4 +33,4 @@ export type {
 } from './types.js';
 
 export { ocrTextMatches } from './utils/ocr.js';
-export type { FieldRead, OcrOverflow, OcrSwaps } from './utils/ocr.js';
+export type { Charset, FieldRead, OcrOverflow, OcrSwaps } from './utils/ocr.js';

--- a/packages/core/src/screen-result.ts
+++ b/packages/core/src/screen-result.ts
@@ -125,8 +125,8 @@ export class ScreenResult {
     if (!config) return {};
     const part = partName ? config.parts?.find(row => row.name === partName) : undefined;
     const match: MatchOptions = {};
-    // Explicit swaps win; fall back to the charset's bundled swaps.
-    const swaps = part?.swaps ?? config.swaps ?? resolveCharsetSwaps(part?.charset ?? config.charset);
+    // Resolution order respects specificity: part > config, explicit > charset-derived.
+    const swaps = part?.swaps ?? resolveCharsetSwaps(part?.charset) ?? config.swaps ?? resolveCharsetSwaps(config.charset);
     const overflow = part?.overflow ?? config.overflow;
     const read = part?.read ?? config.read;
     if (swaps) match.swaps = swaps;

--- a/packages/core/src/screen-result.ts
+++ b/packages/core/src/screen-result.ts
@@ -5,6 +5,7 @@ import type { Page } from '@playwright/test';
 import { ocrStep } from './ocr-step.js';
 import { hideOcrOverlay, overlayBoxesFromResult, showOcrOverlay } from './ocr-overlay.js';
 import { unhoverBeforeCapture } from './unhover.js';
+import { resolveCharsetSwaps } from './utils/ocr.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -124,7 +125,8 @@ export class ScreenResult {
     if (!config) return {};
     const part = partName ? config.parts?.find(row => row.name === partName) : undefined;
     const match: MatchOptions = {};
-    const swaps = part?.swaps ?? config.swaps;
+    // Explicit swaps win; fall back to the charset's bundled swaps.
+    const swaps = part?.swaps ?? config.swaps ?? resolveCharsetSwaps(part?.charset ?? config.charset);
     const overflow = part?.overflow ?? config.overflow;
     const read = part?.read ?? config.read;
     if (swaps) match.swaps = swaps;

--- a/packages/core/src/screen.ts
+++ b/packages/core/src/screen.ts
@@ -7,7 +7,7 @@ import type { ScreenConfig } from './screen-config.js';
 import { loadScreen } from './configure.js';
 import { FieldExtractor } from './field-extractor.js';
 import { ScreenResult } from './screen-result.js';
-import { cleanupOCR, getOCRUtil } from './utils/ocr.js';
+import { cleanupOCR, getOCRUtil, setCharsetRegistry, type Charset } from './utils/ocr.js';
 import { ensureCvReady } from './utils/vision.js';
 
 export interface BindOcrScreenOptions {
@@ -51,6 +51,9 @@ interface InitOptions {
   storage?: { root: string };
   devtools?: boolean;
   unhoverBeforeCapture?: boolean;
+  strategies?: {
+    charsets?: Record<string, Charset>;
+  };
 }
 
 interface InitState {
@@ -83,6 +86,10 @@ export async function init(options: InitOptions): Promise<void> {
     initState = { config: options, extractor, shotDir: defaultShotDir() };
   } else {
     initState.config = { ...initState.config, ...options };
+  }
+
+  if (options.strategies?.charsets) {
+    setCharsetRegistry(options.strategies.charsets);
   }
 
   try {

--- a/packages/core/src/screen.ts
+++ b/packages/core/src/screen.ts
@@ -144,6 +144,7 @@ export function screen(
 export async function release(): Promise<void> {
   initState?.extractor.cleanup();
   initState = null;
+  setCharsetRegistry({});
   await cleanupOCR();
 }
 

--- a/packages/core/src/utils/ocr.ts
+++ b/packages/core/src/utils/ocr.ts
@@ -23,9 +23,13 @@ export interface Charset {
 
 let charsetRegistry: Record<string, Charset> = {};
 
-/** Called by `init()` to register user-defined charsets. */
+/**
+ * Called by `init()` to register user-defined charsets.
+ * Merges into the existing registry — subsequent calls accumulate charsets rather than replacing them.
+ * Call `setCharsetRegistry({})` (or `release()`) to clear.
+ */
 export function setCharsetRegistry(registry: Record<string, Charset>): void {
-  charsetRegistry = registry;
+  charsetRegistry = { ...charsetRegistry, ...registry };
 }
 
 /** Look up a registered charset by name, or return undefined if not found. */
@@ -40,14 +44,17 @@ export function lookupCharset(name: string): Charset | undefined {
 export function resolveCharsetSwaps(charset: string | Charset | undefined): OcrSwaps | undefined {
   if (!charset) return undefined;
   if (typeof charset === 'object') return charset.swaps;
-  return charsetRegistry[charset]?.swaps;
+  return lookupCharset(charset)?.swaps;
 }
 
 export function charsetForField(name = '', type = '', preset = 'auto'): string | undefined {
   if (type === 'checkbox') return undefined;
-  // Check the user registry first (registered charsets take priority over built-in presets).
-  if (preset && preset !== 'auto' && charsetRegistry[preset]) return charsetRegistry[preset].chars;
-  if (preset && preset !== 'auto' && CHARSET_PRESETS[preset]) return CHARSET_PRESETS[preset];
+  if (preset && preset !== 'auto') {
+    // User-registered charsets take priority over built-in presets.
+    const custom = lookupCharset(preset);
+    if (custom) return custom.chars;
+    if (CHARSET_PRESETS[preset]) return CHARSET_PRESETS[preset];
+  }
   const key = `${name} ${type}`.toLowerCase();
   if (key.includes('email')) return CHARSET_PRESETS.email;
   if (key.includes('vin')) return CHARSET_PRESETS.vin;

--- a/packages/core/src/utils/ocr.ts
+++ b/packages/core/src/utils/ocr.ts
@@ -13,8 +13,40 @@ export const CHARSET_PRESETS: Record<string, string> = {
   vin: `${UPPER}${LOWER}${DIGITS}`,
 };
 
+/** A named charset bundling a Tesseract whitelist with expected OCR confusions. */
+export interface Charset {
+  /** Tesseract character whitelist passed directly to `tessedit_char_whitelist`. */
+  chars: string;
+  /** Expected glyph → OCR glyphs that are acceptable in its place. */
+  swaps?: OcrSwaps;
+}
+
+let charsetRegistry: Record<string, Charset> = {};
+
+/** Called by `init()` to register user-defined charsets. */
+export function setCharsetRegistry(registry: Record<string, Charset>): void {
+  charsetRegistry = registry;
+}
+
+/** Look up a registered charset by name, or return undefined if not found. */
+export function lookupCharset(name: string): Charset | undefined {
+  return charsetRegistry[name];
+}
+
+/**
+ * Resolve the bundled swaps for a charset name string or inline Charset object.
+ * Returns undefined if the name is not registered or the charset has no swaps.
+ */
+export function resolveCharsetSwaps(charset: string | Charset | undefined): OcrSwaps | undefined {
+  if (!charset) return undefined;
+  if (typeof charset === 'object') return charset.swaps;
+  return charsetRegistry[charset]?.swaps;
+}
+
 export function charsetForField(name = '', type = '', preset = 'auto'): string | undefined {
   if (type === 'checkbox') return undefined;
+  // Check the user registry first (registered charsets take priority over built-in presets).
+  if (preset && preset !== 'auto' && charsetRegistry[preset]) return charsetRegistry[preset].chars;
   if (preset && preset !== 'auto' && CHARSET_PRESETS[preset]) return CHARSET_PRESETS[preset];
   const key = `${name} ${type}`.toLowerCase();
   if (key.includes('email')) return CHARSET_PRESETS.email;


### PR DESCRIPTION
## Summary

- New `Charset` interface: `{ chars: string; swaps?: OcrSwaps }`
- `init({ strategies: { charsets: { vin: { chars: 'ABCDEFGHJKLMNPRSTUVWXYZ0-9', swaps: { 'O': ['0'] } } } } })` registers charsets
- `charsetForField()` checks the user registry before falling back to built-in `CHARSET_PRESETS` — registered charset's `chars` is used as the Tesseract whitelist
- `matchOptions()` now uses the resolved charset's bundled `swaps` as a fallback when the element has no explicit `swaps`
- `HaveTextOptions.charset` accepts a name string or inline `Charset` object for per-assertion overrides
- Swaps resolution order: explicit call-site `swaps` > call-site `charset.swaps` > config `swaps` > config `charset.swaps`
- Export `Charset` from the public index

## Before / after

```ts
// Before — swaps scattered at every call site
await customerInfoScreen.element('vin').toHaveValue(vehicle.vin, { swaps: { 'O': ['0'], 'I': ['1'] } });

// After — register once, call site is clean
await init({
  page,
  strategies: {
    charsets: {
      vin: { chars: 'ABCDEFGHJKLMNPRSTUVWXYZ0-9', swaps: { 'O': ['0'], 'I': ['1'] } },
    },
  },
});

// index.json element has "charset": "vin" — swaps flow automatically
await customerInfoScreen.element('vin').toHaveValue(vehicle.vin);
```

Closes #65

## Test plan

- [ ] `tsc --noEmit` passes (clean)
- [ ] Element with `charset: 'vin'` in config picks up bundled swaps at assertion time
- [ ] Explicit `swaps` on element config override charset bundled swaps
- [ ] Call-site `{ charset: 'vin' }` applies that charset's swaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)