### PR TITLE
feat: TypedResult Pick + Strategies.Ocr global charset defaults and inference

### DIFF
--- a/packages/core/src/field-extractor.ts
+++ b/packages/core/src/field-extractor.ts
@@ -1,6 +1,6 @@
 import { VisionUtil } from './utils/vision.js';
 import type { Rect, MatchResult } from './utils/vision.js';
-import { OCRUtil, charsetForField, pickFromOptions } from './utils/ocr.js';
+import { OCRUtil, charsetForField, pickFromOptions, resolveOcrCharset } from './utils/ocr.js';
 import * as fs from 'fs/promises';
 import { ElementType } from './types.js';
 import type { ElementConfig, ElementResult, ScreenComparison } from './types.js';
@@ -408,7 +408,8 @@ export class FieldExtractor {
     let traceImage: Buffer;
     let traceName: string;
     if (this.visionUtil.hasEnoughInk(ocrImage, 3)) {
-      const charset = charsetForField(name, type, charsetPreset);
+      const resolvedPreset = charsetPreset ?? resolveOcrCharset(name);
+      const charset = charsetForField(name, type, resolvedPreset);
       const charsetOpt = charset !== undefined ? { charset } : {};
       const prep = this.visionUtil.ocrPrepOptions(ocrImage, charsetOpt);
       const prepared = this.visionUtil.prepareForOcr(ocrImage, prep.scale, { ...prep, ...charsetOpt });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,7 @@ export type {
 
 export { ocrTextMatches } from './utils/ocr.js';
 export type { Charset, FieldRead, OcrOverflow, OcrSwaps } from './utils/ocr.js';
-export type { Strategies } from './screen.js';
+export { Strategies } from './screen.js';
+export type { OcrStrategy } from './screen.js';
 export { createScreen } from './screen-api.js';
 export type { TypedResult } from './screen-api.js';

--- a/packages/core/src/screen-api.ts
+++ b/packages/core/src/screen-api.ts
@@ -16,7 +16,22 @@ type CatalogElementName<
 export type TypedResult<
   T extends Record<string, { name: string; elements: Record<string, string> }>,
   S extends T[keyof T]['name'],
-> = Omit<ScreenResult, 'element'> & {
+> = Pick<
+  ScreenResult,
+  | 'waitFor'
+  | 'refresh'
+  | 'waitForElement'
+  | 'allElements'
+  | 'filledElements'
+  | 'emptyElements'
+  | 'count'
+  | 'filledCount'
+  | 'emptyCount'
+  | 'hasElement'
+  | 'raw'
+  | 'elementResult'
+  | 'matchOptions'
+> & {
   element(name: CatalogElementName<T, S>): ScreenElement;
 };
 

--- a/packages/core/src/screen-result.ts
+++ b/packages/core/src/screen-result.ts
@@ -5,7 +5,7 @@ import type { Page } from '@playwright/test';
 import { ocrStep } from './ocr-step.js';
 import { hideOcrOverlay, overlayBoxesFromResult, showOcrOverlay } from './ocr-overlay.js';
 import { unhoverBeforeCapture } from './unhover.js';
-import { resolveCharsetSwaps } from './utils/ocr.js';
+import { resolveCharsetSwaps, getOcrStrategy } from './utils/ocr.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -125,10 +125,11 @@ export class ScreenResult {
     if (!config) return {};
     const part = partName ? config.parts?.find(row => row.name === partName) : undefined;
     const match: MatchOptions = {};
-    // Resolution order respects specificity: part > config, explicit > charset-derived.
-    const swaps = part?.swaps ?? resolveCharsetSwaps(part?.charset) ?? config.swaps ?? resolveCharsetSwaps(config.charset);
-    const overflow = part?.overflow ?? config.overflow;
-    const read = part?.read ?? config.read;
+    // Resolution order: part > config > Strategies.Ocr > (built-in defaults in element.ts)
+    const strategy = getOcrStrategy();
+    const swaps = part?.swaps ?? resolveCharsetSwaps(part?.charset) ?? config.swaps ?? resolveCharsetSwaps(config.charset) ?? strategy?.swaps;
+    const overflow = part?.overflow ?? config.overflow ?? strategy?.overflow;
+    const read = part?.read ?? config.read ?? strategy?.read;
     if (swaps) match.swaps = swaps;
     if (overflow) match.overflow = overflow;
     if (read) match.read = read;

--- a/packages/core/src/screen.ts
+++ b/packages/core/src/screen.ts
@@ -7,7 +7,7 @@ import type { ScreenConfig } from './screen-config.js';
 import { loadScreen } from './configure.js';
 import { FieldExtractor } from './field-extractor.js';
 import { ScreenResult } from './screen-result.js';
-import { cleanupOCR, getOCRUtil, setCharsetRegistry, type Charset } from './utils/ocr.js';
+import { cleanupOCR, getOCRUtil, setCharsetRegistry, setOcrStrategy, type Charset, type OcrStrategy } from './utils/ocr.js';
 import { ensureCvReady } from './utils/vision.js';
 
 export interface BindOcrScreenOptions {
@@ -48,7 +48,20 @@ export function bindOcrScreen(
 
 export interface Strategies {
   charsets?: Record<string, Charset>;
+  ocr?: OcrStrategy;
 }
+
+export { type OcrStrategy };
+
+/** Runtime factories for strategy slots. */
+export const Strategies = {
+  Ocr: {
+    /** Create an Ocr strategy with global charset defaults, name-inference, and swaps. */
+    default(options: OcrStrategy): OcrStrategy {
+      return options;
+    },
+  },
+};
 
 interface InitOptions {
   page: Page;
@@ -92,6 +105,9 @@ export async function init(options: InitOptions): Promise<void> {
 
   if (options.strategies?.charsets) {
     setCharsetRegistry(options.strategies.charsets);
+  }
+  if (options.strategies?.ocr !== undefined) {
+    setOcrStrategy(options.strategies.ocr);
   }
 
   try {
@@ -147,6 +163,7 @@ export async function release(): Promise<void> {
   initState?.extractor.cleanup();
   initState = null;
   setCharsetRegistry({});
+  setOcrStrategy(undefined);
   await cleanupOCR();
 }
 

--- a/packages/core/src/utils/ocr.test.ts
+++ b/packages/core/src/utils/ocr.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { ocrTextMatches, normalizeOcrText, charsetForField } from './ocr.js';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ocrTextMatches, normalizeOcrText, charsetForField, setOcrStrategy, getOcrStrategy, resolveOcrCharset } from './ocr.js';
 
 // ---------------------------------------------------------------------------
 // ocrTextMatches
@@ -176,5 +176,68 @@ describe('charsetForField', () => {
     expect(charset).toContain('A');
     expect(charset).toContain('0');
     expect(charset).toContain(' ');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setOcrStrategy / getOcrStrategy / resolveOcrCharset
+// ---------------------------------------------------------------------------
+
+describe('setOcrStrategy / getOcrStrategy', () => {
+  beforeEach(() => setOcrStrategy(undefined));
+  afterEach(() => setOcrStrategy(undefined));
+
+  it('returns undefined when no strategy is set', () => {
+    expect(getOcrStrategy()).toBeUndefined();
+  });
+
+  it('stores and returns the strategy', () => {
+    const strategy = { defaultCharset: 'digits' };
+    setOcrStrategy(strategy);
+    expect(getOcrStrategy()).toBe(strategy);
+  });
+
+  it('clears the strategy when set to undefined', () => {
+    setOcrStrategy({ defaultCharset: 'digits' });
+    setOcrStrategy(undefined);
+    expect(getOcrStrategy()).toBeUndefined();
+  });
+});
+
+describe('resolveOcrCharset', () => {
+  beforeEach(() => setOcrStrategy(undefined));
+  afterEach(() => setOcrStrategy(undefined));
+
+  it('returns undefined when no strategy is set', () => {
+    expect(resolveOcrCharset('phoneNumber')).toBeUndefined();
+  });
+
+  it('returns defaultCharset when no infer map matches', () => {
+    setOcrStrategy({ defaultCharset: 'alnum' });
+    expect(resolveOcrCharset('customerName')).toBe('alnum');
+  });
+
+  it('returns undefined when strategy has neither infer nor defaultCharset', () => {
+    setOcrStrategy({ swaps: { '@': 'Q' } });
+    expect(resolveOcrCharset('email')).toBeUndefined();
+  });
+
+  it('matches infer map by substring (case-insensitive)', () => {
+    setOcrStrategy({ infer: { phone: 'digits', email: 'email' } });
+    expect(resolveOcrCharset('phoneNumber')).toBe('digits');
+    expect(resolveOcrCharset('PHONE')).toBe('digits');
+    expect(resolveOcrCharset('emailAddress')).toBe('email');
+  });
+
+  it('infer match takes priority over defaultCharset', () => {
+    setOcrStrategy({ defaultCharset: 'text', infer: { vin: 'vin' } });
+    expect(resolveOcrCharset('vehicleVin')).toBe('vin');
+    expect(resolveOcrCharset('customerName')).toBe('text');
+  });
+
+  it('returns first matching infer key when multiple keys match', () => {
+    setOcrStrategy({ infer: { phone: 'digits', phoneNumber: 'alnum' } });
+    const result = resolveOcrCharset('phoneNumber');
+    expect(['digits', 'alnum']).toContain(result);
   });
 });

--- a/packages/core/src/utils/ocr.ts
+++ b/packages/core/src/utils/ocr.ts
@@ -21,7 +21,22 @@ export interface Charset {
   swaps?: OcrSwaps;
 }
 
+/** Global OCR strategy set by init(). */
+export interface OcrStrategy {
+  /** Fallback charset when an element has no explicit charset and name-inference finds nothing. */
+  defaultCharset?: string;
+  /** Map from element-name substring (case-insensitive) → charset name. Checked before built-in heuristics. */
+  infer?: Record<string, string>;
+  /** Global swaps applied when no element-level swaps are configured. */
+  swaps?: OcrSwaps;
+  /** Global overflow applied when no element-level overflow is configured. */
+  overflow?: OcrOverflow;
+  /** Global read mode applied when no element-level read is configured. */
+  read?: FieldRead;
+}
+
 let charsetRegistry: Record<string, Charset> = {};
+let globalOcrStrategy: OcrStrategy | undefined;
 
 /**
  * Called by `init()` to register user-defined charsets.
@@ -30,6 +45,30 @@ let charsetRegistry: Record<string, Charset> = {};
  */
 export function setCharsetRegistry(registry: Record<string, Charset>): void {
   charsetRegistry = { ...charsetRegistry, ...registry };
+}
+
+export function setOcrStrategy(strategy: OcrStrategy | undefined): void {
+  globalOcrStrategy = strategy;
+}
+
+export function getOcrStrategy(): OcrStrategy | undefined {
+  return globalOcrStrategy;
+}
+
+/**
+ * Resolve a charset using Strategies.Ocr: checks `infer` map first (substring match),
+ * then falls back to `defaultCharset`. Returns undefined when no strategy is set.
+ */
+export function resolveOcrCharset(elementName: string): string | undefined {
+  if (!globalOcrStrategy) return undefined;
+  const { infer, defaultCharset } = globalOcrStrategy;
+  if (infer) {
+    const lower = elementName.toLowerCase();
+    for (const [substring, charset] of Object.entries(infer)) {
+      if (lower.includes(substring.toLowerCase())) return charset;
+    }
+  }
+  return defaultCharset;
 }
 
 /** Look up a registered charset by name, or return undefined if not found. */


### PR DESCRIPTION
## Summary

Closes #79. Closes #52.

### TypedResult — Pick instead of Omit (#79)

`TypedResult<T,S>` was defined as `Omit<ScreenResult, 'element'> & { element(narrow) }`. `Omit` strips only the one named key and passes through everything else, including internal coordination methods:

- `markDirty()` — internal dirty-state flag
- `ensureFresh()` — internal refresh trigger  
- `paintOverlay()` / `hideOverlay()` — internal debug rendering

**Fix:** replace `Omit` with an explicit `Pick` of the intentional public surface: `waitFor`, `refresh`, `waitForElement`, `element` (narrowed), `allElements`, `filledElements`, `emptyElements`, `count`, `filledCount`, `emptyCount`, `hasElement`, `raw`, `elementResult`, `matchOptions`.

### Strategies.Ocr — global OCR defaults (#52)

Adds a `Strategies.Ocr` slot to `init({ strategies })` for setting global OCR defaults that apply across all screens when no element-level config overrides them.

```ts
await init({
  page,
  strategies: {
    ocr: Strategies.Ocr.default({
      defaultCharset: 'digits',          // fallback when name inference misses
      infer: { phone: 'digits', email: 'email' }, // element-name → charset
      swaps: { '@': ['Q', 'O'] },        // global OCR glyph substitutions
      overflow: 'end',                   // global overflow mode
      read: 'clipboard',                 // global read mode
    }),
  },
});
```

**Resolution order** (most specific wins): call options → element/part config → `Strategies.Ocr` → built-in `charsetForField` heuristics.

## Test plan

- [x] `tsc --noEmit` clean
- [x] 120/120 tests pass (9 new tests for `setOcrStrategy`, `getOcrStrategy`, `resolveOcrCharset`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)