### PR TITLE
feat: getByText / getAllByText / toContainText on ScreenResult

### DIFF
--- a/packages/core/src/configure.ts
+++ b/packages/core/src/configure.ts
@@ -19,7 +19,7 @@ interface GlobalConfig {
    */
   unhoverBeforeCapture?: boolean;
   /**
-   * Override the default `{ x: 8, y: 8 }` unhover destination.
+   * Override the default unhover destination (top-left corner).
    * Useful when the top-left corner overlaps interactive content.
    */
   unhoverPoint?: { x: number; y: number };
@@ -34,6 +34,11 @@ export function getGlobalConfig(): GlobalConfig {
 /** Reset merged config (unit tests). */
 export function resetGlobalConfig(): void {
   globalConfig = {};
+}
+
+/** Clear only the unhoverPoint from the global config (called by release()). */
+export function clearConfigUnhoverPoint(): void {
+  delete (globalConfig as { unhoverPoint?: unknown }).unhoverPoint;
 }
 
 /**

--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -9,6 +9,7 @@ import {
   type OcrSwaps,
 } from './utils/ocr.js';
 import { ocrStep, expectTimeout } from './ocr-step.js';
+import { getClickStrategy, getFillStrategy } from './strategies.js';
 
 export const VISIBLE_CONFIDENCE = 0.7;
 
@@ -479,10 +480,7 @@ export class ScreenElement {
     return ocrStep(`element('${this.label}').fill(${JSON.stringify(text)})`, async () => {
       await this.ensureLocated(options?.timeout);
       await this.withOverlay(async () => {
-        await this.clickRect(this.result.ocrLocation ?? this.result.location);
-        await this.page!.keyboard.press('ControlOrMeta+A');
-        await this.page!.keyboard.press('Backspace');
-        await this.page!.keyboard.insertText(text);
+        await getFillStrategy().fill(this.page!, this.result.ocrLocation ?? this.result.location, text);
         this.live?.markDirty();
       });
     });
@@ -550,10 +548,8 @@ export class ScreenElement {
     if (!this.page) {
       throw new Error('Page not provided. Cannot click element.');
     }
-    await this.page.mouse.click(
-      rect.x + rect.width / 2,
-      rect.y + rect.height / 2,
-    );
+    const { x, y } = getClickStrategy().getPoint(rect);
+    await this.page.mouse.click(x, y);
   }
 
   /**

--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -529,7 +529,8 @@ export class ScreenElement {
       await this.withOverlay(async () => {
         const rect = this.result.ocrLocation ?? this.result.location;
         if (!this.page) throw new Error('Page not provided. Cannot double-click element.');
-        await this.page.mouse.dblclick(rect.x + rect.width / 2, rect.y + rect.height / 2);
+        const { x, y } = getClickStrategy().getPoint(rect);
+        await this.page.mouse.dblclick(x, y);
         this.live?.markDirty();
       });
     });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,8 @@ export type { TypedScreenConfig } from './typed-screen.js';
 export { ScreenResult } from './screen-result.js';
 export { ScreenElement, NegatedScreenElement } from './element.js';
 export type { HaveTextOptions, MatchOptions, WaitForOptions } from './element.js';
+export { TextElement, findAllMatches } from './text-element.js';
+export type { TextQuery, TextElementOptions, TextMatch, WordBox } from './text-element.js';
 
 export { ElementType } from './field-extractor.js';
 export type { ElementConfig, ElementResult, ScreenComparison } from './field-extractor.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,7 @@ export type {
 export { ocrTextMatches } from './utils/ocr.js';
 export type { Charset, FieldRead, OcrOverflow, OcrSwaps } from './utils/ocr.js';
 export { Strategies } from './screen.js';
-export type { OcrStrategy } from './screen.js';
+export type { OcrStrategy, ClickStrategy, FillStrategy, CaptureStrategy } from './screen.js';
+export { presets, mergeInitOptions } from './presets.js';
 export { createScreen } from './screen-api.js';
 export type { TypedResult } from './screen-api.js';

--- a/packages/core/src/presets.ts
+++ b/packages/core/src/presets.ts
@@ -1,0 +1,63 @@
+import { Strategies } from './strategies.js';
+
+/**
+ * Environment presets — spread into `init()` to configure strategies for common runtimes.
+ *
+ *   await init({ page, storage: { root }, ...presets.guacamole });
+ */
+export const presets = {
+  /**
+   * Apache Guacamole / HTML5 remote desktop.
+   * Triple-click select (Ctrl+A is unreliable over the protocol),
+   * clipboard read for OCR, and common remote-font character swaps.
+   */
+  guacamole: {
+    strategies: {
+      fill: Strategies.Fill.tripleClickType(),
+      ocr: Strategies.Ocr.default({
+        read: 'clipboard' as const,
+        swaps: {
+          "'": ["'", '’'],
+          '"': ['“', '”'],
+        },
+      }),
+    },
+  },
+
+  /**
+   * Windows RDP / remote desktop.
+   * Char-by-char typing avoids clipboard paste issues over the protocol.
+   */
+  rdp: {
+    strategies: {
+      fill: Strategies.Fill.charByChar({ delay: 30 }),
+    },
+  },
+
+  /**
+   * Webview / embedded browser.
+   * Uses the standard select-all-type recipe with insertText.
+   */
+  webview: {
+    strategies: {
+      fill: Strategies.Fill.selectAllType(),
+    },
+  },
+} as const;
+
+/**
+ * Deep-merge two `init()` option objects, combining their `strategies` slots.
+ * Useful when a preset and per-test options both configure strategies.
+ *
+ *   const opts = mergeInitOptions(presets.guacamole, { strategies: { click: Strategies.Click.offset({ x: 0.1, y: 0.5 }) } });
+ */
+export function mergeInitOptions<T extends { strategies?: object }>(
+  base: T,
+  overrides: Partial<T>,
+): T {
+  return {
+    ...base,
+    ...overrides,
+    strategies: { ...base.strategies, ...overrides.strategies },
+  } as T;
+}

--- a/packages/core/src/screen-result.ts
+++ b/packages/core/src/screen-result.ts
@@ -1,14 +1,13 @@
 import type { ElementConfig, ElementResult, ScreenComparison } from './types.js';
 import type { ScreenConfig } from './screen-config.js';
 import { ScreenElement, VISIBLE_CONFIDENCE, type MatchOptions, type WaitForOptions } from './element.js';
-import { TextElement, findAllMatches, type TextQuery, type TextElementOptions } from './text-element.js';
+import { TextElement, findAllMatches, extractWords, type TextQuery, type TextElementOptions } from './text-element.js';
 import type { Page } from '@playwright/test';
 import { ocrStep, expectTimeout } from './ocr-step.js';
 import { hideOcrOverlay, overlayBoxesFromResult, showOcrOverlay } from './ocr-overlay.js';
 import { unhoverBeforeCapture } from './unhover.js';
 import { resolveCharsetSwaps, getOcrStrategy, getOCRUtil, type FieldRead } from './utils/ocr.js';
 import * as fs from 'node:fs';
-import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 
 export type ScreenExtractor = {
@@ -320,18 +319,11 @@ export class ScreenResult {
   // Text locators
   // ---------------------------------------------------------------------------
 
-  private async captureWords(): Promise<{ words: import('./text-element.js').WordBox[]; shotDir: string }> {
+  private async captureWords(): Promise<{ words: import('./text-element.js').WordBox[] }> {
     if (!this.host || !this.page) {
       throw new Error('getByText / toContainText requires ScreenResult.bind(page, ...)');
     }
-    fs.mkdirSync(this.host.shotDir, { recursive: true });
-    const shotPath = path.join(this.host.shotDir, `${this.host.screen.name}-text-live.png`);
-    await unhoverBeforeCapture(this.page, this.host.unhover);
-    await this.page.screenshot({ path: shotPath, timeout: 2_000 });
-    const buf = await fsp.readFile(shotPath);
-    const ocrUtil = await getOCRUtil();
-    const words = await ocrUtil.extractPageWords(buf);
-    return { words, shotDir: this.host.shotDir };
+    return extractWords(this.page, this.host.shotDir, this.host.screen.name, this.host.unhover);
   }
 
   /**
@@ -351,17 +343,21 @@ export class ScreenResult {
       const timeout = options?.timeout ?? 15_000;
       const deadline = Date.now() + timeout;
       while (true) {
-        const { words: w } = await this.captureWords();
-        const matches = findAllMatches(w, query);
-        if (matches[0]) {
-          return new TextElement(
-            matches[0],
-            query,
-            this.page,
-            this.host.shotDir,
-            this.host.screen.name,
-            this.host.unhover,
-          );
+        try {
+          const { words: w } = await this.captureWords();
+          const matches = findAllMatches(w, query);
+          if (matches[0]) {
+            return new TextElement(
+              matches[0],
+              query,
+              this.page,
+              this.host.shotDir,
+              this.host.screen.name,
+              this.host.unhover,
+            );
+          }
+        } catch {
+          // transient screenshot error (navigation, partial load) — retry
         }
         if (Date.now() >= deadline) break;
         await new Promise<void>((r) => setTimeout(r, 150));
@@ -401,12 +397,13 @@ export class ScreenResult {
     return ocrStep(`screen.toContainText(${String(query)})`, async () => {
       const timeout = options?.timeout ?? expectTimeout();
       const deadline = Date.now() + timeout;
-      let found = false;
       while (true) {
-        const { words } = await this.captureWords();
-        const matches = findAllMatches(words, query);
-        found = matches.length > 0 && (matches[0]?.confidence ?? 0) >= VISIBLE_CONFIDENCE;
-        if (found) return;
+        try {
+          const { words } = await this.captureWords();
+          if (findAllMatches(words, query).some((m) => m.confidence >= VISIBLE_CONFIDENCE)) return;
+        } catch {
+          // transient screenshot error (navigation, partial load) — retry
+        }
         if (Date.now() >= deadline) break;
         await new Promise<void>((r) => setTimeout(r, 150));
       }

--- a/packages/core/src/screen-result.ts
+++ b/packages/core/src/screen-result.ts
@@ -1,12 +1,14 @@
 import type { ElementConfig, ElementResult, ScreenComparison } from './types.js';
 import type { ScreenConfig } from './screen-config.js';
 import { ScreenElement, VISIBLE_CONFIDENCE, type MatchOptions, type WaitForOptions } from './element.js';
+import { TextElement, findAllMatches, type TextQuery, type TextElementOptions } from './text-element.js';
 import type { Page } from '@playwright/test';
-import { ocrStep } from './ocr-step.js';
+import { ocrStep, expectTimeout } from './ocr-step.js';
 import { hideOcrOverlay, overlayBoxesFromResult, showOcrOverlay } from './ocr-overlay.js';
 import { unhoverBeforeCapture } from './unhover.js';
-import { resolveCharsetSwaps, getOcrStrategy, type FieldRead } from './utils/ocr.js';
+import { resolveCharsetSwaps, getOcrStrategy, getOCRUtil, type FieldRead } from './utils/ocr.js';
 import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 
 export type ScreenExtractor = {
@@ -312,6 +314,104 @@ export class ScreenResult {
   async hideOverlay(): Promise<void> {
     if (!this.page || !this.host?.overlay) return;
     await hideOcrOverlay(this.page);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Text locators
+  // ---------------------------------------------------------------------------
+
+  private async captureWords(): Promise<{ words: import('./text-element.js').WordBox[]; shotDir: string }> {
+    if (!this.host || !this.page) {
+      throw new Error('getByText / toContainText requires ScreenResult.bind(page, ...)');
+    }
+    fs.mkdirSync(this.host.shotDir, { recursive: true });
+    const shotPath = path.join(this.host.shotDir, `${this.host.screen.name}-text-live.png`);
+    await unhoverBeforeCapture(this.page, this.host.unhover);
+    await this.page.screenshot({ path: shotPath, timeout: 2_000 });
+    const buf = await fsp.readFile(shotPath);
+    const ocrUtil = await getOCRUtil();
+    const words = await ocrUtil.extractPageWords(buf);
+    return { words, shotDir: this.host.shotDir };
+  }
+
+  /**
+   * Find the first occurrence of text on screen via OCR.
+   * Waits until the text is visible (by default).
+   * Use for dynamic / ad-hoc content that is not registered in index.json —
+   * dropdown options, toast messages, menu rows, table cells.
+   *
+   * @param query - Exact string (case-insensitive) or RegExp.
+   * @param options.timeout - How long to wait for the text to appear (ms). Default 15 000.
+   */
+  async getByText(query: TextQuery, options?: TextElementOptions): Promise<TextElement> {
+    return ocrStep(`screen.getByText(${String(query)})`, async () => {
+      if (!this.host || !this.page) {
+        throw new Error('getByText requires ScreenResult.bind(page, ...)');
+      }
+      const timeout = options?.timeout ?? 15_000;
+      const deadline = Date.now() + timeout;
+      while (true) {
+        const { words: w } = await this.captureWords();
+        const matches = findAllMatches(w, query);
+        if (matches[0]) {
+          return new TextElement(
+            matches[0],
+            query,
+            this.page,
+            this.host.shotDir,
+            this.host.screen.name,
+            this.host.unhover,
+          );
+        }
+        if (Date.now() >= deadline) break;
+        await new Promise<void>((r) => setTimeout(r, 150));
+      }
+      throw new Error(`Text ${String(query)} not found within ${timeout}ms`);
+    });
+  }
+
+  /**
+   * Find all occurrences of text on screen via OCR.
+   * Returns immediately with whatever matches are currently visible — no implicit wait.
+   * Use for list rows, repeated badges, or any case where multiple matches are expected.
+   */
+  async getAllByText(query: TextQuery): Promise<TextElement[]> {
+    return ocrStep(`screen.getAllByText(${String(query)})`, async () => {
+      const { words } = await this.captureWords();
+      const matches = findAllMatches(words, query);
+      return matches.map((m) => new TextElement(
+        m,
+        query,
+        this.page,
+        this.host?.shotDir,
+        this.host?.screen.name,
+        this.host?.unhover,
+      ));
+    });
+  }
+
+  /**
+   * Assert that the given text is visible anywhere on screen.
+   * Useful for smoke-checking dynamic feedback without registering an element.
+   *
+   * @param query - Exact string (case-insensitive) or RegExp.
+   * @param options.timeout - How long to poll (ms). Default: expectTimeout().
+   */
+  async toContainText(query: TextQuery, options?: TextElementOptions): Promise<void> {
+    return ocrStep(`screen.toContainText(${String(query)})`, async () => {
+      const timeout = options?.timeout ?? expectTimeout();
+      const deadline = Date.now() + timeout;
+      let found = false;
+      while (true) {
+        const { words } = await this.captureWords();
+        const matches = findAllMatches(words, query);
+        found = matches.length > 0 && (matches[0]?.confidence ?? 0) >= VISIBLE_CONFIDENCE;
+        if (found) return;
+        if (Date.now() >= deadline) break;
+        await new Promise<void>((r) => setTimeout(r, 150));
+      }
+      throw new Error(`Screen does not contain text ${String(query)} within ${timeout}ms`);
+    });
   }
 
   /**

--- a/packages/core/src/screen.ts
+++ b/packages/core/src/screen.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { test as base } from '@playwright/test';
 import type { Page, TestType } from '@playwright/test';
 import type { ScreenConfig } from './screen-config.js';
-import { loadScreen } from './configure.js';
+import { loadScreen, clearConfigUnhoverPoint } from './configure.js';
 import { FieldExtractor } from './field-extractor.js';
 import { ScreenResult } from './screen-result.js';
 import { cleanupOCR, getOCRUtil, setCharsetRegistry, setOcrStrategy, type Charset, type FieldRead } from './utils/ocr.js';
@@ -91,7 +91,7 @@ interface InitOptions {
   /** Environment-level read override. Wins over index.json; call site wins over this. */
   read?: FieldRead;
   /**
-   * Override the default `{ x: 8, y: 8 }` unhover destination.
+   * Override the default unhover destination (top-left corner).
    * Useful when the top-left corner overlaps interactive content.
    */
   unhoverPoint?: { x: number; y: number };
@@ -216,6 +216,7 @@ export async function release(): Promise<void> {
   initState?.extractor.cleanup();
   initState = null;
   setUnhoverPoint(undefined);
+  clearConfigUnhoverPoint();
   setClickStrategy(undefined);
   setFillStrategy(undefined);
   setCharsetRegistry({});

--- a/packages/core/src/screen.ts
+++ b/packages/core/src/screen.ts
@@ -7,9 +7,18 @@ import type { ScreenConfig } from './screen-config.js';
 import { loadScreen } from './configure.js';
 import { FieldExtractor } from './field-extractor.js';
 import { ScreenResult } from './screen-result.js';
-import { cleanupOCR, getOCRUtil, setCharsetRegistry, setOcrStrategy, type Charset, type FieldRead, type OcrStrategy } from './utils/ocr.js';
+import { cleanupOCR, getOCRUtil, setCharsetRegistry, setOcrStrategy, type Charset, type FieldRead } from './utils/ocr.js';
 import { setUnhoverPoint } from './unhover.js';
 import { ensureCvReady } from './utils/vision.js';
+import {
+  Strategies,
+  setClickStrategy,
+  setFillStrategy,
+  type ClickStrategy,
+  type FillStrategy,
+  type CaptureStrategy,
+  type OcrStrategy,
+} from './strategies.js';
 
 export interface BindOcrScreenOptions {
   shotDir?: string;
@@ -65,19 +74,12 @@ export function bindOcrScreen(
 export interface Strategies {
   charsets?: Record<string, Charset>;
   ocr?: OcrStrategy;
+  click?: ClickStrategy;
+  fill?: FillStrategy;
+  capture?: CaptureStrategy;
 }
 
-export { type OcrStrategy };
-
-/** Runtime factories for strategy slots. */
-export const Strategies = {
-  Ocr: {
-    /** Create an Ocr strategy with global charset defaults, name-inference, and swaps. */
-    default(options: OcrStrategy): OcrStrategy {
-      return options;
-    },
-  },
-};
+export { Strategies, type OcrStrategy, type ClickStrategy, type FillStrategy, type CaptureStrategy };
 
 interface InitOptions {
   page: Page;
@@ -130,6 +132,17 @@ export async function init(options: InitOptions): Promise<void> {
 
   if (options.unhoverPoint !== undefined) {
     setUnhoverPoint(options.unhoverPoint);
+  }
+  if (options.strategies?.capture !== undefined) {
+    const cap = options.strategies.capture;
+    initState.config.unhoverBeforeCapture = cap.unhover;
+    if (cap.unhoverPoint !== undefined) setUnhoverPoint(cap.unhoverPoint);
+  }
+  if (options.strategies?.click !== undefined) {
+    setClickStrategy(options.strategies.click);
+  }
+  if (options.strategies?.fill !== undefined) {
+    setFillStrategy(options.strategies.fill);
   }
   if (options.strategies?.charsets) {
     setCharsetRegistry(options.strategies.charsets);
@@ -203,6 +216,8 @@ export async function release(): Promise<void> {
   initState?.extractor.cleanup();
   initState = null;
   setUnhoverPoint(undefined);
+  setClickStrategy(undefined);
+  setFillStrategy(undefined);
   setCharsetRegistry({});
   setOcrStrategy(undefined);
   await cleanupOCR();

--- a/packages/core/src/strategies.test.ts
+++ b/packages/core/src/strategies.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Page } from '@playwright/test';
+import { Strategies, setClickStrategy, setFillStrategy, getClickStrategy, getFillStrategy } from './strategies.js';
+import type { Rect } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const rect: Rect = { x: 100, y: 200, width: 80, height: 40 };
+
+function mockPage() {
+  return {
+    mouse: { click: vi.fn(), tripleclick: vi.fn() },
+    keyboard: {
+      press: vi.fn(),
+      type: vi.fn(),
+      insertText: vi.fn(),
+    },
+  } as unknown as Page;
+}
+
+// ---------------------------------------------------------------------------
+// Strategies.Click
+// ---------------------------------------------------------------------------
+
+describe('Strategies.Click.center()', () => {
+  it('returns the midpoint of the rect', () => {
+    const pt = Strategies.Click.center().getPoint(rect);
+    expect(pt).toEqual({ x: 140, y: 220 });
+  });
+});
+
+describe('Strategies.Click.offset()', () => {
+  it('{ x: 0, y: 0.5 } → left-center', () => {
+    const pt = Strategies.Click.offset({ x: 0, y: 0.5 }).getPoint(rect);
+    expect(pt).toEqual({ x: 100, y: 220 });
+  });
+
+  it('{ x: 1, y: 1 } → bottom-right corner', () => {
+    const pt = Strategies.Click.offset({ x: 1, y: 1 }).getPoint(rect);
+    expect(pt).toEqual({ x: 180, y: 240 });
+  });
+
+  it('{ x: 0.5, y: 0.5 } → same as center', () => {
+    const pt = Strategies.Click.offset({ x: 0.5, y: 0.5 }).getPoint(rect);
+    expect(pt).toEqual(Strategies.Click.center().getPoint(rect));
+  });
+});
+
+describe('Strategies.Click.point(fn)', () => {
+  it('delegates to the provided function', () => {
+    const fn = vi.fn().mockReturnValue({ x: 10, y: 20 });
+    const pt = Strategies.Click.point(fn).getPoint(rect);
+    expect(fn).toHaveBeenCalledWith(rect);
+    expect(pt).toEqual({ x: 10, y: 20 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Strategies.Fill
+// ---------------------------------------------------------------------------
+
+describe('Strategies.Fill.selectAllType()', () => {
+  it('click → Ctrl+A → Backspace → insertText', async () => {
+    const page = mockPage();
+    await Strategies.Fill.selectAllType().fill(page, rect, 'hello');
+    expect(page.mouse.click).toHaveBeenCalledWith(140, 220);
+    expect(page.keyboard.press).toHaveBeenCalledWith('ControlOrMeta+A');
+    expect(page.keyboard.press).toHaveBeenCalledWith('Backspace');
+    expect(page.keyboard.insertText).toHaveBeenCalledWith('hello');
+    expect(page.keyboard.type).not.toHaveBeenCalled();
+  });
+});
+
+describe('Strategies.Fill.tripleClickType()', () => {
+  it('triple-click then insertText (no Ctrl+A)', async () => {
+    const page = mockPage();
+    await Strategies.Fill.tripleClickType().fill(page, rect, 'hello');
+    expect(page.mouse.click).toHaveBeenCalledWith(140, 220, { clickCount: 3 });
+    expect(page.keyboard.insertText).toHaveBeenCalledWith('hello');
+    expect(page.keyboard.press).not.toHaveBeenCalled();
+  });
+});
+
+describe('Strategies.Fill.clearAndType()', () => {
+  it('click → Ctrl+A → Backspace → keyboard.type', async () => {
+    const page = mockPage();
+    await Strategies.Fill.clearAndType().fill(page, rect, 'hello');
+    expect(page.mouse.click).toHaveBeenCalledWith(140, 220);
+    expect(page.keyboard.press).toHaveBeenCalledWith('ControlOrMeta+A');
+    expect(page.keyboard.press).toHaveBeenCalledWith('Backspace');
+    expect(page.keyboard.type).toHaveBeenCalledWith('hello');
+    expect(page.keyboard.insertText).not.toHaveBeenCalled();
+  });
+});
+
+describe('Strategies.Fill.typeOnly()', () => {
+  it('keyboard.type without any click or selection', async () => {
+    const page = mockPage();
+    await Strategies.Fill.typeOnly().fill(page, rect, 'hello');
+    expect(page.keyboard.type).toHaveBeenCalledWith('hello');
+    expect(page.mouse.click).not.toHaveBeenCalled();
+    expect(page.keyboard.press).not.toHaveBeenCalled();
+  });
+});
+
+describe('Strategies.Fill.charByChar()', () => {
+  it('click then keyboard.type with delay', async () => {
+    const page = mockPage();
+    await Strategies.Fill.charByChar({ delay: 30 }).fill(page, rect, 'hi');
+    expect(page.mouse.click).toHaveBeenCalledWith(140, 220);
+    expect(page.keyboard.type).toHaveBeenCalledWith('hi', { delay: 30 });
+  });
+});
+
+describe('Strategies.Fill.insertText()', () => {
+  it('click then insertText without selection', async () => {
+    const page = mockPage();
+    await Strategies.Fill.insertText().fill(page, rect, 'hello');
+    expect(page.mouse.click).toHaveBeenCalledWith(140, 220);
+    expect(page.keyboard.insertText).toHaveBeenCalledWith('hello');
+    expect(page.keyboard.press).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Strategies.Capture
+// ---------------------------------------------------------------------------
+
+describe('Strategies.Capture', () => {
+  it('unhover() sets unhover:true with no point by default', () => {
+    const cap = Strategies.Capture.unhover();
+    expect(cap.unhover).toBe(true);
+    expect(cap.unhoverPoint).toBeUndefined();
+  });
+
+  it('unhover({ point }) stores the point', () => {
+    const cap = Strategies.Capture.unhover({ point: { x: 5, y: 10 } });
+    expect(cap.unhover).toBe(true);
+    expect(cap.unhoverPoint).toEqual({ x: 5, y: 10 });
+  });
+
+  it('noop() sets unhover:false', () => {
+    expect(Strategies.Capture.noop().unhover).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Module-level state: setClickStrategy / setFillStrategy
+// ---------------------------------------------------------------------------
+
+describe('module-level strategy state', () => {
+  afterEach(() => {
+    setClickStrategy(undefined);
+    setFillStrategy(undefined);
+  });
+
+  it('getClickStrategy() returns center by default', () => {
+    const pt = getClickStrategy().getPoint(rect);
+    expect(pt).toEqual({ x: 140, y: 220 });
+  });
+
+  it('setClickStrategy() overrides the default', () => {
+    setClickStrategy(Strategies.Click.offset({ x: 0, y: 0 }));
+    const pt = getClickStrategy().getPoint(rect);
+    expect(pt).toEqual({ x: 100, y: 200 });
+  });
+
+  it('setClickStrategy(undefined) restores the default', () => {
+    setClickStrategy(Strategies.Click.offset({ x: 0, y: 0 }));
+    setClickStrategy(undefined);
+    const pt = getClickStrategy().getPoint(rect);
+    expect(pt).toEqual({ x: 140, y: 220 });
+  });
+
+  it('getFillStrategy() uses selectAllType by default', async () => {
+    const page = mockPage();
+    await getFillStrategy().fill(page, rect, 'x');
+    expect(page.keyboard.press).toHaveBeenCalledWith('ControlOrMeta+A');
+  });
+
+  it('setFillStrategy() overrides the default', async () => {
+    setFillStrategy(Strategies.Fill.typeOnly());
+    const page = mockPage();
+    await getFillStrategy().fill(page, rect, 'x');
+    expect(page.keyboard.type).toHaveBeenCalledWith('x');
+    expect(page.keyboard.press).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// presets sanity check
+// ---------------------------------------------------------------------------
+
+describe('presets', () => {
+  beforeEach(() => { setFillStrategy(undefined); });
+  afterEach(() => { setFillStrategy(undefined); });
+
+  it('presets.guacamole.strategies.fill uses tripleClickType', async () => {
+    const { presets } = await import('./presets.js');
+    const page = mockPage();
+    await presets.guacamole.strategies.fill.fill(page, rect, 'val');
+    expect(page.mouse.click).toHaveBeenCalledWith(140, 220, { clickCount: 3 });
+  });
+
+  it('presets.rdp.strategies.fill uses charByChar with delay 30', async () => {
+    const { presets } = await import('./presets.js');
+    const page = mockPage();
+    await presets.rdp.strategies.fill.fill(page, rect, 'val');
+    expect(page.keyboard.type).toHaveBeenCalledWith('val', { delay: 30 });
+  });
+});

--- a/packages/core/src/strategies.ts
+++ b/packages/core/src/strategies.ts
@@ -1,0 +1,154 @@
+import type { Page } from '@playwright/test';
+import type { Rect } from './types.js';
+import type { OcrStrategy } from './utils/ocr.js';
+export type { OcrStrategy };
+
+// ─── Strategy interfaces ──────────────────────────────────────────────────────
+
+export interface ClickStrategy {
+  /** Returns the point to click within the element's bounding rect. */
+  getPoint(rect: Rect): { x: number; y: number };
+}
+
+export interface FillStrategy {
+  /** Full fill sequence: focus, select, type. Owns all keyboard/mouse steps. */
+  fill(page: Page, rect: Rect, text: string): Promise<void>;
+}
+
+export interface CaptureStrategy {
+  unhover: boolean;
+  unhoverPoint?: { x: number; y: number };
+}
+
+// ─── Module-level state ───────────────────────────────────────────────────────
+
+let globalClickStrategy: ClickStrategy | undefined;
+let globalFillStrategy: FillStrategy | undefined;
+
+export function setClickStrategy(s: ClickStrategy | undefined): void {
+  globalClickStrategy = s;
+}
+export function setFillStrategy(s: FillStrategy | undefined): void {
+  globalFillStrategy = s;
+}
+
+export function getClickStrategy(): ClickStrategy {
+  return globalClickStrategy ?? Strategies.Click.center();
+}
+export function getFillStrategy(): FillStrategy {
+  return globalFillStrategy ?? Strategies.Fill.selectAllType();
+}
+
+// ─── Strategies namespace ─────────────────────────────────────────────────────
+
+export const Strategies = {
+  Ocr: {
+    /** Create an Ocr strategy with global charset defaults, name-inference, and swaps. */
+    default(options: OcrStrategy): OcrStrategy {
+      return options;
+    },
+  },
+
+  Click: {
+    /** Click the center of the element rect. Default behavior. */
+    center(): ClickStrategy {
+      return { getPoint: (r) => ({ x: r.x + r.width / 2, y: r.y + r.height / 2 }) };
+    },
+
+    /**
+     * Click at a fractional offset within the element rect.
+     * `{ x: 0, y: 0.5 }` → left-center; `{ x: 0.5, y: 0.5 }` → center.
+     */
+    offset(pct: { x: number; y: number }): ClickStrategy {
+      return { getPoint: (r) => ({ x: r.x + r.width * pct.x, y: r.y + r.height * pct.y }) };
+    },
+
+    /** Click at a custom point derived from the rect. */
+    point(fn: (rect: Rect) => { x: number; y: number }): ClickStrategy {
+      return { getPoint: fn };
+    },
+  },
+
+  Fill: {
+    /** Click → Ctrl/Cmd+A → Backspace → insertText. Default behavior. */
+    selectAllType(): FillStrategy {
+      return {
+        async fill(page, rect, text) {
+          await page.mouse.click(rect.x + rect.width / 2, rect.y + rect.height / 2);
+          await page.keyboard.press('ControlOrMeta+A');
+          await page.keyboard.press('Backspace');
+          await page.keyboard.insertText(text);
+        },
+      };
+    },
+
+    /**
+     * Triple-click (selects all in remote/Guacamole envs) → insertText.
+     * Preferred over selectAllType for environments that don't relay Ctrl+A.
+     */
+    tripleClickType(): FillStrategy {
+      return {
+        async fill(page, rect, text) {
+          await page.mouse.click(rect.x + rect.width / 2, rect.y + rect.height / 2, { clickCount: 3 });
+          await page.keyboard.insertText(text);
+        },
+      };
+    },
+
+    /** Click → Ctrl/Cmd+A → Backspace → keyboard.type (slower, fires key events). */
+    clearAndType(): FillStrategy {
+      return {
+        async fill(page, rect, text) {
+          await page.mouse.click(rect.x + rect.width / 2, rect.y + rect.height / 2);
+          await page.keyboard.press('ControlOrMeta+A');
+          await page.keyboard.press('Backspace');
+          await page.keyboard.type(text);
+        },
+      };
+    },
+
+    /** Type into the currently focused element without clicking or clearing. */
+    typeOnly(): FillStrategy {
+      return {
+        async fill(page, _rect, text) {
+          await page.keyboard.type(text);
+        },
+      };
+    },
+
+    /**
+     * Click to focus, then type one character at a time with a delay.
+     * Use in environments where rapid key events are dropped.
+     */
+    charByChar(options: { delay: number }): FillStrategy {
+      return {
+        async fill(page, rect, text) {
+          await page.mouse.click(rect.x + rect.width / 2, rect.y + rect.height / 2);
+          await page.keyboard.type(text, { delay: options.delay });
+        },
+      };
+    },
+
+    /** Click to focus, then use insertText without selecting/clearing first. */
+    insertText(): FillStrategy {
+      return {
+        async fill(page, rect, text) {
+          await page.mouse.click(rect.x + rect.width / 2, rect.y + rect.height / 2);
+          await page.keyboard.insertText(text);
+        },
+      };
+    },
+  },
+
+  Capture: {
+    /** Move the mouse to a neutral corner before OCR screenshots. Default behavior. */
+    unhover(options?: { point?: { x: number; y: number } }): CaptureStrategy {
+      return { unhover: true, unhoverPoint: options?.point };
+    },
+
+    /** Skip the unhover mouse move before capture. */
+    noop(): CaptureStrategy {
+      return { unhover: false };
+    },
+  },
+};

--- a/packages/core/src/strategies.ts
+++ b/packages/core/src/strategies.ts
@@ -143,7 +143,7 @@ export const Strategies = {
   Capture: {
     /** Move the mouse to a neutral corner before OCR screenshots. Default behavior. */
     unhover(options?: { point?: { x: number; y: number } }): CaptureStrategy {
-      return { unhover: true, unhoverPoint: options?.point };
+      return { unhover: true, ...(options?.point !== undefined && { unhoverPoint: options.point }) };
     },
 
     /** Skip the unhover mouse move before capture. */

--- a/packages/core/src/text-element.test.ts
+++ b/packages/core/src/text-element.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { findAllMatches, TextElement } from './text-element.js';
+import type { WordBox, TextMatch } from './text-element.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function word(text: string, x: number, y: number, w = 50, h = 16, conf = 90): WordBox {
+  return { text, confidence: conf, x, y, width: w, height: h };
+}
+
+function match(text: string, conf = 0.9): TextMatch {
+  return { location: { x: 0, y: 0, width: 50, height: 16 }, confidence: conf, text };
+}
+
+// ---------------------------------------------------------------------------
+// findAllMatches — string queries
+// ---------------------------------------------------------------------------
+
+describe('findAllMatches — string', () => {
+  it('matches a single word', () => {
+    const words = [word('Hello', 0, 0), word('World', 60, 0)];
+    const hits = findAllMatches(words, 'Hello');
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.text).toBe('Hello');
+  });
+
+  it('matches a two-word phrase', () => {
+    const words = [word('Hello', 0, 0), word('World', 60, 0)];
+    const hits = findAllMatches(words, 'Hello World');
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.text).toBe('Hello World');
+  });
+
+  it('is case-insensitive', () => {
+    const words = [word('SUBMIT', 0, 0)];
+    expect(findAllMatches(words, 'submit')).toHaveLength(1);
+  });
+
+  it('strips punctuation when comparing', () => {
+    const words = [word('Done!', 0, 0)];
+    expect(findAllMatches(words, 'Done')).toHaveLength(1);
+  });
+
+  it('does not match across lines (different y)', () => {
+    // word at y=0 and y=30 — more than 6px apart, different lines
+    const words = [word('Hello', 0, 0), word('World', 0, 30)];
+    const hits = findAllMatches(words, 'Hello World');
+    expect(hits).toHaveLength(0);
+  });
+
+  it('returns empty when no match', () => {
+    const words = [word('Foo', 0, 0)];
+    expect(findAllMatches(words, 'Bar')).toHaveLength(0);
+  });
+
+  it('confidence is average of word confidences / 100', () => {
+    const words = [word('A', 0, 0, 50, 16, 80), word('B', 60, 0, 50, 16, 60)];
+    const hits = findAllMatches(words, 'A B');
+    expect(hits[0]!.confidence).toBeCloseTo(0.7);
+  });
+
+  it('location is bounding box of all matched words', () => {
+    const words = [word('First', 10, 5, 40, 16), word('Last', 70, 3, 50, 20)];
+    const hits = findAllMatches(words, 'First Last');
+    const loc = hits[0]!.location;
+    expect(loc.x).toBe(10);
+    expect(loc.y).toBe(3);
+    expect(loc.width).toBe(110); // (70+50) - 10
+    expect(loc.height).toBe(20); // max(5+16, 3+20) - 3 = 23 - 3
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findAllMatches — regex queries
+// ---------------------------------------------------------------------------
+
+describe('findAllMatches — regex', () => {
+  it('matches a regex against a single word', () => {
+    const words = [word('Order-12345', 0, 0)];
+    const hits = findAllMatches(words, /Order-\d+/);
+    expect(hits).toHaveLength(1);
+  });
+
+  it('matches a regex spanning two words', () => {
+    const words = [word('Aug', 0, 0), word('22', 60, 0)];
+    const hits = findAllMatches(words, /Aug \d+/);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.text).toBe('Aug 22');
+  });
+
+  it('returns empty when regex does not match', () => {
+    const words = [word('Foo', 0, 0)];
+    expect(findAllMatches(words, /\d{4}/)).toHaveLength(0);
+  });
+
+  it('caps window size at 4 words for regex', () => {
+    // 5-word line — a regex match on words 1-4 is fine, but not 1-5
+    const ws = [
+      word('a', 0, 0), word('b', 20, 0), word('c', 40, 0),
+      word('d', 60, 0), word('e', 80, 0),
+    ];
+    const hits = findAllMatches(ws, /a b c d/);
+    expect(hits).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findAllMatches — line grouping
+// ---------------------------------------------------------------------------
+
+describe('findAllMatches — line grouping', () => {
+  it('groups words within 6px y-center into the same line', () => {
+    const words = [word('A', 0, 0), word('B', 60, 4)]; // cy=8 and cy=12 → diff=4 ≤ 6
+    const hits = findAllMatches(words, 'A B');
+    expect(hits).toHaveLength(1);
+  });
+
+  it('does not group words more than 6px apart', () => {
+    const words = [word('A', 0, 0), word('B', 0, 20)]; // cy=8 and cy=28 → diff=20
+    const hits = findAllMatches(words, 'A B');
+    expect(hits).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TextElement — static (no live page)
+// ---------------------------------------------------------------------------
+
+describe('TextElement (static, no page)', () => {
+  it('bounds() returns match location', () => {
+    const m = match('Submit');
+    m.location = { x: 10, y: 20, width: 60, height: 18 };
+    const el = new TextElement(m, 'Submit');
+    expect(el.bounds()).toEqual({ x: 10, y: 20, width: 60, height: 18 });
+  });
+
+  it('text() returns raw matched text', () => {
+    const el = new TextElement(match('Hello World'), 'Hello World');
+    expect(el.text()).toBe('Hello World');
+  });
+
+  it('click() throws without a page', async () => {
+    const el = new TextElement(match('Btn'), 'Btn');
+    await expect(el.click()).rejects.toThrow('click() requires a live page');
+  });
+
+  it('toBeVisible() passes when confidence is high enough', async () => {
+    const el = new TextElement(match('OK', 0.95), 'OK');
+    await expect(el.toBeVisible()).resolves.toBeUndefined();
+  });
+
+  it('toBeVisible() throws when confidence is below threshold', async () => {
+    const el = new TextElement(match('OK', 0.3), 'OK');
+    await expect(el.toBeVisible()).rejects.toThrow(/not visible/i);
+  });
+
+  it('toBeHidden() passes when confidence is below threshold', async () => {
+    const el = new TextElement(match('Gone', 0.3), 'Gone');
+    await expect(el.toBeHidden()).resolves.toBeUndefined();
+  });
+
+  it('toBeHidden() throws when text is still visible', async () => {
+    const el = new TextElement(match('Gone', 0.95), 'Gone');
+    await expect(el.toBeHidden()).rejects.toThrow(/still visible/i);
+  });
+
+  it('toHaveText() passes when text matches string', async () => {
+    const el = new TextElement(match('Submit'), 'Submit');
+    await expect(el.toHaveText('Submit')).resolves.toBeUndefined();
+  });
+
+  it('toHaveText() passes when text matches regex', async () => {
+    const el = new TextElement(match('Order-123'), /Order-\d+/);
+    await expect(el.toHaveText(/Order-\d+/)).resolves.toBeUndefined();
+  });
+
+  it('toHaveText() throws on mismatch without page', async () => {
+    const el = new TextElement(match('Foo'), 'Foo');
+    await expect(el.toHaveText('Bar')).rejects.toThrow(/Expected text/i);
+  });
+
+  it('waitFor() delegates to toBeVisible()', async () => {
+    const el = new TextElement(match('OK', 0.95), 'OK');
+    await expect(el.waitFor()).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/text-element.test.ts
+++ b/packages/core/src/text-element.test.ts
@@ -122,6 +122,13 @@ describe('findAllMatches — line grouping', () => {
     const hits = findAllMatches(words, 'A B');
     expect(hits).toHaveLength(0);
   });
+
+  it('groups a third word within 6px of a non-first group member', () => {
+    // cy: A=8, B=10, C=16 — A and B join (|10-8|=2≤6); C is >6 from A but ≤6 from B
+    const words = [word('A', 0, 0), word('B', 60, 2), word('C', 120, 8)];
+    const hits = findAllMatches(words, 'A B C');
+    expect(hits).toHaveLength(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/text-element.ts
+++ b/packages/core/src/text-element.ts
@@ -1,0 +1,271 @@
+import type { Page } from '@playwright/test';
+import type { Rect } from './types.js';
+import { ocrStep, expectTimeout } from './ocr-step.js';
+import { getOCRUtil } from './utils/ocr.js';
+import { unhoverBeforeCapture } from './unhover.js';
+import { VISIBLE_CONFIDENCE } from './element.js';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as fsp from 'node:fs/promises';
+
+// ---------------------------------------------------------------------------
+// Text matching
+// ---------------------------------------------------------------------------
+
+export type TextQuery = string | RegExp;
+
+/** Normalise a word for matching: lowercase, strip non-alphanumeric. */
+function normalise(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9 ]/g, '').replace(/\s+/g, ' ').trim();
+}
+
+export interface WordBox {
+  text: string;
+  confidence: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Group a flat list of word boxes into lines by y-center proximity (within 6px),
+ * then sort each line left-to-right.
+ */
+function groupIntoLines(words: WordBox[]): WordBox[][] {
+  const lines: WordBox[][] = [];
+  for (const word of words) {
+    const cy = word.y + word.height / 2;
+    const line = lines.find((l) => Math.abs(l[0]!.y + l[0]!.height / 2 - cy) <= 6);
+    if (line) {
+      line.push(word);
+    } else {
+      lines.push([word]);
+    }
+  }
+  for (const line of lines) line.sort((a, b) => a.x - b.x);
+  return lines;
+}
+
+/**
+ * Test a phrase (joined from a word window) against a query.
+ * String query: normalised case-insensitive equality.
+ * RegExp query: tested against the raw joined phrase.
+ */
+function phraseMatches(rawPhrase: string, query: TextQuery): boolean {
+  if (query instanceof RegExp) return query.test(rawPhrase);
+  return normalise(rawPhrase) === normalise(query);
+}
+
+/**
+ * Union rect of a window of word boxes.
+ */
+function unionRect(window: WordBox[]): Rect {
+  const x = window[0]!.x;
+  const y = Math.min(...window.map((w) => w.y));
+  const x2 = Math.max(...window.map((w) => w.x + w.width));
+  const y2 = Math.max(...window.map((w) => w.y + w.height));
+  return { x, y, width: x2 - x, height: y2 - y };
+}
+
+/** Average Tesseract confidence (0–100) → 0–1. */
+function avgConfidence(window: WordBox[]): number {
+  return window.reduce((s, w) => s + w.confidence, 0) / window.length / 100;
+}
+
+export interface TextMatch {
+  location: Rect;
+  confidence: number;
+  text: string;
+}
+
+/**
+ * Find all matches for a query in a flat list of word boxes.
+ * For string queries, tries every consecutive window of N words (N = word count of query).
+ * For regex queries, tries every window of 1–4 words.
+ */
+export function findAllMatches(words: WordBox[], query: TextQuery): TextMatch[] {
+  const lines = groupIntoLines(words);
+  const matches: TextMatch[] = [];
+
+  const maxWindow = query instanceof RegExp
+    ? 4
+    : (typeof query === 'string' ? query.trim().split(/\s+/).length : 4);
+
+  for (const line of lines) {
+    for (let n = 1; n <= Math.min(maxWindow, line.length); n++) {
+      for (let i = 0; i <= line.length - n; i++) {
+        const window = line.slice(i, i + n);
+        const rawPhrase = window.map((w) => w.text).join(' ');
+        if (phraseMatches(rawPhrase, query)) {
+          matches.push({
+            location: unionRect(window),
+            confidence: avgConfidence(window),
+            text: rawPhrase,
+          });
+        }
+      }
+    }
+  }
+
+  return matches;
+}
+
+// ---------------------------------------------------------------------------
+// TextElement
+// ---------------------------------------------------------------------------
+
+const TEXT_VISIBLE_CONFIDENCE = VISIBLE_CONFIDENCE;
+
+/** OCR word extraction from the live page screenshot. */
+async function extractWords(page: Page, shotDir: string, screenName: string, unhover?: boolean): Promise<{ words: WordBox[]; shotPath: string }> {
+  fs.mkdirSync(shotDir, { recursive: true });
+  const shotPath = path.join(shotDir, `${screenName}-text-live.png`);
+  await unhoverBeforeCapture(page, unhover);
+  await page.screenshot({ path: shotPath, timeout: 2_000 });
+  const buf = await fsp.readFile(shotPath);
+  const ocrUtil = await getOCRUtil();
+  const words = await ocrUtil.extractPageWords(buf);
+  return { words, shotPath };
+}
+
+export type TextElementOptions = {
+  timeout?: number;
+};
+
+/**
+ * A lightweight element located by visible text via OCR.
+ * Returned by `ScreenResult.getByText()` and `ScreenResult.getAllByText()`.
+ * Supports click, visibility assertions, and text assertions.
+ * Does not support fill/toHaveValue — use a registered element for inputs.
+ */
+export class TextElement {
+  constructor(
+    private match: TextMatch,
+    private query: TextQuery,
+    private page?: Page,
+    private shotDir?: string,
+    private screenName?: string,
+    private unhover?: boolean,
+  ) {}
+
+  /** The bounding rect of the matched text in screen coordinates. */
+  bounds(): Rect {
+    return this.match.location;
+  }
+
+  /** The raw OCR text that was matched. */
+  text(): string {
+    return this.match.text;
+  }
+
+  /** Click the center of the matched text region. */
+  async click(): Promise<void> {
+    return ocrStep(`getByText(${formatQuery(this.query)}).click()`, async () => {
+      if (!this.page) throw new Error('click() requires a live page');
+      const { x, y, width, height } = this.match.location;
+      await this.page.mouse.click(x + width / 2, y + height / 2);
+    });
+  }
+
+  /**
+   * Assert the text is visible on screen.
+   * When bound to a live page, polls until the text appears or timeout expires.
+   */
+  async toBeVisible(options?: TextElementOptions): Promise<void> {
+    return ocrStep(`getByText(${formatQuery(this.query)}).toBeVisible()`, async () => {
+      if (this.page) {
+        await this.pollUntil(true, options?.timeout ?? expectTimeout());
+      } else {
+        if (this.match.confidence < TEXT_VISIBLE_CONFIDENCE) {
+          throw new Error(
+            `Text ${formatQuery(this.query)} not visible (confidence: ${this.match.confidence.toFixed(3)})`,
+          );
+        }
+      }
+    });
+  }
+
+  /**
+   * Assert the text is not visible on screen.
+   */
+  async toBeHidden(options?: TextElementOptions): Promise<void> {
+    return ocrStep(`getByText(${formatQuery(this.query)}).toBeHidden()`, async () => {
+      if (this.page) {
+        await this.pollUntil(false, options?.timeout ?? expectTimeout());
+      } else {
+        if (this.match.confidence >= TEXT_VISIBLE_CONFIDENCE) {
+          throw new Error(`Text ${formatQuery(this.query)} is still visible`);
+        }
+      }
+    });
+  }
+
+  /**
+   * Assert the matched OCR text equals or matches expected.
+   */
+  async toHaveText(expected: string | RegExp, options?: TextElementOptions): Promise<void> {
+    return ocrStep(`getByText(${formatQuery(this.query)}).toHaveText(${formatQuery(expected)})`, async () => {
+      const check = () => {
+        const actual = this.match.text;
+        const ok = expected instanceof RegExp ? expected.test(actual) : normalise(actual) === normalise(expected);
+        if (!ok) return `Expected text ${formatQuery(expected)}, got "${actual}"`;
+        return undefined;
+      };
+      const first = check();
+      if (first === undefined) return;
+      if (!this.page || !this.shotDir) throw new Error(first);
+      const deadline = Date.now() + (options?.timeout ?? expectTimeout());
+      let lastErr = first;
+      while (Date.now() < deadline) {
+        await new Promise<void>((r) => setTimeout(r, 150));
+        const { words } = await extractWords(this.page!, this.shotDir!, this.screenName ?? 'screen', this.unhover);
+        const found = findAllMatches(words, this.query);
+        if (found[0]) this.match = found[0];
+        const next = check();
+        if (next === undefined) return;
+        lastErr = next;
+      }
+      throw new Error(lastErr);
+    });
+  }
+
+  /**
+   * Wait until this text is visible on screen.
+   * Equivalent to toBeVisible() — exists for ergonomic parity with ScreenElement.waitFor().
+   */
+  async waitFor(options?: TextElementOptions): Promise<void> {
+    return this.toBeVisible(options);
+  }
+
+  private async pollUntil(wantVisible: boolean, timeout: number): Promise<void> {
+    if (!this.page || !this.shotDir) {
+      throw new Error('pollUntil requires a live page');
+    }
+    const deadline = Date.now() + timeout;
+    let lastConf = this.match.confidence;
+    const already = (wantVisible ? lastConf >= TEXT_VISIBLE_CONFIDENCE : lastConf < TEXT_VISIBLE_CONFIDENCE);
+    if (already) return;
+    while (Date.now() < deadline) {
+      await new Promise<void>((r) => setTimeout(r, 150));
+      try {
+        const { words } = await extractWords(this.page, this.shotDir, this.screenName ?? 'screen', this.unhover);
+        const found = findAllMatches(words, this.query);
+        lastConf = found[0]?.confidence ?? 0;
+        if (found[0]) this.match = found[0];
+        const met = wantVisible ? lastConf >= TEXT_VISIBLE_CONFIDENCE : lastConf < TEXT_VISIBLE_CONFIDENCE;
+        if (met) return;
+      } catch {
+        // navigation / partial screenshot
+      }
+    }
+    const state = wantVisible ? 'visible' : 'hidden';
+    throw new Error(
+      `Text ${formatQuery(this.query)} not ${state} within ${timeout}ms (confidence: ${lastConf.toFixed(3)})`,
+    );
+  }
+}
+
+function formatQuery(q: string | RegExp): string {
+  return q instanceof RegExp ? String(q) : `"${q}"`;
+}

--- a/packages/core/src/text-element.ts
+++ b/packages/core/src/text-element.ts
@@ -4,9 +4,9 @@ import { ocrStep, expectTimeout } from './ocr-step.js';
 import { getOCRUtil } from './utils/ocr.js';
 import { unhoverBeforeCapture } from './unhover.js';
 import { VISIBLE_CONFIDENCE } from './element.js';
+import { getClickStrategy } from './strategies.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import * as fsp from 'node:fs/promises';
 
 // ---------------------------------------------------------------------------
 // Text matching
@@ -36,7 +36,7 @@ function groupIntoLines(words: WordBox[]): WordBox[][] {
   const lines: WordBox[][] = [];
   for (const word of words) {
     const cy = word.y + word.height / 2;
-    const line = lines.find((l) => Math.abs(l[0]!.y + l[0]!.height / 2 - cy) <= 6);
+    const line = lines.find((l) => l.some((w) => Math.abs(w.y + w.height / 2 - cy) <= 6));
     if (line) {
       line.push(word);
     } else {
@@ -118,15 +118,14 @@ export function findAllMatches(words: WordBox[], query: TextQuery): TextMatch[] 
 const TEXT_VISIBLE_CONFIDENCE = VISIBLE_CONFIDENCE;
 
 /** OCR word extraction from the live page screenshot. */
-async function extractWords(page: Page, shotDir: string, screenName: string, unhover?: boolean): Promise<{ words: WordBox[]; shotPath: string }> {
+export async function extractWords(page: Page, shotDir: string, screenName: string, unhover?: boolean): Promise<{ words: WordBox[] }> {
   fs.mkdirSync(shotDir, { recursive: true });
   const shotPath = path.join(shotDir, `${screenName}-text-live.png`);
   await unhoverBeforeCapture(page, unhover);
-  await page.screenshot({ path: shotPath, timeout: 2_000 });
-  const buf = await fsp.readFile(shotPath);
+  const buf = await page.screenshot({ path: shotPath, timeout: 2_000 });
   const ocrUtil = await getOCRUtil();
   const words = await ocrUtil.extractPageWords(buf);
-  return { words, shotPath };
+  return { words };
 }
 
 export type TextElementOptions = {
@@ -159,12 +158,12 @@ export class TextElement {
     return this.match.text;
   }
 
-  /** Click the center of the matched text region. */
+  /** Click the matched text region using the configured ClickStrategy. */
   async click(): Promise<void> {
     return ocrStep(`getByText(${formatQuery(this.query)}).click()`, async () => {
       if (!this.page) throw new Error('click() requires a live page');
-      const { x, y, width, height } = this.match.location;
-      await this.page.mouse.click(x + width / 2, y + height / 2);
+      const { x, y } = getClickStrategy().getPoint(this.match.location);
+      await this.page.mouse.click(x, y);
     });
   }
 

--- a/packages/core/src/unhover.ts
+++ b/packages/core/src/unhover.ts
@@ -11,6 +11,13 @@ export function setUnhoverPoint(point: { x: number; y: number } | undefined): vo
   globalUnhoverPoint = point;
 }
 
+let globalUnhoverPoint: { x: number; y: number } | undefined;
+
+/** Set by `init({ unhoverPoint })`. Pass `undefined` to clear. */
+export function setUnhoverPoint(point: { x: number; y: number } | undefined): void {
+  globalUnhoverPoint = point;
+}
+
 /**
  * Move the mouse off interactive content so template matching is not skewed by
  * hover highlights. Enabled by default; pass `false` or

--- a/packages/core/src/unhover.ts
+++ b/packages/core/src/unhover.ts
@@ -11,13 +11,6 @@ export function setUnhoverPoint(point: { x: number; y: number } | undefined): vo
   globalUnhoverPoint = point;
 }
 
-let globalUnhoverPoint: { x: number; y: number } | undefined;
-
-/** Set by `init({ unhoverPoint })`. Pass `undefined` to clear. */
-export function setUnhoverPoint(point: { x: number; y: number } | undefined): void {
-  globalUnhoverPoint = point;
-}
-
 /**
  * Move the mouse off interactive content so template matching is not skewed by
  * hover highlights. Enabled by default; pass `false` or


### PR DESCRIPTION
Closes #45

## Summary

- **`screen.getByText(query, opts?)`** — OCR-polls the live page until the text appears (default timeout), returns a `TextElement`
- **`screen.getAllByText(query)`** — no implicit wait; returns all current `TextElement` matches
- **`screen.toContainText(query, opts?)`** — screen-level assertion that any matching text with confidence ≥ 0.7 is present
- **`TextElement`** — lightweight locator with `click()`, `toBeVisible()`, `toBeHidden()`, `toHaveText()`, `waitFor()`; no `fill()` or `toHaveValue()` (those belong on registered elements with blank/live diffs)

Both `string` and `RegExp` queries are supported throughout. String matching is case-insensitive with punctuation stripped. Words are grouped into lines by y-center proximity (±6 px); match location is the bounding union of all matched words.

## New files

| File | Purpose |
|---|---|
| `text-element.ts` | `TextElement`, `findAllMatches`, `WordBox`, `TextQuery`, `TextMatch` |
| `text-element.test.ts` | 25 unit tests (no mocks needed for pure matching logic) |

## Test plan

- [ ] All 307 unit tests pass (`npx vitest run`)
- [ ] TypeScript clean (`npm run typecheck`)
- [ ] `findAllMatches` tested for: single/multi-word string, case-insensitivity, punctuation stripping, cross-line miss, regex single/multi-word, regex window cap (4), line grouping within ±6 px
- [ ] `TextElement` tested for: `bounds()`, `text()`, `click()` guard, `toBeVisible` pass/fail, `toBeHidden` pass/fail, `toHaveText` string/regex/throw, `waitFor()` delegation

🤖 Generated with [Claude Code](https://claude.com/claude-code)