### PR TITLE
feat: addScreenHandler — dismiss non-deterministic overlays on live capture

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,6 @@
 export { saveScreen } from './configure.js';
+export { addScreenHandler, removeScreenHandler } from './screen-handler.js';
+export type { ScreenHandlerOptions } from './screen-handler.js';
 export {
   bindOcrScreen,
   createFixture,

--- a/packages/core/src/screen-handler.test.ts
+++ b/packages/core/src/screen-handler.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { addScreenHandler, removeScreenHandler, clearScreenHandlers, runHandlers } from './screen-handler.js';
+import { ScreenResult } from './screen-result.js';
+import { ScreenElement } from './element.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeExtractor(confidence = 0.95) {
+  return {
+    loadForms: vi.fn().mockResolvedValue(undefined),
+    locateOnScreenshot: vi.fn().mockResolvedValue({
+      name: 'ok',
+      value: '',
+      location: { x: 10, y: 20, width: 80, height: 30 },
+      confidence,
+      isEmpty: true,
+    }),
+    extractElements: vi.fn().mockResolvedValue({
+      elements: [{ name: 'ok', value: '', location: { x: 10, y: 20, width: 80, height: 30 }, isEmpty: false }],
+      totalElements: 1,
+      filledElements: 1,
+      emptyElements: 0,
+    }),
+  };
+}
+
+function makeHost(extractor = makeExtractor()) {
+  return {
+    extractor,
+    screen: {
+      name: 'license-warning',
+      blankScreenPath: '/tmp/blank.png',
+      ready: 'ok',
+      elementConfigs: [
+        { name: 'ok', templatePath: '/tmp/ok.png' },
+        { name: 'cancel', templatePath: '/tmp/cancel.png' },
+      ],
+    },
+    shotDir: '/tmp/shots',
+  };
+}
+
+function makePage() {
+  return {
+    screenshot: vi.fn().mockResolvedValue(Buffer.from('')),
+    mouse: { click: vi.fn() },
+  } as unknown as import('@playwright/test').Page;
+}
+
+// Stub loadScreen so handlers can be added without touching disk
+vi.mock('./configure.js', () => ({
+  loadScreen: vi.fn((name: string) => ({
+    name,
+    blankScreenPath: `/tmp/${name}/blank.png`,
+    ready: 'ok',
+    elementConfigs: [
+      { name: 'ok', templatePath: `/tmp/${name}/ok.png` },
+      { name: 'dismiss-btn', templatePath: `/tmp/${name}/dismiss-btn.png` },
+    ],
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('addScreenHandler / removeScreenHandler', () => {
+  beforeEach(() => {
+    clearScreenHandlers();
+  });
+
+  it('returns a cleanup function that removes the handler', async () => {
+    const fn = vi.fn();
+    const cleanup = addScreenHandler('license-warning', fn);
+    cleanup();
+    const host = makeHost();
+    await runHandlers('/tmp/shot.png', host, makePage());
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('removeScreenHandler removes by target string', async () => {
+    const fn = vi.fn();
+    addScreenHandler('license-warning', fn);
+    removeScreenHandler('license-warning');
+    const host = makeHost();
+    await runHandlers('/tmp/shot.png', host, makePage());
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('multiple handlers for the same target are independently removable', async () => {
+    const fn1 = vi.fn();
+    const fn2 = vi.fn();
+    const cleanup1 = addScreenHandler('license-warning', fn1, { noWaitAfter: true });
+    addScreenHandler('license-warning', fn2, { noWaitAfter: true });
+    cleanup1();
+    const host = makeHost();
+    await runHandlers('/tmp/shot.png', host, makePage());
+    expect(fn1).not.toHaveBeenCalled();
+    expect(fn2).toHaveBeenCalledOnce();
+  });
+});
+
+describe('runHandlers — screen form', () => {
+  beforeEach(() => {
+    clearScreenHandlers();
+  });
+
+  it('fires when detection confidence is above threshold', async () => {
+    const fn = vi.fn();
+    addScreenHandler('license-warning', fn, { noWaitAfter: true });
+    const host = makeHost(makeExtractor(0.95));
+    await runHandlers('/tmp/shot.png', host, makePage());
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it('does not fire when confidence is below threshold', async () => {
+    const fn = vi.fn();
+    addScreenHandler('license-warning', fn, { noWaitAfter: true });
+    const host = makeHost(makeExtractor(0.3));
+    await runHandlers('/tmp/shot.png', host, makePage());
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('passes a ScreenResult to the callback', async () => {
+    let received: unknown;
+    addScreenHandler('license-warning', async (s) => { received = s; }, { noWaitAfter: true });
+    const host = makeHost();
+    await runHandlers('/tmp/shot.png', host, makePage());
+    expect(received).toBeInstanceOf(ScreenResult);
+  });
+
+  it('respects times: 1 — fires once then removes itself', async () => {
+    const fn = vi.fn();
+    addScreenHandler('license-warning', fn, { times: 1, noWaitAfter: true });
+    const host = makeHost();
+    await runHandlers('/tmp/shot.png', host, makePage());
+    await runHandlers('/tmp/shot.png', host, makePage());
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it('fires up to times: 2', async () => {
+    const fn = vi.fn();
+    addScreenHandler('license-warning', fn, { times: 2, noWaitAfter: true });
+    const host = makeHost();
+    await runHandlers('/tmp/shot.png', host, makePage());
+    await runHandlers('/tmp/shot.png', host, makePage());
+    await runHandlers('/tmp/shot.png', host, makePage());
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not re-enter while the handler is active', async () => {
+    const calls: string[] = [];
+    addScreenHandler('license-warning', async () => {
+      calls.push('enter');
+      const host = makeHost();
+      // simulate a nested runHandlers call (e.g. from a click inside the handler)
+      await runHandlers('/tmp/shot.png', host, makePage());
+      calls.push('exit');
+    }, { noWaitAfter: true });
+    const host = makeHost();
+    await runHandlers('/tmp/shot.png', host, makePage());
+    expect(calls).toEqual(['enter', 'exit']);
+  });
+});
+
+describe('runHandlers — dotted element form', () => {
+  beforeEach(() => {
+    clearScreenHandlers();
+  });
+
+  it('passes a ScreenElement to the callback', async () => {
+    let received: unknown;
+    addScreenHandler('license-warning.dismiss-btn', async (el) => { received = el; }, { noWaitAfter: true });
+    const host = makeHost();
+    await runHandlers('/tmp/shot.png', host, makePage());
+    expect(received).toBeInstanceOf(ScreenElement);
+  });
+
+  it('fires when detection confidence is above threshold', async () => {
+    const fn = vi.fn();
+    addScreenHandler('license-warning.dismiss-btn', fn, { noWaitAfter: true });
+    const host = makeHost(makeExtractor(0.9));
+    await runHandlers('/tmp/shot.png', host, makePage());
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it('does not fire when confidence is below threshold', async () => {
+    const fn = vi.fn();
+    addScreenHandler('license-warning.dismiss-btn', fn, { noWaitAfter: true });
+    const host = makeHost(makeExtractor(0.2));
+    await runHandlers('/tmp/shot.png', host, makePage());
+    expect(fn).not.toHaveBeenCalled();
+  });
+});
+
+describe('noWaitAfter option', () => {
+  beforeEach(() => {
+    clearScreenHandlers();
+  });
+
+  it('skips the wait-until-gone poll when noWaitAfter is true', async () => {
+    const fn = vi.fn();
+    addScreenHandler('license-warning', fn, { noWaitAfter: true });
+    const page = makePage();
+    const host = makeHost();
+    await runHandlers('/tmp/shot.png', host, page);
+    expect(fn).toHaveBeenCalledOnce();
+    // No page.screenshot call for the gone-poll (the mock extractor would keep returning high confidence)
+    expect(page.screenshot).not.toHaveBeenCalled();
+  });
+
+  it('waits until gone when noWaitAfter is false — polls page.screenshot until low confidence', async () => {
+    const fn = vi.fn();
+    addScreenHandler('license-warning', fn); // noWaitAfter defaults to false
+    const extractor = makeExtractor(0.95);
+    // Detection returns high confidence; gone-poll returns low confidence on the first poll
+    extractor.locateOnScreenshot
+      .mockResolvedValueOnce({ name: 'ok', value: '', location: { x: 0, y: 0, width: 1, height: 1 }, confidence: 0.95, isEmpty: true }) // detection
+      .mockResolvedValueOnce({ name: 'ok', value: '', location: { x: 0, y: 0, width: 1, height: 1 }, confidence: 0.1, isEmpty: true }); // gone-poll succeeds
+    const host = makeHost(extractor);
+    const page = makePage();
+    await runHandlers('/tmp/shot.png', host, page);
+    expect(fn).toHaveBeenCalledOnce();
+    // page.screenshot should be called at least once for the gone-poll
+    expect(page.screenshot).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/screen-handler.ts
+++ b/packages/core/src/screen-handler.ts
@@ -1,0 +1,202 @@
+import type { Page } from '@playwright/test';
+import type { ElementConfig, ElementResult } from './types.js';
+import type { ScreenConfig } from './screen-config.js';
+import type { ScreenHost, ScreenExtractor } from './screen-result.js';
+import { ScreenResult } from './screen-result.js';
+import { ScreenElement, VISIBLE_CONFIDENCE } from './element.js';
+import { loadScreen } from './configure.js';
+import * as path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ScreenHandlerOptions {
+  /** Maximum number of times the handler fires. Default: Infinity. */
+  times?: number;
+  /** Skip the wait-until-gone poll after the handler returns. Default: false. */
+  noWaitAfter?: boolean;
+}
+
+interface HandlerEntry {
+  target: string;
+  screenName: string;
+  elementName: string | undefined;
+  screenConfig: ScreenConfig;
+  detectionConfig: ElementConfig;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fn: (matched: any) => Promise<void>;
+  times: number;
+  noWaitAfter: boolean;
+  fireCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+const handlers: HandlerEntry[] = [];
+const activeTargets = new Set<string>();
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Register a handler that fires when an authored screen is detected on any
+ * live capture. The callback receives a bound, OCR-populated ScreenResult.
+ */
+export function addScreenHandler(
+  target: string,
+  fn: (matched: ScreenResult) => Promise<void>,
+  options?: ScreenHandlerOptions,
+): () => void;
+
+/**
+ * Register a handler that fires when a specific element within a screen is
+ * detected on any live capture. Dotted target: `'screen-name.element-name'`.
+ * The callback receives the matched ScreenElement.
+ */
+export function addScreenHandler(
+  target: `${string}.${string}`,
+  fn: (matched: ScreenElement) => Promise<void>,
+  options?: ScreenHandlerOptions,
+): () => void;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function addScreenHandler(target: string, fn: (matched: any) => Promise<void>, options: ScreenHandlerOptions = {}): () => void {
+  const dot = target.indexOf('.');
+  const screenName = dot === -1 ? target : target.slice(0, dot);
+  const elementName = dot === -1 ? undefined : target.slice(dot + 1);
+
+  const screenConfig = loadScreen(screenName);
+
+  let detectionConfig: ElementConfig | undefined;
+  if (elementName) {
+    detectionConfig = screenConfig.elementConfigs.find((c) => c.name === elementName);
+    if (!detectionConfig) {
+      throw new Error(`addScreenHandler: element "${elementName}" not found in screen "${screenName}"`);
+    }
+  } else {
+    const ready = screenConfig.ready;
+    const readyName =
+      typeof ready === 'string' ? ready
+      : Array.isArray(ready) ? ready[0]
+      : ready && 'any' in ready ? ready.any[0]
+      : undefined;
+    detectionConfig = readyName
+      ? screenConfig.elementConfigs.find((c) => c.name === readyName)
+      : screenConfig.elementConfigs[0];
+    if (!detectionConfig) {
+      throw new Error(`addScreenHandler: screen "${screenName}" has no elements to detect`);
+    }
+  }
+
+  const entry: HandlerEntry = {
+    target,
+    screenName,
+    elementName,
+    screenConfig,
+    detectionConfig,
+    fn,
+    times: options.times ?? Infinity,
+    noWaitAfter: options.noWaitAfter ?? false,
+    fireCount: 0,
+  };
+  handlers.push(entry);
+  return () => {
+    const idx = handlers.indexOf(entry);
+    if (idx !== -1) handlers.splice(idx, 1);
+  };
+}
+
+/** Remove all handlers registered for the given target (screen or element). */
+export function removeScreenHandler(target: string): void {
+  for (let i = handlers.length - 1; i >= 0; i--) {
+    if (handlers[i]!.target === target) handlers.splice(i, 1);
+  }
+}
+
+/** Remove all registered handlers (called by release()). */
+export function clearScreenHandlers(): void {
+  handlers.length = 0;
+  activeTargets.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Detection + dispatch
+// ---------------------------------------------------------------------------
+
+/**
+ * Check all registered handlers against an already-taken screenshot.
+ * Called from ScreenResult.captureLive() after every live screenshot.
+ */
+export async function runHandlers(shot: string, host: ScreenHost, page: Page): Promise<void> {
+  for (const entry of [...handlers]) {
+    if (activeTargets.has(entry.target)) continue;
+    if (entry.fireCount >= entry.times) continue;
+
+    let located: ElementResult;
+    try {
+      located = await host.extractor.locateOnScreenshot(shot, entry.detectionConfig);
+    } catch {
+      continue;
+    }
+    if ((located.confidence ?? 0) < VISIBLE_CONFIDENCE) continue;
+
+    activeTargets.add(entry.target);
+    entry.fireCount++;
+    try {
+      const handlerHost: ScreenHost = {
+        extractor: host.extractor,
+        screen: entry.screenConfig,
+        shotDir: host.shotDir,
+        ...(host.unhover !== undefined && { unhover: host.unhover }),
+      };
+
+      let arg: ScreenResult | ScreenElement;
+      if (entry.elementName) {
+        const bound = ScreenResult.bind(page, host.extractor, entry.screenConfig, host.shotDir, {
+          ...(host.unhover !== undefined && { unhover: host.unhover }),
+        });
+        arg = new ScreenElement(located, page, bound);
+      } else {
+        arg = await ScreenResult.fromShot(shot, page, handlerHost);
+      }
+
+      await entry.fn(arg);
+
+      if (!entry.noWaitAfter) {
+        await waitUntilGone(page, host.shotDir, entry.screenName, host.extractor, entry.detectionConfig);
+      }
+    } finally {
+      activeTargets.delete(entry.target);
+    }
+
+    if (entry.fireCount >= entry.times) {
+      const idx = handlers.indexOf(entry);
+      if (idx !== -1) handlers.splice(idx, 1);
+    }
+  }
+}
+
+async function waitUntilGone(
+  page: Page,
+  shotDir: string,
+  screenName: string,
+  extractor: ScreenExtractor,
+  detectionConfig: ElementConfig,
+): Promise<void> {
+  const pollShot = path.join(shotDir, `${screenName}-handler-gone.png`);
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    await new Promise<void>((r) => setTimeout(r, 150));
+    try {
+      await page.screenshot({ path: pollShot, timeout: 2_000 });
+      const located = await extractor.locateOnScreenshot(pollShot, detectionConfig);
+      if ((located.confidence ?? 0) < VISIBLE_CONFIDENCE) return;
+    } catch {
+      return;
+    }
+  }
+}

--- a/packages/core/src/screen-result.ts
+++ b/packages/core/src/screen-result.ts
@@ -9,6 +9,7 @@ import { unhoverBeforeCapture } from './unhover.js';
 import { resolveCharsetSwaps, getOcrStrategy, getOCRUtil, type FieldRead } from './utils/ocr.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { runHandlers } from './screen-handler.js';
 
 export type ScreenExtractor = {
   loadForms(blankFormPath: string, filledFormPath: string): Promise<void>;
@@ -68,6 +69,16 @@ export class ScreenResult {
     private page?: Page,
     private host?: ScreenHost,
   ) {}
+
+  /**
+   * Construct a ScreenResult pre-populated from an already-taken screenshot.
+   * Used by screen handler dispatch — avoids an extra screenshot round-trip.
+   */
+  static async fromShot(shot: string, page: Page, host: ScreenHost): Promise<ScreenResult> {
+    await host.extractor.loadForms(host.screen.blankScreenPath, shot);
+    const comparison = await extractComparison(host.extractor, host.screen.elementConfigs);
+    return new ScreenResult(comparison, page, host);
+  }
 
   /**
    * Bind a screen to a live page so element().waitFor / fill / click can screenshot and match.
@@ -295,6 +306,7 @@ export class ScreenResult {
   private async captureLive(shot: string): Promise<void> {
     await unhoverBeforeCapture(this.page!, this.host?.unhover);
     await this.page!.screenshot({ path: shot, timeout: 2_000 });
+    if (this.host) await runHandlers(shot, this.host, this.page!);
   }
 
   private async loadExtracted(shot: string): Promise<void> {

--- a/packages/core/src/screen.ts
+++ b/packages/core/src/screen.ts
@@ -5,6 +5,7 @@ import { test as base } from '@playwright/test';
 import type { Page, TestType } from '@playwright/test';
 import type { ScreenConfig } from './screen-config.js';
 import { loadScreen, clearConfigUnhoverPoint } from './configure.js';
+import { clearScreenHandlers } from './screen-handler.js';
 import { FieldExtractor } from './field-extractor.js';
 import { ScreenResult } from './screen-result.js';
 import { cleanupOCR, getOCRUtil, setCharsetRegistry, setOcrStrategy, type Charset, type FieldRead } from './utils/ocr.js';
@@ -217,6 +218,7 @@ export async function release(): Promise<void> {
   initState = null;
   setUnhoverPoint(undefined);
   clearConfigUnhoverPoint();
+  clearScreenHandlers();
   setClickStrategy(undefined);
   setFillStrategy(undefined);
   setCharsetRegistry({});


### PR DESCRIPTION
Closes #56.

## Summary

- `addScreenHandler(target, fn, opts?)` — registers a handler that fires whenever a live capture detects the overlay. Target is either `'screen-name'` (fn receives a `ScreenResult`) or `'screen-name.element-name'` (fn receives a `ScreenElement`)
- `removeScreenHandler(target)` — remove by name string; `addScreenHandler` also returns a cleanup function for closure-based teardown
- Detection reuses the already-taken screenshot — zero extra I/O per polling tick; just one `locateOnScreenshot` template match per registered handler
- Reentrancy guard (`activeTargets` Set) prevents the same handler from triggering itself while it's running
- `{ times, noWaitAfter }` options supported; `release()` clears all handlers
- Injection point: `ScreenResult.captureLive()` — fires after every live screenshot across `waitFor`, `refresh`, `waitForElement`, `waitForAny`
- `ScreenResult.fromShot(shot, page, host)` static added — constructs a pre-populated result from an existing screenshot without an extra capture

## Test plan
- [ ] `addScreenHandler` / `removeScreenHandler` registration and cleanup
- [ ] Screen form fires `ScreenResult`; dotted element form fires `ScreenElement`
- [ ] Confidence threshold gates firing
- [ ] `times` cap, reentrancy guard, `noWaitAfter` behavior
- [ ] `waitUntilGone` polls until confidence drops
- [ ] 216 total tests passing, tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)