### PR TITLE
fix: ScreenName empty-catalog fallback, forward-ref reorder, deprecate old typed API, add createScreen tests

### DIFF
--- a/packages/core/src/author/author.test.ts
+++ b/packages/core/src/author/author.test.ts
@@ -232,6 +232,7 @@ describe('author apply + catalog', () => {
     expect(src).toContain('export const strategies');
     expect(src).toContain('export const screens');
     expect(src).toContain('export type ScreenName');
+    expect(src).toContain('keyof typeof screens extends never');
     expect(src).toContain('export type ElementName');
     expect(src).not.toContain('type: "field"');
     expect(src).not.toContain('export type Screens');

--- a/packages/core/src/author/catalog.ts
+++ b/packages/core/src/author/catalog.ts
@@ -102,11 +102,14 @@ export const screens = {
 ${screensBody}
 } as const;
 
+export type ScreenName = keyof typeof screens extends never
+  ? string
+  : (typeof screens)[keyof typeof screens]['name'];
+
 type _ScreenKey<S extends ScreenName> = {
   [K in keyof typeof screens]: (typeof screens)[K]['name'] extends S ? K : never;
 }[keyof typeof screens];
 
-export type ScreenName = (typeof screens)[keyof typeof screens]['name'];
 export type ElementName<S extends ScreenName> = keyof (typeof screens)[_ScreenKey<S>]['elements'] & string;
 `;
 }

--- a/packages/core/src/screen-api.test.ts
+++ b/packages/core/src/screen-api.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./screen.js', () => ({
+  screen: vi.fn(),
+}));
+
+import { createScreen } from './screen-api.js';
+import { screen as rawScreen } from './screen.js';
+
+const mockScreen = vi.mocked(rawScreen);
+
+describe('createScreen', () => {
+  const catalog = {
+    htmlLogin: { name: 'html-login', elements: { username: 'username', password: 'password' } },
+    customerInfo: { name: 'customer-info', elements: { custNum: 'custNum' } },
+  } as const;
+
+  beforeEach(() => {
+    mockScreen.mockReset();
+  });
+
+  it('returns a callable function', () => {
+    const screen = createScreen(catalog);
+    expect(typeof screen).toBe('function');
+  });
+
+  it('delegates name and options to the underlying screen()', () => {
+    const fakeResult = {} as ReturnType<typeof rawScreen>;
+    mockScreen.mockReturnValue(fakeResult);
+
+    const screen = createScreen(catalog);
+    const options = { overlay: true } as Parameters<typeof rawScreen>[1];
+    const result = screen('html-login', options);
+
+    expect(mockScreen).toHaveBeenCalledOnce();
+    expect(mockScreen).toHaveBeenCalledWith('html-login', options);
+    expect(result).toBe(fakeResult);
+  });
+
+  it('passes undefined options through when called without options', () => {
+    mockScreen.mockReturnValue({} as ReturnType<typeof rawScreen>);
+    const screen = createScreen(catalog);
+    screen('customer-info');
+    expect(mockScreen).toHaveBeenCalledWith('customer-info', undefined);
+  });
+
+  it('each createScreen call returns a distinct function', () => {
+    const screen1 = createScreen(catalog);
+    const screen2 = createScreen(catalog);
+    expect(screen1).not.toBe(screen2);
+  });
+});

--- a/packages/core/src/typed-screen.ts
+++ b/packages/core/src/typed-screen.ts
@@ -1,10 +1,11 @@
+import path from 'node:path';
 import type { ScreenComparison, ElementConfig } from './types.js';
 import { ScreenResult } from './screen-result.js';
 import type { Page } from '@playwright/test';
 
 /**
- * Type-safe screen configuration
- * Extracts element names as literal types for compile-time safety
+ * @deprecated Use `createScreen` from the package root instead.
+ * `defineTypedScreen` will be removed in the next major version.
  */
 export interface TypedScreenConfig<TElements extends readonly ElementConfig[]> {
   name: string;
@@ -14,14 +15,11 @@ export interface TypedScreenConfig<TElements extends readonly ElementConfig[]> {
   debug?: boolean | undefined;
 }
 
-/**
- * Extract element names from config as literal union type
- */
 type ExtractElementNames<T extends readonly ElementConfig[]> = T[number]['name'];
 
 /**
- * Type-safe screen result wrapper
- * Provides compile-time checking of element names
+ * @deprecated Use `createScreen` from the package root instead.
+ * `TypedScreenResult` will be removed in the next major version.
  */
 export class TypedScreenResult<TElements extends readonly ElementConfig[]> extends ScreenResult {
   constructor(
@@ -32,10 +30,6 @@ export class TypedScreenResult<TElements extends readonly ElementConfig[]> exten
     super(comparison, page);
   }
 
-  /**
-   * Get an element by name with type safety
-   * TypeScript will error if you use a name that doesn't exist in the config
-   */
   element<TName extends ExtractElementNames<TElements>>(
     name: TName
   ): ReturnType<ScreenResult['element']> {
@@ -44,8 +38,8 @@ export class TypedScreenResult<TElements extends readonly ElementConfig[]> exten
 }
 
 /**
- * Create a type-safe screen configuration
- * Use this instead of defineScreen for full type safety
+ * @deprecated Use `createScreen` from the package root instead.
+ * `defineTypedScreen` will be removed in the next major version.
  */
 export function defineTypedScreen<
   const TElements extends readonly ElementConfig[]
@@ -56,8 +50,6 @@ export function defineTypedScreen<
   elements: TElements;
   debug?: boolean;
 }): TypedScreenConfig<TElements> {
-  const path = require('path');
-  
   const blankScreenPath = path.join(
     config.baseDir,
     config.blankScreen || 'blank.png'
@@ -87,7 +79,7 @@ export function defineTypedScreen<
     } else if (el.sectionTemplatePath) {
       elementConfig.sectionTemplatePath = el.sectionTemplatePath;
     }
-    
+
     if ('animated' in el && el.animated) {
       elementConfig.animated = el.animated;
     }
@@ -103,14 +95,14 @@ export function defineTypedScreen<
     blankScreenPath,
     elementConfigs,
   };
-  
+
   if (config.baseDir !== undefined) {
     result.baseDir = config.baseDir;
   }
-  
+
   if (config.debug !== undefined) {
     result.debug = config.debug;
   }
-  
+
   return result;
 }


### PR DESCRIPTION
## Summary

Four issues resolved in one PR — all touch the typed catalog API surface:

- **Closes #75** — `ScreenName` now conditionally falls back to `string` when the catalog is empty, so `createScreen(screens)(name)` degrades gracefully instead of failing with cryptic "not assignable to type 'never'" errors.
- **Closes #78** — reorder the emitted type aliases in `generated.ts` so `ScreenName` is declared before `_ScreenKey`, eliminating the forward reference that would trigger `@typescript-eslint/no-use-before-define` in consumer projects.
- **Closes #76** — `@deprecated` JSDoc added to `defineTypedScreen`, `TypedScreenResult`, and `TypedScreenConfig` pointing to `createScreen`; replaced the CJS `require('path')` inside `defineTypedScreen` with a static ESM `import`.
- **Closes #77** — new `screen-api.test.ts` covering `createScreen`: returns a function, delegates name + options to the underlying `screen()`, passes `undefined` options through, and produces a distinct function per factory call.

## Test plan

- [x] 111/111 tests pass (up from 107 before this branch)
- [x] New assertion: `expect(src).toContain('keyof typeof screens extends never')` confirms the empty-catalog fallback is emitted
- [x] `screen-api.test.ts` mocks `screen.js` to isolate the unit from the `@playwright/test` dependency chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)