### PR TITLE
feat: TM v2 charset library panel

### DIFF
--- a/packages/tools/tm-v2/handler.mjs
+++ b/packages/tools/tm-v2/handler.mjs
@@ -381,18 +381,27 @@ async function handleInternal(req, res, url) {
   }
 
   if (req.method === 'GET' && url.pathname === '/api/charsets') {
-    const data = fs.existsSync(CHARSETS_FILE)
-      ? JSON.parse(fs.readFileSync(CHARSETS_FILE, 'utf8'))
-      : {};
+    let data = {};
+    if (fs.existsSync(CHARSETS_FILE)) {
+      try {
+        const parsed = JSON.parse(fs.readFileSync(CHARSETS_FILE, 'utf8'));
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) data = parsed;
+      } catch (_) {}
+    }
     send(res, 200, { charsets: data });
     return;
   }
 
   if (req.method === 'PUT' && url.pathname === '/api/charsets') {
     const body = JSON.parse(await readBody(req) || '{}');
+    const incoming = (body && body.charsets) ?? {};
+    if (typeof incoming !== 'object' || incoming === null || Array.isArray(incoming)) {
+      send(res, 400, { error: 'charsets must be a plain object' });
+      return;
+    }
     fs.mkdirSync(HOME, { recursive: true });
-    fs.writeFileSync(CHARSETS_FILE, `${JSON.stringify(body.charsets || {}, null, 2)}\n`);
-    send(res, 200, { charsets: body.charsets || {} });
+    fs.writeFileSync(CHARSETS_FILE, `${JSON.stringify(incoming, null, 2)}\n`);
+    send(res, 200, { charsets: incoming });
     return;
   }
 

--- a/packages/tools/tm-v2/handler.mjs
+++ b/packages/tools/tm-v2/handler.mjs
@@ -21,6 +21,7 @@ const CACHE_DIR = path.join(HOME, 'screens');
 const DEFAULT_GCS = 'gs://qawolf-prod-team-storage/clzn2wsor00hcda0ickzd3544/screens';
 
 const RUNTIME_FILES = ['blank.png', 'index.json'];
+const CHARSETS_FILE = path.join(HOME, 'charsets.json');
 
 function normalizeGcs(raw) {
   const uri = String(raw || '').trim().replace(/\/+$/, '');
@@ -270,6 +271,18 @@ async function pushRuntimeScreens({ names, dryRun }) {
         gcloud: String(log).trim(),
       });
     }
+    if (fs.existsSync(CHARSETS_FILE)) {
+      const dest = `${gcsUri}/charsets.json`;
+      const log = dryRun
+        ? `Would copy ${CHARSETS_FILE} to ${dest}`
+        : await runGcloud(['storage', 'cp', CHARSETS_FILE, dest]);
+      logs.push({
+        screen: 'charsets.json',
+        dest,
+        files: ['charsets.json'],
+        gcloud: String(log).trim(),
+      });
+    }
   } finally {
     fs.rmSync(staging, { recursive: true, force: true });
   }
@@ -364,6 +377,22 @@ async function handleInternal(req, res, url) {
     const settings = { gcsUri: normalizeGcs(body.gcsUri) };
     writeSettings(settings);
     send(res, 200, { ...settings, cacheDir: CACHE_DIR });
+    return;
+  }
+
+  if (req.method === 'GET' && url.pathname === '/api/charsets') {
+    const data = fs.existsSync(CHARSETS_FILE)
+      ? JSON.parse(fs.readFileSync(CHARSETS_FILE, 'utf8'))
+      : {};
+    send(res, 200, { charsets: data });
+    return;
+  }
+
+  if (req.method === 'PUT' && url.pathname === '/api/charsets') {
+    const body = JSON.parse(await readBody(req) || '{}');
+    fs.mkdirSync(HOME, { recursive: true });
+    fs.writeFileSync(CHARSETS_FILE, `${JSON.stringify(body.charsets || {}, null, 2)}\n`);
+    send(res, 200, { charsets: body.charsets || {} });
     return;
   }
 

--- a/packages/tools/tm-v2/index.html
+++ b/packages/tools/tm-v2/index.html
@@ -122,6 +122,21 @@
   #authBanner[hidden] { display: none; }
   #authBanner code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; background: #111; color: #ff4; padding: 2px 6px; border-radius: 3px; user-select: all; display: inline-block; }
   #authBannerClose { align-self: flex-end; padding: 2px 8px; font-size: 11px; background: transparent; border: 1px solid #764; color: #fb8; }
+  #charsetPanel { border-top: 1px solid #333; margin-top: 8px; padding-top: 8px; }
+  #charsetPanel h4 { margin: 0 0 6px; font-size: 11px; color: #888; text-transform: uppercase; letter-spacing: .05em; display: flex; align-items: center; gap: 4px; }
+  #charsetPanel h4 button { margin-left: auto; padding: 2px 8px; font-size: 11px; }
+  #charsetList { display: flex; flex-direction: column; gap: 4px; overflow-y: auto; max-height: 280px; }
+  .charset-row { background: #1f1f1f; border: 1px solid #333; border-radius: 4px; font-size: 11px; }
+  .charset-row-header { display: flex; align-items: center; gap: 4px; padding: 5px 6px; cursor: pointer; user-select: none; }
+  .charset-row-header:hover { background: #2a2a2a; border-radius: 4px 4px 0 0; }
+  .charset-row-header .cs-name { flex: 1; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #cfc; }
+  .charset-row-header .cs-del { padding: 1px 6px; font-size: 11px; color: #f88; background: transparent; border: 1px solid #555; }
+  .charset-row-body { padding: 6px 8px; border-top: 1px solid #2a2a2a; display: flex; flex-direction: column; gap: 6px; }
+  .charset-row-body label { color: #888; font-size: 11px; display: flex; flex-direction: column; gap: 2px; }
+  .charset-row-body input[type=text] { width: 100%; font-size: 11px; background: #222; color: #eee; border: 1px solid #444; padding: 4px 6px; border-radius: 3px; }
+  .charset-row-body .cs-swaps { display: flex; flex-direction: column; gap: 3px; }
+  .charset-row-body .cs-swaps-actions { display: flex; gap: 4px; margin-top: 2px; }
+  .charset-row-body .cs-save { padding: 3px 10px; font-size: 11px; }
 </style>
 </head>
 <body>
@@ -170,6 +185,10 @@
     <button id="authBannerClose" type="button">Dismiss</button>
   </div>
   <div id="tree" class="tree"></div>
+  <div id="charsetPanel">
+    <h4>Charsets <button id="charsetAdd" type="button">+ Add</button></h4>
+    <div id="charsetList"></div>
+  </div>
 </aside>
 <main id="main">
   <div class="stage" id="stage">
@@ -605,17 +624,156 @@ function hidePop() {
   document.getElementById('detailPlaceholder').hidden = false;
 }
 
+let charsets = {};
+
 const CHARSET_OPTIONS = [
   { value: 'text', label: 'Text' },
   { value: 'digits', label: 'Digits' },
   { value: 'alnum', label: 'Letters + digits' },
 ];
 
+async function loadCharsets() {
+  try {
+    const data = await api('/api/charsets');
+    charsets = data.charsets || {};
+    renderCharsetList();
+  } catch (_) {}
+}
+
+async function saveCharsets() {
+  charsets = collectCharsets();
+  await api('/api/charsets', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ charsets }),
+  });
+  // Refresh all charset selects in the element detail panel.
+  const sel = document.getElementById('popCharset');
+  if (sel) fillCharsetSelect(sel, sel.value);
+}
+
+function collectCharsets() {
+  const result = {};
+  for (const row of document.getElementById('charsetList').querySelectorAll('.charset-row')) {
+    const nameEl = row.querySelector('[data-cs-name]');
+    const charsEl = row.querySelector('[data-cs-chars]');
+    if (!nameEl || !charsEl) continue;
+    const n = nameEl.value.trim();
+    if (!n) continue;
+    const swaps = rowsToSwaps(row.querySelector('.cs-swaps'));
+    result[n] = { chars: charsEl.value, ...(swaps && Object.keys(swaps).length ? { swaps } : {}) };
+  }
+  return result;
+}
+
+function renderCharsetList() {
+  const list = document.getElementById('charsetList');
+  list.innerHTML = '';
+  for (const [name, cs] of Object.entries(charsets)) {
+    list.appendChild(charsetRowEl(name, cs));
+  }
+}
+
+function charsetRowEl(name, cs) {
+  const wrap = document.createElement('div');
+  wrap.className = 'charset-row';
+  const header = document.createElement('div');
+  header.className = 'charset-row-header';
+  header.innerHTML =
+    `<span class="cs-name">${name}</span>` +
+    `<button type="button" class="cs-del" title="Delete">×</button>`;
+  header.querySelector('.cs-name').addEventListener('click', () => {
+    body.hidden = !body.hidden;
+  });
+  header.querySelector('.cs-del').addEventListener('click', (e) => {
+    e.stopPropagation();
+    wrap.remove();
+    saveCharsets().catch((err) => toast(err.message));
+  });
+
+  const body = document.createElement('div');
+  body.className = 'charset-row-body';
+  body.hidden = true;
+
+  const swapContainer = document.createElement('div');
+  swapContainer.className = 'cs-swaps';
+  renderSwapRows(swapContainer, cs.swaps);
+
+  body.innerHTML =
+    `<label>Name<input data-cs-name type="text" value="${name}"></label>` +
+    `<label>Chars<input data-cs-chars type="text" value="${cs.chars || ''}"></label>`;
+
+  const swapLabel = document.createElement('label');
+  swapLabel.textContent = 'Swaps';
+  swapLabel.appendChild(swapContainer);
+
+  const swapActions = document.createElement('div');
+  swapActions.className = 'cs-swaps-actions';
+  const addSwapBtn = document.createElement('button');
+  addSwapBtn.type = 'button';
+  addSwapBtn.textContent = '+ Swap';
+  addSwapBtn.style.fontSize = '11px';
+  addSwapBtn.addEventListener('click', () => {
+    const el = document.createElement('div');
+    el.className = 'swap-row';
+    el.innerHTML =
+      `<input data-swap="from" type="text" maxlength="4" placeholder="@">` +
+      `<input data-swap="to" type="text" placeholder="Q,C">` +
+      `<button type="button" data-swap-remove title="Remove">×</button>`;
+    swapContainer.appendChild(el);
+  });
+  swapContainer.addEventListener('click', (e) => {
+    const btn = e.target.closest('[data-swap-remove]');
+    if (!btn) return;
+    const row = btn.closest('.swap-row');
+    row.remove();
+    if (!swapContainer.children.length) renderSwapRows(swapContainer, null);
+  });
+  swapActions.appendChild(addSwapBtn);
+
+  const saveBtn = document.createElement('button');
+  saveBtn.type = 'button';
+  saveBtn.className = 'cs-save primary';
+  saveBtn.textContent = 'Save';
+  saveBtn.addEventListener('click', async () => {
+    try {
+      await saveCharsets();
+      // Update header name display.
+      header.querySelector('.cs-name').textContent = wrap.querySelector('[data-cs-name]').value.trim();
+      setStatus('Charset saved');
+    } catch (err) { toast(err.message); }
+  });
+
+  body.appendChild(swapLabel);
+  body.appendChild(swapActions);
+  body.appendChild(saveBtn);
+  wrap.appendChild(header);
+  wrap.appendChild(body);
+  return wrap;
+}
+
+document.getElementById('charsetAdd').addEventListener('click', () => {
+  const list = document.getElementById('charsetList');
+  const row = charsetRowEl('', { chars: '' });
+  // Auto-expand new row for editing.
+  row.querySelector('.charset-row-body').hidden = false;
+  list.appendChild(row);
+  row.querySelector('[data-cs-name]').focus();
+});
+
 function fillCharsetSelect(select, selected) {
   const current = selected || 'auto';
-  select.innerHTML = CHARSET_OPTIONS.map((opt) =>
+  let html = CHARSET_OPTIONS.map((opt) =>
     `<option value="${opt.value}"${opt.value === current ? ' selected' : ''}>${opt.label}</option>`,
   ).join('');
+  const customNames = Object.keys(charsets);
+  if (customNames.length) {
+    html += `<option disabled>── custom ──</option>`;
+    for (const name of customNames) {
+      html += `<option value="${name}"${name === current ? ' selected' : ''}>${name}</option>`;
+    }
+  }
+  select.innerHTML = html;
 }
 
 function swapsToRows(swaps) {
@@ -1242,7 +1400,7 @@ stage.addEventListener('click', (e) => {
 });
 document.getElementById('popRead').addEventListener('change', syncOverflowVisibility);
 
-loadSettings()
+Promise.all([loadSettings(), loadCharsets()])
   .then(renderTree)
   .then(() => setView('source'))
   .catch(handleApiError);

--- a/packages/tools/tm-v2/index.html
+++ b/packages/tools/tm-v2/index.html
@@ -626,6 +626,8 @@ function hidePop() {
 
 let charsets = {};
 
+const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
 const CHARSET_OPTIONS = [
   { value: 'text', label: 'Text' },
   { value: 'digits', label: 'Digits' },
@@ -640,16 +642,22 @@ async function loadCharsets() {
   } catch (_) {}
 }
 
-async function saveCharsets() {
+async function saveCharsets(selectedName) {
+  const prev = charsets;
   charsets = collectCharsets();
-  await api('/api/charsets', {
-    method: 'PUT',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ charsets }),
-  });
-  // Refresh all charset selects in the element detail panel.
+  try {
+    await api('/api/charsets', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ charsets }),
+    });
+  } catch (err) {
+    charsets = prev;
+    throw err;
+  }
+  renderCharsetList();
   const sel = document.getElementById('popCharset');
-  if (sel) fillCharsetSelect(sel, sel.value);
+  if (sel) fillCharsetSelect(sel, selectedName ?? sel.value);
 }
 
 function collectCharsets() {
@@ -680,7 +688,7 @@ function charsetRowEl(name, cs) {
   const header = document.createElement('div');
   header.className = 'charset-row-header';
   header.innerHTML =
-    `<span class="cs-name">${name}</span>` +
+    `<span class="cs-name">${esc(name)}</span>` +
     `<button type="button" class="cs-del" title="Delete">×</button>`;
   header.querySelector('.cs-name').addEventListener('click', () => {
     body.hidden = !body.hidden;
@@ -700,8 +708,8 @@ function charsetRowEl(name, cs) {
   renderSwapRows(swapContainer, cs.swaps);
 
   body.innerHTML =
-    `<label>Name<input data-cs-name type="text" value="${name}"></label>` +
-    `<label>Chars<input data-cs-chars type="text" value="${cs.chars || ''}"></label>`;
+    `<label>Name<input data-cs-name type="text" value="${esc(name)}"></label>` +
+    `<label>Chars<input data-cs-chars type="text" value="${esc(cs.chars || '')}"></label>`;
 
   const swapLabel = document.createElement('label');
   swapLabel.textContent = 'Swaps';
@@ -709,26 +717,12 @@ function charsetRowEl(name, cs) {
 
   const swapActions = document.createElement('div');
   swapActions.className = 'cs-swaps-actions';
+  wireSwapContainer(swapContainer);
   const addSwapBtn = document.createElement('button');
   addSwapBtn.type = 'button';
   addSwapBtn.textContent = '+ Swap';
   addSwapBtn.style.fontSize = '11px';
-  addSwapBtn.addEventListener('click', () => {
-    const el = document.createElement('div');
-    el.className = 'swap-row';
-    el.innerHTML =
-      `<input data-swap="from" type="text" maxlength="4" placeholder="@">` +
-      `<input data-swap="to" type="text" placeholder="Q,C">` +
-      `<button type="button" data-swap-remove title="Remove">×</button>`;
-    swapContainer.appendChild(el);
-  });
-  swapContainer.addEventListener('click', (e) => {
-    const btn = e.target.closest('[data-swap-remove]');
-    if (!btn) return;
-    const row = btn.closest('.swap-row');
-    row.remove();
-    if (!swapContainer.children.length) renderSwapRows(swapContainer, null);
-  });
+  addSwapBtn.addEventListener('click', () => addSwapRow(swapContainer));
   swapActions.appendChild(addSwapBtn);
 
   const saveBtn = document.createElement('button');
@@ -737,9 +731,9 @@ function charsetRowEl(name, cs) {
   saveBtn.textContent = 'Save';
   saveBtn.addEventListener('click', async () => {
     try {
-      await saveCharsets();
-      // Update header name display.
-      header.querySelector('.cs-name').textContent = wrap.querySelector('[data-cs-name]').value.trim();
+      const newName = wrap.querySelector('[data-cs-name]').value.trim();
+      await saveCharsets(newName);
+      header.querySelector('.cs-name').textContent = newName;
       setStatus('Charset saved');
     } catch (err) { toast(err.message); }
   });
@@ -750,6 +744,25 @@ function charsetRowEl(name, cs) {
   wrap.appendChild(header);
   wrap.appendChild(body);
   return wrap;
+}
+
+function addSwapRow(container) {
+  const el = document.createElement('div');
+  el.className = 'swap-row';
+  el.innerHTML =
+    `<input data-swap="from" type="text" maxlength="4" placeholder="@">` +
+    `<input data-swap="to" type="text" placeholder="Q,C">` +
+    `<button type="button" data-swap-remove title="Remove">×</button>`;
+  container.appendChild(el);
+}
+
+function wireSwapContainer(container) {
+  container.addEventListener('click', (e) => {
+    const btn = e.target.closest('[data-swap-remove]');
+    if (!btn) return;
+    btn.closest('.swap-row').remove();
+    if (!container.children.length) renderSwapRows(container, null);
+  });
 }
 
 document.getElementById('charsetAdd').addEventListener('click', () => {
@@ -770,7 +783,7 @@ function fillCharsetSelect(select, selected) {
   if (customNames.length) {
     html += `<option disabled>── custom ──</option>`;
     for (const name of customNames) {
-      html += `<option value="${name}"${name === current ? ' selected' : ''}>${name}</option>`;
+      html += `<option value="${esc(name)}"${name === current ? ' selected' : ''}>${esc(name)}</option>`;
     }
   }
   select.innerHTML = html;
@@ -870,24 +883,9 @@ function renderPop() {
   }
 }
 
+wireSwapContainer(document.getElementById('popSwaps'));
 document.getElementById('popAddSwap').addEventListener('click', () => {
-  const container = document.getElementById('popSwaps');
-  const el = document.createElement('div');
-  el.className = 'swap-row';
-  el.innerHTML =
-    `<input data-swap="from" type="text" maxlength="4" placeholder="@">` +
-    `<input data-swap="to" type="text" placeholder="Q,C">` +
-    `<button type="button" data-swap-remove title="Remove">×</button>`;
-  container.appendChild(el);
-});
-
-document.getElementById('popSwaps').addEventListener('click', (e) => {
-  const btn = e.target.closest('[data-swap-remove]');
-  if (!btn) return;
-  const row = btn.closest('.swap-row');
-  const container = document.getElementById('popSwaps');
-  row.remove();
-  if (!container.children.length) renderSwapRows(container, null);
+  addSwapRow(document.getElementById('popSwaps'));
 });
 
 document.getElementById('popSaveOpts').addEventListener('click', async () => {


### PR DESCRIPTION
## Summary

- Adds `GET /PUT /api/charsets` routes in `handler.mjs` that read/write `~/.smart-vision/charsets.json`
- Pushes `charsets.json` alongside `generated.ts` in `pushRuntimeScreens`
- Adds a **Charsets** panel at the bottom of the `<aside>` tree — create, edit, and delete named charsets with a name, character whitelist, and swap rows
- Extends `fillCharsetSelect` to show custom charsets below the three built-ins with a `── custom ──` separator

## Test plan

- [ ] Load the TM v2 UI — charset panel appears below the screen tree
- [ ] Click `+ Add`, fill in name/chars/swaps, click Save — charset appears in list and in element charset dropdown
- [ ] Open an element's detail panel — custom charsets appear in the charset select
- [ ] Delete a charset — it disappears from the list and the dropdown
- [ ] Push GCS — `charsets.json` appears in the push log alongside `generated.ts`

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)