### PR TITLE
feat: createScreenApi + ScreenName/ElementName types from generated.ts

### DIFF
--- a/packages/core/src/author/author.test.ts
+++ b/packages/core/src/author/author.test.ts
@@ -231,6 +231,8 @@ describe('author apply + catalog', () => {
     expect(src).toContain('satisfies Strategies');
     expect(src).toContain('export const strategies');
     expect(src).toContain('export const screens');
+    expect(src).toContain('export type ScreenName');
+    expect(src).toContain('export type ElementName');
     expect(src).not.toContain('type: "field"');
     expect(src).not.toContain('export type Screens');
     expect(fs.readFileSync(dest, 'utf8')).toBe(src);

--- a/packages/core/src/author/catalog.ts
+++ b/packages/core/src/author/catalog.ts
@@ -101,6 +101,13 @@ export const strategies = ${strategiesBody} satisfies Strategies;
 export const screens = {
 ${screensBody}
 } as const;
+
+type _ScreenKey<S extends ScreenName> = {
+  [K in keyof typeof screens]: (typeof screens)[K]['name'] extends S ? K : never;
+}[keyof typeof screens];
+
+export type ScreenName = (typeof screens)[keyof typeof screens]['name'];
+export type ElementName<S extends ScreenName> = keyof (typeof screens)[_ScreenKey<S>]['elements'] & string;
 `;
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,4 +35,5 @@ export type {
 export { ocrTextMatches } from './utils/ocr.js';
 export type { Charset, FieldRead, OcrOverflow, OcrSwaps } from './utils/ocr.js';
 export type { Strategies } from './screen.js';
-export { createScreenApi } from './screen-api.js';
+export { createScreen } from './screen-api.js';
+export type { TypedResult } from './screen-api.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,3 +35,4 @@ export type {
 export { ocrTextMatches } from './utils/ocr.js';
 export type { Charset, FieldRead, OcrOverflow, OcrSwaps } from './utils/ocr.js';
 export type { Strategies } from './screen.js';
+export { createScreenApi } from './screen-api.js';

--- a/packages/core/src/screen-api.ts
+++ b/packages/core/src/screen-api.ts
@@ -13,7 +13,7 @@ type CatalogElementName<
   S extends T[keyof T]['name'],
 > = keyof T[ScreenKey<T, S>]['elements'] & string;
 
-type TypedResult<
+export type TypedResult<
   T extends Record<string, { name: string; elements: Record<string, string> }>,
   S extends T[keyof T]['name'],
 > = Omit<ScreenResult, 'element'> & {
@@ -22,27 +22,23 @@ type TypedResult<
 
 /**
  * Create a typed screen() function bound to a generated.ts catalog.
- * Call once with your imported `screens` const, then use the returned
- * `screen()` for compile-time element-name checking.
+ * Call once with your imported `screens` const; the returned function
+ * replaces the untyped `screen()` import for compile-time element-name checking.
  *
- *   import { createScreenApi } from '@rickcedwhat/playwright-smart-vision';
+ *   import { createScreen } from '@rickcedwhat/playwright-smart-vision';
  *   import { screens } from '../helpers/screens.generated';
  *
- *   const api = createScreenApi(screens);
+ *   const screen = createScreen(screens);
  *
  *   // In a test (after await init(...)):
- *   const customerInfo = api.screen('customer-info');
+ *   const customerInfo = screen('customer-info');
  *   await customerInfo.element('customerNumber').toHaveValue('SEA314535');
  *   // TypeScript error: customerInfo.element('typo') ← won't compile
  */
-export function createScreenApi<
+export function createScreen<
   const T extends Record<string, { name: string; elements: Record<string, string> }>,
->(_catalog: T): {
-  screen<S extends T[keyof T]['name']>(name: S, options?: BindOcrScreenOptions): TypedResult<T, S>;
-} {
-  return {
-    screen(name, options) {
-      return rawScreen(name as string, options) as unknown as TypedResult<T, typeof name>;
-    },
+>(_catalog: T): <S extends T[keyof T]['name']>(name: S, options?: BindOcrScreenOptions) => TypedResult<T, S> {
+  return function screen(name, options) {
+    return rawScreen(name as string, options) as unknown as TypedResult<T, typeof name>;
   };
 }

--- a/packages/core/src/screen-api.ts
+++ b/packages/core/src/screen-api.ts
@@ -1,0 +1,48 @@
+import { screen as rawScreen } from './screen.js';
+import type { BindOcrScreenOptions } from './screen.js';
+import type { ScreenResult } from './screen-result.js';
+import type { ScreenElement } from './element.js';
+
+type ScreenKey<
+  T extends Record<string, { name: string; elements: Record<string, string> }>,
+  S extends T[keyof T]['name'],
+> = { [K in keyof T]: T[K]['name'] extends S ? K : never }[keyof T];
+
+type CatalogElementName<
+  T extends Record<string, { name: string; elements: Record<string, string> }>,
+  S extends T[keyof T]['name'],
+> = keyof T[ScreenKey<T, S>]['elements'] & string;
+
+type TypedResult<
+  T extends Record<string, { name: string; elements: Record<string, string> }>,
+  S extends T[keyof T]['name'],
+> = Omit<ScreenResult, 'element'> & {
+  element(name: CatalogElementName<T, S>): ScreenElement;
+};
+
+/**
+ * Create a typed screen() function bound to a generated.ts catalog.
+ * Call once with your imported `screens` const, then use the returned
+ * `screen()` for compile-time element-name checking.
+ *
+ *   import { createScreenApi } from '@rickcedwhat/playwright-smart-vision';
+ *   import { screens } from '../helpers/screens.generated';
+ *
+ *   const api = createScreenApi(screens);
+ *
+ *   // In a test (after await init(...)):
+ *   const customerInfo = api.screen('customer-info');
+ *   await customerInfo.element('customerNumber').toHaveValue('SEA314535');
+ *   // TypeScript error: customerInfo.element('typo') ← won't compile
+ */
+export function createScreenApi<
+  const T extends Record<string, { name: string; elements: Record<string, string> }>,
+>(_catalog: T): {
+  screen<S extends T[keyof T]['name']>(name: S, options?: BindOcrScreenOptions): TypedResult<T, S>;
+} {
+  return {
+    screen(name, options) {
+      return rawScreen(name as string, options) as unknown as TypedResult<T, typeof name>;
+    },
+  };
+}


### PR DESCRIPTION
Closes #53

## Summary

- Adds `createScreenApi(screens)` factory — takes the `screens as const` from `generated.ts` and returns a typed `screen()` that accepts only valid screen names and returns an element API narrowed to the element names for that screen
- `screenCatalogSource()` now emits `ScreenName` and `ElementName<S>` type aliases directly in `generated.ts`, so users can also use them to annotate their own function signatures
- Exports `createScreenApi` from the package root
- Updates `author.test.ts` to assert the new type aliases appear in generated output

## Usage

```ts
import { createScreenApi } from '@rickcedwhat/playwright-smart-vision';
import { screens } from '../helpers/screens.generated';

const api = createScreenApi(screens);

// In a test (after await init(...)):
const s = api.screen('customer-info');                // typed to ScreenName
await s.element('customerNumber').toHaveValue('SEA'); // typed to ElementName<'customer-info'>
// s.element('typo') → TypeScript compile error
```

Or use the generated type aliases directly:
```ts
import type { ScreenName, ElementName } from '../helpers/screens.generated';

function myHelper<S extends ScreenName>(name: S, el: ElementName<S>) { ... }
```

The existing untyped `screen(string)` API is unchanged — no migration required.

## Test plan

- [ ] `pnpm run -C packages/core typecheck` — no errors
- [ ] `pnpm run -C packages/core test:unit` — 107 tests pass
- [ ] Generated file contains `export type ScreenName` and `export type ElementName`
- [ ] TypeScript rejects `api.screen('invalid-name')` and `s.element('typo')` at compile time

🤖 Generated with [Claude Code](https://claude.com/claude-code)