### PR TITLE
fix: lazy-load @playwright/test in createFixture (optional peer)

### DIFF
--- a/packages/core/src/screen.ts
+++ b/packages/core/src/screen.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { test as base } from '@playwright/test';
 import type { Page, TestType } from '@playwright/test';
 import type { ScreenConfig } from './screen-config.js';
 import { loadScreen, clearConfigUnhoverPoint } from './configure.js';
@@ -257,6 +256,10 @@ interface ScreenWorkerFixtures {
  *   test.use({ ocrOverlay: true });
  */
 export function createFixture(): TestType<ScreenFixtures, ScreenWorkerFixtures> {
+  // Dynamic import so @playwright/test is not required at module load time
+  // (it is an optional peer — QA Wolf flows use init()/screen() without fixtures)
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { test: base } = require('@playwright/test') as typeof import('@playwright/test');
   return base.extend<ScreenFixtures, ScreenWorkerFixtures>({
     _ocrReady: [
       async ({}, use) => {


### PR DESCRIPTION
## Problem

`screen.ts` had a top-level `import { test as base } from '@playwright/test'`. Since `@playwright/test` is an optional peer, workspaces that use `init()` / `screen()` without Playwright fixtures (e.g. QA Wolf flows) crashed at module load time with a missing-module error.

## Fix

Move the import inside `createFixture()` using `require()`. The value is only needed when someone calls `createFixture()` — which only happens in Playwright test setup files, where `@playwright/test` is always present.

All other `@playwright/test` imports in the package are `import type` and are already erased at runtime — this was the only value import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)