### PR TITLE
feat: Strategies.Click/Fill/Capture + env presets (#50 #51 #55)

### DIFF
--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -9,6 +9,7 @@ import {
   type OcrSwaps,
 } from './utils/ocr.js';
 import { ocrStep, expectTimeout } from './ocr-step.js';
+import { getClickStrategy, getFillStrategy } from './strategies.js';
 
 export const VISIBLE_CONFIDENCE = 0.7;
 
@@ -479,10 +480,7 @@ export class ScreenElement {
     return ocrStep(`element('${this.label}').fill(${JSON.stringify(text)})`, async () => {
       await this.ensureLocated(options?.timeout);
       await this.withOverlay(async () => {
-        await this.clickRect(this.result.ocrLocation ?? this.result.location);
-        await this.page!.keyboard.press('ControlOrMeta+A');
-        await this.page!.keyboard.press('Backspace');
-        await this.page!.keyboard.insertText(text);
+        await getFillStrategy().fill(this.page!, this.result.ocrLocation ?? this.result.location, text);
         this.live?.markDirty();
       });
     });
@@ -550,10 +548,8 @@ export class ScreenElement {
     if (!this.page) {
       throw new Error('Page not provided. Cannot click element.');
     }
-    await this.page.mouse.click(
-      rect.x + rect.width / 2,
-      rect.y + rect.height / 2,
-    );
+    const { x, y } = getClickStrategy().getPoint(rect);
+    await this.page.mouse.click(x, y);
   }
 
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,7 @@ export type {
 export { ocrTextMatches } from './utils/ocr.js';
 export type { Charset, FieldRead, OcrOverflow, OcrSwaps } from './utils/ocr.js';
 export { Strategies } from './screen.js';
-export type { OcrStrategy } from './screen.js';
+export type { OcrStrategy, ClickStrategy, FillStrategy, CaptureStrategy } from './screen.js';
+export { presets, mergeInitOptions } from './presets.js';
 export { createScreen } from './screen-api.js';
 export type { TypedResult } from './screen-api.js';

--- a/packages/core/src/presets.ts
+++ b/packages/core/src/presets.ts
@@ -1,0 +1,63 @@
+import { Strategies } from './strategies.js';
+
+/**
+ * Environment presets — spread into `init()` to configure strategies for common runtimes.
+ *
+ *   await init({ page, storage: { root }, ...presets.guacamole });
+ */
+export const presets = {
+  /**
+   * Apache Guacamole / HTML5 remote desktop.
+   * Triple-click select (Ctrl+A is unreliable over the protocol),
+   * clipboard read for OCR, and common remote-font character swaps.
+   */
+  guacamole: {
+    strategies: {
+      fill: Strategies.Fill.tripleClickType(),
+      ocr: Strategies.Ocr.default({
+        read: 'clipboard' as const,
+        swaps: {
+          "'": ["'", '’'],
+          '"': ['“', '”'],
+        },
+      }),
+    },
+  },
+
+  /**
+   * Windows RDP / remote desktop.
+   * Char-by-char typing avoids clipboard paste issues over the protocol.
+   */
+  rdp: {
+    strategies: {
+      fill: Strategies.Fill.charByChar({ delay: 30 }),
+    },
+  },
+
+  /**
+   * Webview / embedded browser.
+   * Uses the standard select-all-type recipe with insertText.
+   */
+  webview: {
+    strategies: {
+      fill: Strategies.Fill.selectAllType(),
+    },
+  },
+} as const;
+
+/**
+ * Deep-merge two `init()` option objects, combining their `strategies` slots.
+ * Useful when a preset and per-test options both configure strategies.
+ *
+ *   const opts = mergeInitOptions(presets.guacamole, { strategies: { click: Strategies.Click.offset({ x: 0.1, y: 0.5 }) } });
+ */
+export function mergeInitOptions<T extends { strategies?: object }>(
+  base: T,
+  overrides: Partial<T>,
+): T {
+  return {
+    ...base,
+    ...overrides,
+    strategies: { ...base.strategies, ...overrides.strategies },
+  } as T;
+}

--- a/packages/core/src/screen.ts
+++ b/packages/core/src/screen.ts
@@ -7,9 +7,18 @@ import type { ScreenConfig } from './screen-config.js';
 import { loadScreen } from './configure.js';
 import { FieldExtractor } from './field-extractor.js';
 import { ScreenResult } from './screen-result.js';
-import { cleanupOCR, getOCRUtil, setCharsetRegistry, setOcrStrategy, type Charset, type FieldRead, type OcrStrategy } from './utils/ocr.js';
+import { cleanupOCR, getOCRUtil, setCharsetRegistry, setOcrStrategy, type Charset, type FieldRead } from './utils/ocr.js';
 import { setUnhoverPoint } from './unhover.js';
 import { ensureCvReady } from './utils/vision.js';
+import {
+  Strategies,
+  setClickStrategy,
+  setFillStrategy,
+  type ClickStrategy,
+  type FillStrategy,
+  type CaptureStrategy,
+  type OcrStrategy,
+} from './strategies.js';
 
 export interface BindOcrScreenOptions {
   shotDir?: string;
@@ -65,19 +74,12 @@ export function bindOcrScreen(
 export interface Strategies {
   charsets?: Record<string, Charset>;
   ocr?: OcrStrategy;
+  click?: ClickStrategy;
+  fill?: FillStrategy;
+  capture?: CaptureStrategy;
 }
 
-export { type OcrStrategy };
-
-/** Runtime factories for strategy slots. */
-export const Strategies = {
-  Ocr: {
-    /** Create an Ocr strategy with global charset defaults, name-inference, and swaps. */
-    default(options: OcrStrategy): OcrStrategy {
-      return options;
-    },
-  },
-};
+export { Strategies, type OcrStrategy, type ClickStrategy, type FillStrategy, type CaptureStrategy };
 
 interface InitOptions {
   page: Page;
@@ -130,6 +132,17 @@ export async function init(options: InitOptions): Promise<void> {
 
   if (options.unhoverPoint !== undefined) {
     setUnhoverPoint(options.unhoverPoint);
+  }
+  if (options.strategies?.capture !== undefined) {
+    const cap = options.strategies.capture;
+    initState.config.unhoverBeforeCapture = cap.unhover;
+    if (cap.unhoverPoint !== undefined) setUnhoverPoint(cap.unhoverPoint);
+  }
+  if (options.strategies?.click !== undefined) {
+    setClickStrategy(options.strategies.click);
+  }
+  if (options.strategies?.fill !== undefined) {
+    setFillStrategy(options.strategies.fill);
   }
   if (options.strategies?.charsets) {
     setCharsetRegistry(options.strategies.charsets);
@@ -203,6 +216,8 @@ export async function release(): Promise<void> {
   initState?.extractor.cleanup();
   initState = null;
   setUnhoverPoint(undefined);
+  setClickStrategy(undefined);
+  setFillStrategy(undefined);
   setCharsetRegistry({});
   setOcrStrategy(undefined);
   await cleanupOCR();

--- a/packages/core/src/strategies.test.ts
+++ b/packages/core/src/strategies.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Page } from '@playwright/test';
+import { Strategies, setClickStrategy, setFillStrategy, getClickStrategy, getFillStrategy } from './strategies.js';
+import type { Rect } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const rect: Rect = { x: 100, y: 200, width: 80, height: 40 };
+
+function mockPage() {
+  return {
+    mouse: { click: vi.fn(), tripleclick: vi.fn() },
+    keyboard: {
+      press: vi.fn(),
+      type: vi.fn(),
+      insertText: vi.fn(),
+    },
+  } as unknown as Page;
+}
+
+// ---------------------------------------------------------------------------
+// Strategies.Click
+// ---------------------------------------------------------------------------
+
+describe('Strategies.Click.center()', () => {
+  it('returns the midpoint of the rect', () => {
+    const pt = Strategies.Click.center().getPoint(rect);
+    expect(pt).toEqual({ x: 140, y: 220 });
+  });
+});
+
+describe('Strategies.Click.offset()', () => {
+  it('{ x: 0, y: 0.5 } → left-center', () => {
+    const pt = Strategies.Click.offset({ x: 0, y: 0.5 }).getPoint(rect);
+    expect(pt).toEqual({ x: 100, y: 220 });
+  });
+
+  it('{ x: 1, y: 1 } → bottom-right corner', () => {
+    const pt = Strategies.Click.offset({ x: 1, y: 1 }).getPoint(rect);
+    expect(pt).toEqual({ x: 180, y: 240 });
+  });
+
+  it('{ x: 0.5, y: 0.5 } → same as center', () => {
+    const pt = Strategies.Click.offset({ x: 0.5, y: 0.5 }).getPoint(rect);
+    expect(pt).toEqual(Strategies.Click.center().getPoint(rect));
+  });
+});
+
+describe('Strategies.Click.point(fn)', () => {
+  it('delegates to the provided function', () => {
+    const fn = vi.fn().mockReturnValue({ x: 10, y: 20 });
+    const pt = Strategies.Click.point(fn).getPoint(rect);
+    expect(fn).toHaveBeenCalledWith(rect);
+    expect(pt).toEqual({ x: 10, y: 20 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Strategies.Fill
+// ---------------------------------------------------------------------------
+
+describe('Strategies.Fill.selectAllType()', () => {
+  it('click → Ctrl+A → Backspace → insertText', async () => {
+    const page = mockPage();
+    await Strategies.Fill.selectAllType().fill(page, rect, 'hello');
+    expect(page.mouse.click).toHaveBeenCalledWith(140, 220);
+    expect(page.keyboard.press).toHaveBeenCalledWith('ControlOrMeta+A');
+    expect(page.keyboard.press).toHaveBeenCalledWith('Backspace');
+    expect(page.keyboard.insertText).toHaveBeenCalledWith('hello');
+    expect(page.keyboard.type).not.toHaveBeenCalled();
+  });
+});
+
+describe('Strategies.Fill.tripleClickType()', () => {
+  it('triple-click then insertText (no Ctrl+A)', async () => {
+    const page = mockPage();
+    await Strategies.Fill.tripleClickType().fill(page, rect, 'hello');
+    expect(page.mouse.click).toHaveBeenCalledWith(140, 220, { clickCount: 3 });
+    expect(page.keyboard.insertText).toHaveBeenCalledWith('hello');
+    expect(page.keyboard.press).not.toHaveBeenCalled();
+  });
+});
+
+describe('Strategies.Fill.clearAndType()', () => {
+  it('click → Ctrl+A → Backspace → keyboard.type', async () => {
+    const page = mockPage();
+    await Strategies.Fill.clearAndType().fill(page, rect, 'hello');
+    expect(page.mouse.click).toHaveBeenCalledWith(140, 220);
+    expect(page.keyboard.press).toHaveBeenCalledWith('ControlOrMeta+A');
+    expect(page.keyboard.press).toHaveBeenCalledWith('Backspace');
+    expect(page.keyboard.type).toHaveBeenCalledWith('hello');
+    expect(page.keyboard.insertText).not.toHaveBeenCalled();
+  });
+});
+
+describe('Strategies.Fill.typeOnly()', () => {
+  it('keyboard.type without any click or selection', async () => {
+    const page = mockPage();
+    await Strategies.Fill.typeOnly().fill(page, rect, 'hello');
+    expect(page.keyboard.type).toHaveBeenCalledWith('hello');
+    expect(page.mouse.click).not.toHaveBeenCalled();
+    expect(page.keyboard.press).not.toHaveBeenCalled();
+  });
+});
+
+describe('Strategies.Fill.charByChar()', () => {
+  it('click then keyboard.type with delay', async () => {
+    const page = mockPage();
+    await Strategies.Fill.charByChar({ delay: 30 }).fill(page, rect, 'hi');
+    expect(page.mouse.click).toHaveBeenCalledWith(140, 220);
+    expect(page.keyboard.type).toHaveBeenCalledWith('hi', { delay: 30 });
+  });
+});
+
+describe('Strategies.Fill.insertText()', () => {
+  it('click then insertText without selection', async () => {
+    const page = mockPage();
+    await Strategies.Fill.insertText().fill(page, rect, 'hello');
+    expect(page.mouse.click).toHaveBeenCalledWith(140, 220);
+    expect(page.keyboard.insertText).toHaveBeenCalledWith('hello');
+    expect(page.keyboard.press).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Strategies.Capture
+// ---------------------------------------------------------------------------
+
+describe('Strategies.Capture', () => {
+  it('unhover() sets unhover:true with no point by default', () => {
+    const cap = Strategies.Capture.unhover();
+    expect(cap.unhover).toBe(true);
+    expect(cap.unhoverPoint).toBeUndefined();
+  });
+
+  it('unhover({ point }) stores the point', () => {
+    const cap = Strategies.Capture.unhover({ point: { x: 5, y: 10 } });
+    expect(cap.unhover).toBe(true);
+    expect(cap.unhoverPoint).toEqual({ x: 5, y: 10 });
+  });
+
+  it('noop() sets unhover:false', () => {
+    expect(Strategies.Capture.noop().unhover).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Module-level state: setClickStrategy / setFillStrategy
+// ---------------------------------------------------------------------------
+
+describe('module-level strategy state', () => {
+  afterEach(() => {
+    setClickStrategy(undefined);
+    setFillStrategy(undefined);
+  });
+
+  it('getClickStrategy() returns center by default', () => {
+    const pt = getClickStrategy().getPoint(rect);
+    expect(pt).toEqual({ x: 140, y: 220 });
+  });
+
+  it('setClickStrategy() overrides the default', () => {
+    setClickStrategy(Strategies.Click.offset({ x: 0, y: 0 }));
+    const pt = getClickStrategy().getPoint(rect);
+    expect(pt).toEqual({ x: 100, y: 200 });
+  });
+
+  it('setClickStrategy(undefined) restores the default', () => {
+    setClickStrategy(Strategies.Click.offset({ x: 0, y: 0 }));
+    setClickStrategy(undefined);
+    const pt = getClickStrategy().getPoint(rect);
+    expect(pt).toEqual({ x: 140, y: 220 });
+  });
+
+  it('getFillStrategy() uses selectAllType by default', async () => {
+    const page = mockPage();
+    await getFillStrategy().fill(page, rect, 'x');
+    expect(page.keyboard.press).toHaveBeenCalledWith('ControlOrMeta+A');
+  });
+
+  it('setFillStrategy() overrides the default', async () => {
+    setFillStrategy(Strategies.Fill.typeOnly());
+    const page = mockPage();
+    await getFillStrategy().fill(page, rect, 'x');
+    expect(page.keyboard.type).toHaveBeenCalledWith('x');
+    expect(page.keyboard.press).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// presets sanity check
+// ---------------------------------------------------------------------------
+
+describe('presets', () => {
+  beforeEach(() => { setFillStrategy(undefined); });
+  afterEach(() => { setFillStrategy(undefined); });
+
+  it('presets.guacamole.strategies.fill uses tripleClickType', async () => {
+    const { presets } = await import('./presets.js');
+    const page = mockPage();
+    await presets.guacamole.strategies.fill.fill(page, rect, 'val');
+    expect(page.mouse.click).toHaveBeenCalledWith(140, 220, { clickCount: 3 });
+  });
+
+  it('presets.rdp.strategies.fill uses charByChar with delay 30', async () => {
+    const { presets } = await import('./presets.js');
+    const page = mockPage();
+    await presets.rdp.strategies.fill.fill(page, rect, 'val');
+    expect(page.keyboard.type).toHaveBeenCalledWith('val', { delay: 30 });
+  });
+});

--- a/packages/core/src/strategies.ts
+++ b/packages/core/src/strategies.ts
@@ -1,0 +1,154 @@
+import type { Page } from '@playwright/test';
+import type { Rect } from './types.js';
+import type { OcrStrategy } from './utils/ocr.js';
+export type { OcrStrategy };
+
+// ─── Strategy interfaces ──────────────────────────────────────────────────────
+
+export interface ClickStrategy {
+  /** Returns the point to click within the element's bounding rect. */
+  getPoint(rect: Rect): { x: number; y: number };
+}
+
+export interface FillStrategy {
+  /** Full fill sequence: focus, select, type. Owns all keyboard/mouse steps. */
+  fill(page: Page, rect: Rect, text: string): Promise<void>;
+}
+
+export interface CaptureStrategy {
+  unhover: boolean;
+  unhoverPoint?: { x: number; y: number };
+}
+
+// ─── Module-level state ───────────────────────────────────────────────────────
+
+let globalClickStrategy: ClickStrategy | undefined;
+let globalFillStrategy: FillStrategy | undefined;
+
+export function setClickStrategy(s: ClickStrategy | undefined): void {
+  globalClickStrategy = s;
+}
+export function setFillStrategy(s: FillStrategy | undefined): void {
+  globalFillStrategy = s;
+}
+
+export function getClickStrategy(): ClickStrategy {
+  return globalClickStrategy ?? Strategies.Click.center();
+}
+export function getFillStrategy(): FillStrategy {
+  return globalFillStrategy ?? Strategies.Fill.selectAllType();
+}
+
+// ─── Strategies namespace ─────────────────────────────────────────────────────
+
+export const Strategies = {
+  Ocr: {
+    /** Create an Ocr strategy with global charset defaults, name-inference, and swaps. */
+    default(options: OcrStrategy): OcrStrategy {
+      return options;
+    },
+  },
+
+  Click: {
+    /** Click the center of the element rect. Default behavior. */
+    center(): ClickStrategy {
+      return { getPoint: (r) => ({ x: r.x + r.width / 2, y: r.y + r.height / 2 }) };
+    },
+
+    /**
+     * Click at a fractional offset within the element rect.
+     * `{ x: 0, y: 0.5 }` → left-center; `{ x: 0.5, y: 0.5 }` → center.
+     */
+    offset(pct: { x: number; y: number }): ClickStrategy {
+      return { getPoint: (r) => ({ x: r.x + r.width * pct.x, y: r.y + r.height * pct.y }) };
+    },
+
+    /** Click at a custom point derived from the rect. */
+    point(fn: (rect: Rect) => { x: number; y: number }): ClickStrategy {
+      return { getPoint: fn };
+    },
+  },
+
+  Fill: {
+    /** Click → Ctrl/Cmd+A → Backspace → insertText. Default behavior. */
+    selectAllType(): FillStrategy {
+      return {
+        async fill(page, rect, text) {
+          await page.mouse.click(rect.x + rect.width / 2, rect.y + rect.height / 2);
+          await page.keyboard.press('ControlOrMeta+A');
+          await page.keyboard.press('Backspace');
+          await page.keyboard.insertText(text);
+        },
+      };
+    },
+
+    /**
+     * Triple-click (selects all in remote/Guacamole envs) → insertText.
+     * Preferred over selectAllType for environments that don't relay Ctrl+A.
+     */
+    tripleClickType(): FillStrategy {
+      return {
+        async fill(page, rect, text) {
+          await page.mouse.click(rect.x + rect.width / 2, rect.y + rect.height / 2, { clickCount: 3 });
+          await page.keyboard.insertText(text);
+        },
+      };
+    },
+
+    /** Click → Ctrl/Cmd+A → Backspace → keyboard.type (slower, fires key events). */
+    clearAndType(): FillStrategy {
+      return {
+        async fill(page, rect, text) {
+          await page.mouse.click(rect.x + rect.width / 2, rect.y + rect.height / 2);
+          await page.keyboard.press('ControlOrMeta+A');
+          await page.keyboard.press('Backspace');
+          await page.keyboard.type(text);
+        },
+      };
+    },
+
+    /** Type into the currently focused element without clicking or clearing. */
+    typeOnly(): FillStrategy {
+      return {
+        async fill(page, _rect, text) {
+          await page.keyboard.type(text);
+        },
+      };
+    },
+
+    /**
+     * Click to focus, then type one character at a time with a delay.
+     * Use in environments where rapid key events are dropped.
+     */
+    charByChar(options: { delay: number }): FillStrategy {
+      return {
+        async fill(page, rect, text) {
+          await page.mouse.click(rect.x + rect.width / 2, rect.y + rect.height / 2);
+          await page.keyboard.type(text, { delay: options.delay });
+        },
+      };
+    },
+
+    /** Click to focus, then use insertText without selecting/clearing first. */
+    insertText(): FillStrategy {
+      return {
+        async fill(page, rect, text) {
+          await page.mouse.click(rect.x + rect.width / 2, rect.y + rect.height / 2);
+          await page.keyboard.insertText(text);
+        },
+      };
+    },
+  },
+
+  Capture: {
+    /** Move the mouse to a neutral corner before OCR screenshots. Default behavior. */
+    unhover(options?: { point?: { x: number; y: number } }): CaptureStrategy {
+      return { unhover: true, unhoverPoint: options?.point };
+    },
+
+    /** Skip the unhover mouse move before capture. */
+    noop(): CaptureStrategy {
+      return { unhover: false };
+    },
+  },
+};

--- a/packages/core/src/strategies.ts
+++ b/packages/core/src/strategies.ts
@@ -143,7 +143,7 @@ export const Strategies = {
   Capture: {
     /** Move the mouse to a neutral corner before OCR screenshots. Default behavior. */
     unhover(options?: { point?: { x: number; y: number } }): CaptureStrategy {
-      return { unhover: true, unhoverPoint: options?.point };
+      return { unhover: true, ...(options?.point !== undefined && { unhoverPoint: options.point }) };
     },
 
     /** Skip the unhover mouse move before capture. */

--- a/packages/core/src/unhover.ts
+++ b/packages/core/src/unhover.ts
@@ -11,6 +11,13 @@ export function setUnhoverPoint(point: { x: number; y: number } | undefined): vo
   globalUnhoverPoint = point;
 }
 
+let globalUnhoverPoint: { x: number; y: number } | undefined;
+
+/** Set by `init({ unhoverPoint })`. Pass `undefined` to clear. */
+export function setUnhoverPoint(point: { x: number; y: number } | undefined): void {
+  globalUnhoverPoint = point;
+}
+
 /**
  * Move the mouse off interactive content so template matching is not skewed by
  * hover highlights. Enabled by default; pass `false` or

--- a/packages/core/src/unhover.ts
+++ b/packages/core/src/unhover.ts
@@ -11,13 +11,6 @@ export function setUnhoverPoint(point: { x: number; y: number } | undefined): vo
   globalUnhoverPoint = point;
 }
 
-let globalUnhoverPoint: { x: number; y: number } | undefined;
-
-/** Set by `init({ unhoverPoint })`. Pass `undefined` to clear. */
-export function setUnhoverPoint(point: { x: number; y: number } | undefined): void {
-  globalUnhoverPoint = point;
-}
-
 /**
  * Move the mouse off interactive content so template matching is not skewed by
  * hover highlights. Enabled by default; pass `false` or


### PR DESCRIPTION
## Summary

Typed, pluggable interaction strategies and env presets — PST-style, spread-into-`init()` ergonomics.

**`Strategies.Click`**
- `center()` — center of rect (existing behavior, default)
- `offset({ x, y })` — fractional position within rect
- `point(fn)` — custom fn receiving the rect

**`Strategies.Fill`**
- `selectAllType()` — click → Ctrl+A → Backspace → insertText (existing behavior, default)
- `tripleClickType()` — triple-click select → insertText (Guacamole-friendly)
- `clearAndType()` — click → Ctrl+A → Backspace → keyboard.type
- `typeOnly()` — keyboard.type only, no click/select
- `charByChar({ delay })` — click + `keyboard.type` with per-char delay (RDP-friendly)
- `insertText()` — click → insertText without clearing

**`Strategies.Capture`**
- `unhover()` / `noop()` — wraps existing unhover behavior in the strategy slot

**Presets** — spread-into-`init()` bundles:
- `presets.guacamole` — tripleClickType + clipboard OCR read + remote-font character swaps
- `presets.rdp` — charByChar delay:30
- `presets.webview` — selectAllType (explicit default)

**`mergeInitOptions(base, overrides)`** — deep-merges `strategies` slots when combining a preset with per-test options.

## Wiring
- All strategies set via `init({ strategies: { click, fill, capture } })`
- Module-level getters/setters in `strategies.ts` (same pattern as `setOcrStrategy`)
- `element.ts` `click()` delegates via `getClickStrategy().getPoint(rect)`; `fill()` delegates via `getFillStrategy().fill(page, rect, text)` — existing behavior unchanged when no strategy is configured

## Test plan
- [x] 21 new tests in `strategies.test.ts` covering all factories and module-level state
- [x] 176 total tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)