### PR TITLE
feat: init({ read }) env-level override for FieldRead

### DIFF
--- a/packages/core/src/screen-result.test.ts
+++ b/packages/core/src/screen-result.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ScreenResult } from './screen-result.js';
+import { setOcrStrategy } from './utils/ocr.js';
+import type { ScreenConfig } from './screen-config.js';
+
+function makeConfig(read?: 'ocr' | 'clipboard'): ScreenConfig {
+  return {
+    name: 'test-screen',
+    blankScreenPath: '/fake/blank.png',
+    elementConfigs: [
+      {
+        name: 'field1',
+        blankFormPath: '/fake/blank.png',
+        labelNeedle: '/fake/label.png',
+        ...(read !== undefined && { read }),
+      },
+    ],
+  } as unknown as ScreenConfig;
+}
+
+function makeHost(
+  config: ScreenConfig,
+  initRead?: 'ocr' | 'clipboard',
+): ScreenResult {
+  return ScreenResult.bind(
+    {} as never,
+    {} as never,
+    config,
+    '/tmp',
+    { ...(initRead !== undefined && { initRead }) },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// matchOptions() — read resolution order
+// ---------------------------------------------------------------------------
+
+describe('matchOptions() — read resolution order', () => {
+  beforeEach(() => setOcrStrategy(undefined));
+  afterEach(() => setOcrStrategy(undefined));
+
+  it('returns no read when nothing is configured', () => {
+    const result = makeHost(makeConfig());
+    expect(result.matchOptions('field1').read).toBeUndefined();
+  });
+
+  it('picks up read from Strategies.Ocr (lowest precedence)', () => {
+    setOcrStrategy({ read: 'clipboard' });
+    const result = makeHost(makeConfig());
+    expect(result.matchOptions('field1').read).toBe('clipboard');
+  });
+
+  it('index.json (config.read) wins over Strategies.Ocr', () => {
+    setOcrStrategy({ read: 'clipboard' });
+    const result = makeHost(makeConfig('ocr'));
+    expect(result.matchOptions('field1').read).toBe('ocr');
+  });
+
+  it('init() level wins over index.json config.read', () => {
+    const result = makeHost(makeConfig('clipboard'), 'ocr');
+    expect(result.matchOptions('field1').read).toBe('ocr');
+  });
+
+  it('init() level wins over Strategies.Ocr', () => {
+    setOcrStrategy({ read: 'clipboard' });
+    const result = makeHost(makeConfig(), 'ocr');
+    expect(result.matchOptions('field1').read).toBe('ocr');
+  });
+});

--- a/packages/core/src/screen-result.ts
+++ b/packages/core/src/screen-result.ts
@@ -5,7 +5,7 @@ import type { Page } from '@playwright/test';
 import { ocrStep } from './ocr-step.js';
 import { hideOcrOverlay, overlayBoxesFromResult, showOcrOverlay } from './ocr-overlay.js';
 import { unhoverBeforeCapture } from './unhover.js';
-import { resolveCharsetSwaps, getOcrStrategy } from './utils/ocr.js';
+import { resolveCharsetSwaps, getOcrStrategy, type FieldRead } from './utils/ocr.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -32,6 +32,8 @@ export type ScreenHost = {
   overlay?: boolean;
   /** Override global unhoverBeforeCapture for this bind. */
   unhover?: boolean;
+  /** init()-level read override — wins over index.json, loses to call site. */
+  initRead?: FieldRead;
 };
 
 async function extractComparison(
@@ -74,7 +76,7 @@ export class ScreenResult {
     extractor: ScreenExtractor,
     screen: ScreenConfig,
     shotDir: string,
-    options: { overlay?: boolean; unhover?: boolean } = {},
+    options: { overlay?: boolean; unhover?: boolean; initRead?: FieldRead } = {},
   ): ScreenResult {
     return new ScreenResult({
       elements: [],
@@ -87,6 +89,7 @@ export class ScreenResult {
       shotDir,
       ...(options.overlay !== undefined && { overlay: options.overlay }),
       ...(options.unhover !== undefined && { unhover: options.unhover }),
+      ...(options.initRead !== undefined && { initRead: options.initRead }),
     });
   }
 
@@ -125,11 +128,11 @@ export class ScreenResult {
     if (!config) return {};
     const part = partName ? config.parts?.find(row => row.name === partName) : undefined;
     const match: MatchOptions = {};
-    // Resolution order: part > config > Strategies.Ocr > (built-in defaults in element.ts)
+    // Resolution order: part > init() override > config (index.json) > Strategies.Ocr > (built-in defaults in element.ts)
     const strategy = getOcrStrategy();
     const swaps = part?.swaps ?? resolveCharsetSwaps(part?.charset) ?? config.swaps ?? resolveCharsetSwaps(config.charset) ?? strategy?.swaps;
     const overflow = part?.overflow ?? config.overflow ?? strategy?.overflow;
-    const read = part?.read ?? config.read ?? strategy?.read;
+    const read = part?.read ?? this.host?.initRead ?? config.read ?? strategy?.read;
     if (swaps) match.swaps = swaps;
     if (overflow) match.overflow = overflow;
     if (read) match.read = read;

--- a/packages/core/src/screen.ts
+++ b/packages/core/src/screen.ts
@@ -7,7 +7,7 @@ import type { ScreenConfig } from './screen-config.js';
 import { loadScreen } from './configure.js';
 import { FieldExtractor } from './field-extractor.js';
 import { ScreenResult } from './screen-result.js';
-import { cleanupOCR, getOCRUtil, setCharsetRegistry, setOcrStrategy, type Charset, type OcrStrategy } from './utils/ocr.js';
+import { cleanupOCR, getOCRUtil, setCharsetRegistry, setOcrStrategy, type Charset, type FieldRead, type OcrStrategy } from './utils/ocr.js';
 import { ensureCvReady } from './utils/vision.js';
 
 export interface BindOcrScreenOptions {
@@ -18,6 +18,11 @@ export interface BindOcrScreenOptions {
    * Default inherits global config (true when unset).
    */
   unhover?: boolean;
+  /**
+   * Override `init({ read })` for this screen.
+   * Default inherits the init-level read mode.
+   */
+  read?: FieldRead;
 }
 
 /** Warm OCR + OpenCV (safe to call more than once). */
@@ -41,6 +46,7 @@ export function bindOcrScreen(
   return ScreenResult.bind(page, extractor, config, shotDir, {
     ...(options.overlay !== undefined && { overlay: options.overlay }),
     ...(options.unhover !== undefined && { unhover: options.unhover }),
+    ...(options.read !== undefined && { initRead: options.read }),
   });
 }
 
@@ -68,6 +74,8 @@ interface InitOptions {
   storage?: { root: string };
   devtools?: boolean;
   unhoverBeforeCapture?: boolean;
+  /** Environment-level read override. Wins over index.json; call site wins over this. */
+  read?: FieldRead;
   strategies?: Strategies;
 }
 
@@ -148,6 +156,9 @@ export function screen(
   const mergedOptions: BindOcrScreenOptions = { ...options };
   if (mergedOptions.unhover === undefined && initState.config.unhoverBeforeCapture !== undefined) {
     mergedOptions.unhover = initState.config.unhoverBeforeCapture;
+  }
+  if (mergedOptions.read === undefined && initState.config.read !== undefined) {
+    mergedOptions.read = initState.config.read;
   }
   return bindOcrScreen(
     initState.config.page,


### PR DESCRIPTION
## Summary

Closes #49.

Completes the `read` resolution order:

| Priority | Source | Example |
|---|---|---|
| 1 (highest) | Call site | `.toHaveValue(v, { read: 'clipboard' })` |
| 2 | `init({ read })` | env-level CI override |
| 3 | `index.json` (`config.read`) | per-element TM config |
| 4 | `Strategies.Ocr.read` | global strategy default |
| 5 | Element type default | — |

`init({ read: 'ocr' })` acts as an environment-level control — useful to force all reads to OCR in a CI environment where clipboard is unavailable, overriding any `"read": "clipboard"` set per-element in index.json.

`screen(name, { read: 'clipboard' })` can override the init-level default for a specific bind site.

## Test plan

- [x] `tsc --noEmit` clean
- [x] 125/125 tests pass (5 new tests in `screen-result.test.ts` covering the full resolution order)

🤖 Generated with [Claude Code](https://claude.com/claude-code)