### PR TITLE
feat: getByText / getAllByText / toContainText on ScreenResult

### DIFF
--- a/packages/core/src/configure.ts
+++ b/packages/core/src/configure.ts
@@ -19,7 +19,7 @@ interface GlobalConfig {
    */
   unhoverBeforeCapture?: boolean;
   /**
-   * Override the default `{ x: 8, y: 8 }` unhover destination.
+   * Override the default unhover destination (top-left corner).
    * Useful when the top-left corner overlaps interactive content.
    */
   unhoverPoint?: { x: number; y: number };
@@ -34,6 +34,11 @@ export function getGlobalConfig(): GlobalConfig {
 /** Reset merged config (unit tests). */
 export function resetGlobalConfig(): void {
   globalConfig = {};
+}
+
+/** Clear only the unhoverPoint from the global config (called by release()). */
+export function clearConfigUnhoverPoint(): void {
+  delete (globalConfig as { unhoverPoint?: unknown }).unhoverPoint;
 }
 
 /**

--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -529,7 +529,8 @@ export class ScreenElement {
       await this.withOverlay(async () => {
         const rect = this.result.ocrLocation ?? this.result.location;
         if (!this.page) throw new Error('Page not provided. Cannot double-click element.');
-        await this.page.mouse.dblclick(rect.x + rect.width / 2, rect.y + rect.height / 2);
+        const { x, y } = getClickStrategy().getPoint(rect);
+        await this.page.mouse.dblclick(x, y);
         this.live?.markDirty();
       });
     });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,8 @@ export type { TypedScreenConfig } from './typed-screen.js';
 export { ScreenResult } from './screen-result.js';
 export { ScreenElement, NegatedScreenElement } from './element.js';
 export type { HaveTextOptions, MatchOptions, WaitForOptions } from './element.js';
+export { TextElement, findAllMatches } from './text-element.js';
+export type { TextQuery, TextElementOptions, TextMatch, WordBox } from './text-element.js';
 
 export { ElementType } from './field-extractor.js';
 export type { ElementConfig, ElementResult, ScreenComparison } from './field-extractor.js';

--- a/packages/core/src/screen-result.ts
+++ b/packages/core/src/screen-result.ts
@@ -1,14 +1,13 @@
 import type { ElementConfig, ElementResult, ScreenComparison } from './types.js';
 import type { ScreenConfig } from './screen-config.js';
 import { ScreenElement, VISIBLE_CONFIDENCE, type MatchOptions, type WaitForOptions } from './element.js';
-import { TextElement, findAllMatches, type TextQuery, type TextElementOptions } from './text-element.js';
+import { TextElement, findAllMatches, extractWords, type TextQuery, type TextElementOptions } from './text-element.js';
 import type { Page } from '@playwright/test';
 import { ocrStep, expectTimeout } from './ocr-step.js';
 import { hideOcrOverlay, overlayBoxesFromResult, showOcrOverlay } from './ocr-overlay.js';
 import { unhoverBeforeCapture } from './unhover.js';
 import { resolveCharsetSwaps, getOcrStrategy, getOCRUtil, type FieldRead } from './utils/ocr.js';
 import * as fs from 'node:fs';
-import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 
 export type ScreenExtractor = {
@@ -320,18 +319,11 @@ export class ScreenResult {
   // Text locators
   // ---------------------------------------------------------------------------
 
-  private async captureWords(): Promise<{ words: import('./text-element.js').WordBox[]; shotDir: string }> {
+  private async captureWords(): Promise<{ words: import('./text-element.js').WordBox[] }> {
     if (!this.host || !this.page) {
       throw new Error('getByText / toContainText requires ScreenResult.bind(page, ...)');
     }
-    fs.mkdirSync(this.host.shotDir, { recursive: true });
-    const shotPath = path.join(this.host.shotDir, `${this.host.screen.name}-text-live.png`);
-    await unhoverBeforeCapture(this.page, this.host.unhover);
-    await this.page.screenshot({ path: shotPath, timeout: 2_000 });
-    const buf = await fsp.readFile(shotPath);
-    const ocrUtil = await getOCRUtil();
-    const words = await ocrUtil.extractPageWords(buf);
-    return { words, shotDir: this.host.shotDir };
+    return extractWords(this.page, this.host.shotDir, this.host.screen.name, this.host.unhover);
   }
 
   /**
@@ -351,17 +343,21 @@ export class ScreenResult {
       const timeout = options?.timeout ?? 15_000;
       const deadline = Date.now() + timeout;
       while (true) {
-        const { words: w } = await this.captureWords();
-        const matches = findAllMatches(w, query);
-        if (matches[0]) {
-          return new TextElement(
-            matches[0],
-            query,
-            this.page,
-            this.host.shotDir,
-            this.host.screen.name,
-            this.host.unhover,
-          );
+        try {
+          const { words: w } = await this.captureWords();
+          const matches = findAllMatches(w, query);
+          if (matches[0]) {
+            return new TextElement(
+              matches[0],
+              query,
+              this.page,
+              this.host.shotDir,
+              this.host.screen.name,
+              this.host.unhover,
+            );
+          }
+        } catch {
+          // transient screenshot error (navigation, partial load) — retry
         }
         if (Date.now() >= deadline) break;
         await new Promise<void>((r) => setTimeout(r, 150));
@@ -401,12 +397,13 @@ export class ScreenResult {
     return ocrStep(`screen.toContainText(${String(query)})`, async () => {
       const timeout = options?.timeout ?? expectTimeout();
       const deadline = Date.now() + timeout;
-      let found = false;
       while (true) {
-        const { words } = await this.captureWords();
-        const matches = findAllMatches(words, query);
-        found = matches.length > 0 && (matches[0]?.confidence ?? 0) >= VISIBLE_CONFIDENCE;
-        if (found) return;
+        try {
+          const { words } = await this.captureWords();
+          if (findAllMatches(words, query).some((m) => m.confidence >= VISIBLE_CONFIDENCE)) return;
+        } catch {
+          // transient screenshot error (navigation, partial load) — retry
+        }
         if (Date.now() >= deadline) break;
         await new Promise<void>((r) => setTimeout(r, 150));
       }

--- a/packages/core/src/screen-result.ts
+++ b/packages/core/src/screen-result.ts
@@ -1,12 +1,14 @@
 import type { ElementConfig, ElementResult, ScreenComparison } from './types.js';
 import type { ScreenConfig } from './screen-config.js';
 import { ScreenElement, VISIBLE_CONFIDENCE, type MatchOptions, type WaitForOptions } from './element.js';
+import { TextElement, findAllMatches, type TextQuery, type TextElementOptions } from './text-element.js';
 import type { Page } from '@playwright/test';
-import { ocrStep } from './ocr-step.js';
+import { ocrStep, expectTimeout } from './ocr-step.js';
 import { hideOcrOverlay, overlayBoxesFromResult, showOcrOverlay } from './ocr-overlay.js';
 import { unhoverBeforeCapture } from './unhover.js';
-import { resolveCharsetSwaps, getOcrStrategy, type FieldRead } from './utils/ocr.js';
+import { resolveCharsetSwaps, getOcrStrategy, getOCRUtil, type FieldRead } from './utils/ocr.js';
 import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 
 export type ScreenExtractor = {
@@ -312,6 +314,104 @@ export class ScreenResult {
   async hideOverlay(): Promise<void> {
     if (!this.page || !this.host?.overlay) return;
     await hideOcrOverlay(this.page);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Text locators
+  // ---------------------------------------------------------------------------
+
+  private async captureWords(): Promise<{ words: import('./text-element.js').WordBox[]; shotDir: string }> {
+    if (!this.host || !this.page) {
+      throw new Error('getByText / toContainText requires ScreenResult.bind(page, ...)');
+    }
+    fs.mkdirSync(this.host.shotDir, { recursive: true });
+    const shotPath = path.join(this.host.shotDir, `${this.host.screen.name}-text-live.png`);
+    await unhoverBeforeCapture(this.page, this.host.unhover);
+    await this.page.screenshot({ path: shotPath, timeout: 2_000 });
+    const buf = await fsp.readFile(shotPath);
+    const ocrUtil = await getOCRUtil();
+    const words = await ocrUtil.extractPageWords(buf);
+    return { words, shotDir: this.host.shotDir };
+  }
+
+  /**
+   * Find the first occurrence of text on screen via OCR.
+   * Waits until the text is visible (by default).
+   * Use for dynamic / ad-hoc content that is not registered in index.json —
+   * dropdown options, toast messages, menu rows, table cells.
+   *
+   * @param query - Exact string (case-insensitive) or RegExp.
+   * @param options.timeout - How long to wait for the text to appear (ms). Default 15 000.
+   */
+  async getByText(query: TextQuery, options?: TextElementOptions): Promise<TextElement> {
+    return ocrStep(`screen.getByText(${String(query)})`, async () => {
+      if (!this.host || !this.page) {
+        throw new Error('getByText requires ScreenResult.bind(page, ...)');
+      }
+      const timeout = options?.timeout ?? 15_000;
+      const deadline = Date.now() + timeout;
+      while (true) {
+        const { words: w } = await this.captureWords();
+        const matches = findAllMatches(w, query);
+        if (matches[0]) {
+          return new TextElement(
+            matches[0],
+            query,
+            this.page,
+            this.host.shotDir,
+            this.host.screen.name,
+            this.host.unhover,
+          );
+        }
+        if (Date.now() >= deadline) break;
+        await new Promise<void>((r) => setTimeout(r, 150));
+      }
+      throw new Error(`Text ${String(query)} not found within ${timeout}ms`);
+    });
+  }
+
+  /**
+   * Find all occurrences of text on screen via OCR.
+   * Returns immediately with whatever matches are currently visible — no implicit wait.
+   * Use for list rows, repeated badges, or any case where multiple matches are expected.
+   */
+  async getAllByText(query: TextQuery): Promise<TextElement[]> {
+    return ocrStep(`screen.getAllByText(${String(query)})`, async () => {
+      const { words } = await this.captureWords();
+      const matches = findAllMatches(words, query);
+      return matches.map((m) => new TextElement(
+        m,
+        query,
+        this.page,
+        this.host?.shotDir,
+        this.host?.screen.name,
+        this.host?.unhover,
+      ));
+    });
+  }
+
+  /**
+   * Assert that the given text is visible anywhere on screen.
+   * Useful for smoke-checking dynamic feedback without registering an element.
+   *
+   * @param query - Exact string (case-insensitive) or RegExp.
+   * @param options.timeout - How long to poll (ms). Default: expectTimeout().
+   */
+  async toContainText(query: TextQuery, options?: TextElementOptions): Promise<void> {
+    return ocrStep(`screen.toContainText(${String(query)})`, async () => {
+      const timeout = options?.timeout ?? expectTimeout();
+      const deadline = Date.now() + timeout;
+      let found = false;
+      while (true) {
+        const { words } = await this.captureWords();
+        const matches = findAllMatches(words, query);
+        found = matches.length > 0 && (matches[0]?.confidence ?? 0) >= VISIBLE_CONFIDENCE;
+        if (found) return;
+        if (Date.now() >= deadline) break;
+        await new Promise<void>((r) => setTimeout(r, 150));
+      }
+      throw new Error(`Screen does not contain text ${String(query)} within ${timeout}ms`);
+    });
   }
 
   /**

--- a/packages/core/src/screen.ts
+++ b/packages/core/src/screen.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { test as base } from '@playwright/test';
 import type { Page, TestType } from '@playwright/test';
 import type { ScreenConfig } from './screen-config.js';
-import { loadScreen } from './configure.js';
+import { loadScreen, clearConfigUnhoverPoint } from './configure.js';
 import { FieldExtractor } from './field-extractor.js';
 import { ScreenResult } from './screen-result.js';
 import { cleanupOCR, getOCRUtil, setCharsetRegistry, setOcrStrategy, type Charset, type FieldRead } from './utils/ocr.js';
@@ -91,7 +91,7 @@ interface InitOptions {
   /** Environment-level read override. Wins over index.json; call site wins over this. */
   read?: FieldRead;
   /**
-   * Override the default `{ x: 8, y: 8 }` unhover destination.
+   * Override the default unhover destination (top-left corner).
    * Useful when the top-left corner overlaps interactive content.
    */
   unhoverPoint?: { x: number; y: number };
@@ -216,6 +216,7 @@ export async function release(): Promise<void> {
   initState?.extractor.cleanup();
   initState = null;
   setUnhoverPoint(undefined);
+  clearConfigUnhoverPoint();
   setClickStrategy(undefined);
   setFillStrategy(undefined);
   setCharsetRegistry({});

--- a/packages/core/src/text-element.test.ts
+++ b/packages/core/src/text-element.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { findAllMatches, TextElement } from './text-element.js';
+import type { WordBox, TextMatch } from './text-element.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function word(text: string, x: number, y: number, w = 50, h = 16, conf = 90): WordBox {
+  return { text, confidence: conf, x, y, width: w, height: h };
+}
+
+function match(text: string, conf = 0.9): TextMatch {
+  return { location: { x: 0, y: 0, width: 50, height: 16 }, confidence: conf, text };
+}
+
+// ---------------------------------------------------------------------------
+// findAllMatches — string queries
+// ---------------------------------------------------------------------------
+
+describe('findAllMatches — string', () => {
+  it('matches a single word', () => {
+    const words = [word('Hello', 0, 0), word('World', 60, 0)];
+    const hits = findAllMatches(words, 'Hello');
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.text).toBe('Hello');
+  });
+
+  it('matches a two-word phrase', () => {
+    const words = [word('Hello', 0, 0), word('World', 60, 0)];
+    const hits = findAllMatches(words, 'Hello World');
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.text).toBe('Hello World');
+  });
+
+  it('is case-insensitive', () => {
+    const words = [word('SUBMIT', 0, 0)];
+    expect(findAllMatches(words, 'submit')).toHaveLength(1);
+  });
+
+  it('strips punctuation when comparing', () => {
+    const words = [word('Done!', 0, 0)];
+    expect(findAllMatches(words, 'Done')).toHaveLength(1);
+  });
+
+  it('does not match across lines (different y)', () => {
+    // word at y=0 and y=30 — more than 6px apart, different lines
+    const words = [word('Hello', 0, 0), word('World', 0, 30)];
+    const hits = findAllMatches(words, 'Hello World');
+    expect(hits).toHaveLength(0);
+  });
+
+  it('returns empty when no match', () => {
+    const words = [word('Foo', 0, 0)];
+    expect(findAllMatches(words, 'Bar')).toHaveLength(0);
+  });
+
+  it('confidence is average of word confidences / 100', () => {
+    const words = [word('A', 0, 0, 50, 16, 80), word('B', 60, 0, 50, 16, 60)];
+    const hits = findAllMatches(words, 'A B');
+    expect(hits[0]!.confidence).toBeCloseTo(0.7);
+  });
+
+  it('location is bounding box of all matched words', () => {
+    const words = [word('First', 10, 5, 40, 16), word('Last', 70, 3, 50, 20)];
+    const hits = findAllMatches(words, 'First Last');
+    const loc = hits[0]!.location;
+    expect(loc.x).toBe(10);
+    expect(loc.y).toBe(3);
+    expect(loc.width).toBe(110); // (70+50) - 10
+    expect(loc.height).toBe(20); // max(5+16, 3+20) - 3 = 23 - 3
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findAllMatches — regex queries
+// ---------------------------------------------------------------------------
+
+describe('findAllMatches — regex', () => {
+  it('matches a regex against a single word', () => {
+    const words = [word('Order-12345', 0, 0)];
+    const hits = findAllMatches(words, /Order-\d+/);
+    expect(hits).toHaveLength(1);
+  });
+
+  it('matches a regex spanning two words', () => {
+    const words = [word('Aug', 0, 0), word('22', 60, 0)];
+    const hits = findAllMatches(words, /Aug \d+/);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.text).toBe('Aug 22');
+  });
+
+  it('returns empty when regex does not match', () => {
+    const words = [word('Foo', 0, 0)];
+    expect(findAllMatches(words, /\d{4}/)).toHaveLength(0);
+  });
+
+  it('caps window size at 4 words for regex', () => {
+    // 5-word line — a regex match on words 1-4 is fine, but not 1-5
+    const ws = [
+      word('a', 0, 0), word('b', 20, 0), word('c', 40, 0),
+      word('d', 60, 0), word('e', 80, 0),
+    ];
+    const hits = findAllMatches(ws, /a b c d/);
+    expect(hits).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findAllMatches — line grouping
+// ---------------------------------------------------------------------------
+
+describe('findAllMatches — line grouping', () => {
+  it('groups words within 6px y-center into the same line', () => {
+    const words = [word('A', 0, 0), word('B', 60, 4)]; // cy=8 and cy=12 → diff=4 ≤ 6
+    const hits = findAllMatches(words, 'A B');
+    expect(hits).toHaveLength(1);
+  });
+
+  it('does not group words more than 6px apart', () => {
+    const words = [word('A', 0, 0), word('B', 0, 20)]; // cy=8 and cy=28 → diff=20
+    const hits = findAllMatches(words, 'A B');
+    expect(hits).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TextElement — static (no live page)
+// ---------------------------------------------------------------------------
+
+describe('TextElement (static, no page)', () => {
+  it('bounds() returns match location', () => {
+    const m = match('Submit');
+    m.location = { x: 10, y: 20, width: 60, height: 18 };
+    const el = new TextElement(m, 'Submit');
+    expect(el.bounds()).toEqual({ x: 10, y: 20, width: 60, height: 18 });
+  });
+
+  it('text() returns raw matched text', () => {
+    const el = new TextElement(match('Hello World'), 'Hello World');
+    expect(el.text()).toBe('Hello World');
+  });
+
+  it('click() throws without a page', async () => {
+    const el = new TextElement(match('Btn'), 'Btn');
+    await expect(el.click()).rejects.toThrow('click() requires a live page');
+  });
+
+  it('toBeVisible() passes when confidence is high enough', async () => {
+    const el = new TextElement(match('OK', 0.95), 'OK');
+    await expect(el.toBeVisible()).resolves.toBeUndefined();
+  });
+
+  it('toBeVisible() throws when confidence is below threshold', async () => {
+    const el = new TextElement(match('OK', 0.3), 'OK');
+    await expect(el.toBeVisible()).rejects.toThrow(/not visible/i);
+  });
+
+  it('toBeHidden() passes when confidence is below threshold', async () => {
+    const el = new TextElement(match('Gone', 0.3), 'Gone');
+    await expect(el.toBeHidden()).resolves.toBeUndefined();
+  });
+
+  it('toBeHidden() throws when text is still visible', async () => {
+    const el = new TextElement(match('Gone', 0.95), 'Gone');
+    await expect(el.toBeHidden()).rejects.toThrow(/still visible/i);
+  });
+
+  it('toHaveText() passes when text matches string', async () => {
+    const el = new TextElement(match('Submit'), 'Submit');
+    await expect(el.toHaveText('Submit')).resolves.toBeUndefined();
+  });
+
+  it('toHaveText() passes when text matches regex', async () => {
+    const el = new TextElement(match('Order-123'), /Order-\d+/);
+    await expect(el.toHaveText(/Order-\d+/)).resolves.toBeUndefined();
+  });
+
+  it('toHaveText() throws on mismatch without page', async () => {
+    const el = new TextElement(match('Foo'), 'Foo');
+    await expect(el.toHaveText('Bar')).rejects.toThrow(/Expected text/i);
+  });
+
+  it('waitFor() delegates to toBeVisible()', async () => {
+    const el = new TextElement(match('OK', 0.95), 'OK');
+    await expect(el.waitFor()).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/text-element.test.ts
+++ b/packages/core/src/text-element.test.ts
@@ -122,6 +122,13 @@ describe('findAllMatches — line grouping', () => {
     const hits = findAllMatches(words, 'A B');
     expect(hits).toHaveLength(0);
   });
+
+  it('groups a third word within 6px of a non-first group member', () => {
+    // cy: A=8, B=10, C=16 — A and B join (|10-8|=2≤6); C is >6 from A but ≤6 from B
+    const words = [word('A', 0, 0), word('B', 60, 2), word('C', 120, 8)];
+    const hits = findAllMatches(words, 'A B C');
+    expect(hits).toHaveLength(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/text-element.ts
+++ b/packages/core/src/text-element.ts
@@ -1,0 +1,271 @@
+import type { Page } from '@playwright/test';
+import type { Rect } from './types.js';
+import { ocrStep, expectTimeout } from './ocr-step.js';
+import { getOCRUtil } from './utils/ocr.js';
+import { unhoverBeforeCapture } from './unhover.js';
+import { VISIBLE_CONFIDENCE } from './element.js';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as fsp from 'node:fs/promises';
+
+// ---------------------------------------------------------------------------
+// Text matching
+// ---------------------------------------------------------------------------
+
+export type TextQuery = string | RegExp;
+
+/** Normalise a word for matching: lowercase, strip non-alphanumeric. */
+function normalise(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9 ]/g, '').replace(/\s+/g, ' ').trim();
+}
+
+export interface WordBox {
+  text: string;
+  confidence: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Group a flat list of word boxes into lines by y-center proximity (within 6px),
+ * then sort each line left-to-right.
+ */
+function groupIntoLines(words: WordBox[]): WordBox[][] {
+  const lines: WordBox[][] = [];
+  for (const word of words) {
+    const cy = word.y + word.height / 2;
+    const line = lines.find((l) => Math.abs(l[0]!.y + l[0]!.height / 2 - cy) <= 6);
+    if (line) {
+      line.push(word);
+    } else {
+      lines.push([word]);
+    }
+  }
+  for (const line of lines) line.sort((a, b) => a.x - b.x);
+  return lines;
+}
+
+/**
+ * Test a phrase (joined from a word window) against a query.
+ * String query: normalised case-insensitive equality.
+ * RegExp query: tested against the raw joined phrase.
+ */
+function phraseMatches(rawPhrase: string, query: TextQuery): boolean {
+  if (query instanceof RegExp) return query.test(rawPhrase);
+  return normalise(rawPhrase) === normalise(query);
+}
+
+/**
+ * Union rect of a window of word boxes.
+ */
+function unionRect(window: WordBox[]): Rect {
+  const x = window[0]!.x;
+  const y = Math.min(...window.map((w) => w.y));
+  const x2 = Math.max(...window.map((w) => w.x + w.width));
+  const y2 = Math.max(...window.map((w) => w.y + w.height));
+  return { x, y, width: x2 - x, height: y2 - y };
+}
+
+/** Average Tesseract confidence (0–100) → 0–1. */
+function avgConfidence(window: WordBox[]): number {
+  return window.reduce((s, w) => s + w.confidence, 0) / window.length / 100;
+}
+
+export interface TextMatch {
+  location: Rect;
+  confidence: number;
+  text: string;
+}
+
+/**
+ * Find all matches for a query in a flat list of word boxes.
+ * For string queries, tries every consecutive window of N words (N = word count of query).
+ * For regex queries, tries every window of 1–4 words.
+ */
+export function findAllMatches(words: WordBox[], query: TextQuery): TextMatch[] {
+  const lines = groupIntoLines(words);
+  const matches: TextMatch[] = [];
+
+  const maxWindow = query instanceof RegExp
+    ? 4
+    : (typeof query === 'string' ? query.trim().split(/\s+/).length : 4);
+
+  for (const line of lines) {
+    for (let n = 1; n <= Math.min(maxWindow, line.length); n++) {
+      for (let i = 0; i <= line.length - n; i++) {
+        const window = line.slice(i, i + n);
+        const rawPhrase = window.map((w) => w.text).join(' ');
+        if (phraseMatches(rawPhrase, query)) {
+          matches.push({
+            location: unionRect(window),
+            confidence: avgConfidence(window),
+            text: rawPhrase,
+          });
+        }
+      }
+    }
+  }
+
+  return matches;
+}
+
+// ---------------------------------------------------------------------------
+// TextElement
+// ---------------------------------------------------------------------------
+
+const TEXT_VISIBLE_CONFIDENCE = VISIBLE_CONFIDENCE;
+
+/** OCR word extraction from the live page screenshot. */
+async function extractWords(page: Page, shotDir: string, screenName: string, unhover?: boolean): Promise<{ words: WordBox[]; shotPath: string }> {
+  fs.mkdirSync(shotDir, { recursive: true });
+  const shotPath = path.join(shotDir, `${screenName}-text-live.png`);
+  await unhoverBeforeCapture(page, unhover);
+  await page.screenshot({ path: shotPath, timeout: 2_000 });
+  const buf = await fsp.readFile(shotPath);
+  const ocrUtil = await getOCRUtil();
+  const words = await ocrUtil.extractPageWords(buf);
+  return { words, shotPath };
+}
+
+export type TextElementOptions = {
+  timeout?: number;
+};
+
+/**
+ * A lightweight element located by visible text via OCR.
+ * Returned by `ScreenResult.getByText()` and `ScreenResult.getAllByText()`.
+ * Supports click, visibility assertions, and text assertions.
+ * Does not support fill/toHaveValue — use a registered element for inputs.
+ */
+export class TextElement {
+  constructor(
+    private match: TextMatch,
+    private query: TextQuery,
+    private page?: Page,
+    private shotDir?: string,
+    private screenName?: string,
+    private unhover?: boolean,
+  ) {}
+
+  /** The bounding rect of the matched text in screen coordinates. */
+  bounds(): Rect {
+    return this.match.location;
+  }
+
+  /** The raw OCR text that was matched. */
+  text(): string {
+    return this.match.text;
+  }
+
+  /** Click the center of the matched text region. */
+  async click(): Promise<void> {
+    return ocrStep(`getByText(${formatQuery(this.query)}).click()`, async () => {
+      if (!this.page) throw new Error('click() requires a live page');
+      const { x, y, width, height } = this.match.location;
+      await this.page.mouse.click(x + width / 2, y + height / 2);
+    });
+  }
+
+  /**
+   * Assert the text is visible on screen.
+   * When bound to a live page, polls until the text appears or timeout expires.
+   */
+  async toBeVisible(options?: TextElementOptions): Promise<void> {
+    return ocrStep(`getByText(${formatQuery(this.query)}).toBeVisible()`, async () => {
+      if (this.page) {
+        await this.pollUntil(true, options?.timeout ?? expectTimeout());
+      } else {
+        if (this.match.confidence < TEXT_VISIBLE_CONFIDENCE) {
+          throw new Error(
+            `Text ${formatQuery(this.query)} not visible (confidence: ${this.match.confidence.toFixed(3)})`,
+          );
+        }
+      }
+    });
+  }
+
+  /**
+   * Assert the text is not visible on screen.
+   */
+  async toBeHidden(options?: TextElementOptions): Promise<void> {
+    return ocrStep(`getByText(${formatQuery(this.query)}).toBeHidden()`, async () => {
+      if (this.page) {
+        await this.pollUntil(false, options?.timeout ?? expectTimeout());
+      } else {
+        if (this.match.confidence >= TEXT_VISIBLE_CONFIDENCE) {
+          throw new Error(`Text ${formatQuery(this.query)} is still visible`);
+        }
+      }
+    });
+  }
+
+  /**
+   * Assert the matched OCR text equals or matches expected.
+   */
+  async toHaveText(expected: string | RegExp, options?: TextElementOptions): Promise<void> {
+    return ocrStep(`getByText(${formatQuery(this.query)}).toHaveText(${formatQuery(expected)})`, async () => {
+      const check = () => {
+        const actual = this.match.text;
+        const ok = expected instanceof RegExp ? expected.test(actual) : normalise(actual) === normalise(expected);
+        if (!ok) return `Expected text ${formatQuery(expected)}, got "${actual}"`;
+        return undefined;
+      };
+      const first = check();
+      if (first === undefined) return;
+      if (!this.page || !this.shotDir) throw new Error(first);
+      const deadline = Date.now() + (options?.timeout ?? expectTimeout());
+      let lastErr = first;
+      while (Date.now() < deadline) {
+        await new Promise<void>((r) => setTimeout(r, 150));
+        const { words } = await extractWords(this.page!, this.shotDir!, this.screenName ?? 'screen', this.unhover);
+        const found = findAllMatches(words, this.query);
+        if (found[0]) this.match = found[0];
+        const next = check();
+        if (next === undefined) return;
+        lastErr = next;
+      }
+      throw new Error(lastErr);
+    });
+  }
+
+  /**
+   * Wait until this text is visible on screen.
+   * Equivalent to toBeVisible() — exists for ergonomic parity with ScreenElement.waitFor().
+   */
+  async waitFor(options?: TextElementOptions): Promise<void> {
+    return this.toBeVisible(options);
+  }
+
+  private async pollUntil(wantVisible: boolean, timeout: number): Promise<void> {
+    if (!this.page || !this.shotDir) {
+      throw new Error('pollUntil requires a live page');
+    }
+    const deadline = Date.now() + timeout;
+    let lastConf = this.match.confidence;
+    const already = (wantVisible ? lastConf >= TEXT_VISIBLE_CONFIDENCE : lastConf < TEXT_VISIBLE_CONFIDENCE);
+    if (already) return;
+    while (Date.now() < deadline) {
+      await new Promise<void>((r) => setTimeout(r, 150));
+      try {
+        const { words } = await extractWords(this.page, this.shotDir, this.screenName ?? 'screen', this.unhover);
+        const found = findAllMatches(words, this.query);
+        lastConf = found[0]?.confidence ?? 0;
+        if (found[0]) this.match = found[0];
+        const met = wantVisible ? lastConf >= TEXT_VISIBLE_CONFIDENCE : lastConf < TEXT_VISIBLE_CONFIDENCE;
+        if (met) return;
+      } catch {
+        // navigation / partial screenshot
+      }
+    }
+    const state = wantVisible ? 'visible' : 'hidden';
+    throw new Error(
+      `Text ${formatQuery(this.query)} not ${state} within ${timeout}ms (confidence: ${lastConf.toFixed(3)})`,
+    );
+  }
+}
+
+function formatQuery(q: string | RegExp): string {
+  return q instanceof RegExp ? String(q) : `"${q}"`;
+}

--- a/packages/core/src/text-element.ts
+++ b/packages/core/src/text-element.ts
@@ -4,9 +4,9 @@ import { ocrStep, expectTimeout } from './ocr-step.js';
 import { getOCRUtil } from './utils/ocr.js';
 import { unhoverBeforeCapture } from './unhover.js';
 import { VISIBLE_CONFIDENCE } from './element.js';
+import { getClickStrategy } from './strategies.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import * as fsp from 'node:fs/promises';
 
 // ---------------------------------------------------------------------------
 // Text matching
@@ -36,7 +36,7 @@ function groupIntoLines(words: WordBox[]): WordBox[][] {
   const lines: WordBox[][] = [];
   for (const word of words) {
     const cy = word.y + word.height / 2;
-    const line = lines.find((l) => Math.abs(l[0]!.y + l[0]!.height / 2 - cy) <= 6);
+    const line = lines.find((l) => l.some((w) => Math.abs(w.y + w.height / 2 - cy) <= 6));
     if (line) {
       line.push(word);
     } else {
@@ -118,15 +118,14 @@ export function findAllMatches(words: WordBox[], query: TextQuery): TextMatch[] 
 const TEXT_VISIBLE_CONFIDENCE = VISIBLE_CONFIDENCE;
 
 /** OCR word extraction from the live page screenshot. */
-async function extractWords(page: Page, shotDir: string, screenName: string, unhover?: boolean): Promise<{ words: WordBox[]; shotPath: string }> {
+export async function extractWords(page: Page, shotDir: string, screenName: string, unhover?: boolean): Promise<{ words: WordBox[] }> {
   fs.mkdirSync(shotDir, { recursive: true });
   const shotPath = path.join(shotDir, `${screenName}-text-live.png`);
   await unhoverBeforeCapture(page, unhover);
-  await page.screenshot({ path: shotPath, timeout: 2_000 });
-  const buf = await fsp.readFile(shotPath);
+  const buf = await page.screenshot({ path: shotPath, timeout: 2_000 });
   const ocrUtil = await getOCRUtil();
   const words = await ocrUtil.extractPageWords(buf);
-  return { words, shotPath };
+  return { words };
 }
 
 export type TextElementOptions = {
@@ -159,12 +158,12 @@ export class TextElement {
     return this.match.text;
   }
 
-  /** Click the center of the matched text region. */
+  /** Click the matched text region using the configured ClickStrategy. */
   async click(): Promise<void> {
     return ocrStep(`getByText(${formatQuery(this.query)}).click()`, async () => {
       if (!this.page) throw new Error('click() requires a live page');
-      const { x, y, width, height } = this.match.location;
-      await this.page.mouse.click(x + width / 2, y + height / 2);
+      const { x, y } = getClickStrategy().getPoint(this.match.location);
+      await this.page.mouse.click(x, y);
     });
   }
 


### PR DESCRIPTION
Closes #45

Rebased cleanly on top of main (after #86 merged).

## Summary

- **`screen.getByText(query, opts?)`** — OCR-polls the live page until the text appears, returns a `TextElement`
- **`screen.getAllByText(query)`** — no implicit wait; returns all current matches
- **`screen.toContainText(query, opts?)`** — screen-level assertion that any matching text with confidence ≥ 0.7 is present
- **`TextElement`** — lightweight locator with `click()`, `toBeVisible()`, `toBeHidden()`, `toHaveText()`, `waitFor()`; no `fill()` or `toHaveValue()` (those belong on registered elements)

Both `string` and `RegExp` queries supported. String matching is case-insensitive with punctuation stripped. Words are grouped into lines by y-center proximity (±6 px using nearest-member comparison); match location is the bounding union of all matched words.

## Fixes from code review

- `groupIntoLines`: compare new words against any group member (not just first) to avoid incorrect line splits
- `toContainText`: use `matches.some()` so any high-confidence match satisfies the assertion
- `getByText`/`toContainText`: wrap `captureWords()` in try-catch to retry on transient navigation errors
- `TextElement.click()`: route through `getClickStrategy()` to honour configured strategies
- `dblclick()`: same fix — use `getClickStrategy().getPoint(rect)`
- `release()`: call `clearConfigUnhoverPoint()` so `configure()`-level `unhoverPoint` doesn't leak to the next session
- `captureWords()` now delegates to exported `extractWords()` — eliminates 7-line duplicate
- `extractWords()`: use `page.screenshot()` Buffer return directly, drops unnecessary `fsp.readFile()` roundtrip

## Test plan

- [ ] All 102 unit tests pass (`npx vitest run`)
- [ ] TypeScript clean (`npm run typecheck`)
- [ ] `findAllMatches` tested: single/multi-word, case, punctuation, cross-line miss, regex, grouping (incl. nearest-member regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)