### PR TITLE
feat: enrich boxes with embedded text values and geometric cluster groups

### DIFF
--- a/packages/core/src/author/apply.ts
+++ b/packages/core/src/author/apply.ts
@@ -305,18 +305,21 @@ export function applyScreen(name: string, firstPass?: FirstPass): ApplyScreenRes
   }
   const absorbedSections = new Set<string>();
   const syntheticElements: FirstPassElement[] = [];
+  const usedParentNames = new Set<string>();
   for (const sec of pass.sections || []) {
     const members = membersBySection.get(sec.name);
     if (!members?.length) continue;
     absorbedSections.add(sec.name);
     const parentName = sec.name.replace(/Section$/, '') || sec.name;
+    if (usedParentNames.has(parentName)) continue; // skip duplicates silently
+    usedParentNames.add(parentName);
     const allLabelIds = [...new Set(members.flatMap((m) => m.labelIds ?? []))];
     syntheticElements.push({
       name: parentName,
       type: 'other',
       boxIds: sec.boxIds,
       labelIds: allLabelIds,
-      parts: members.map((m) => ({ name: m.name, ...(m.boxIds[0] != null ? { boxId: m.boxIds[0] } : {}) })),
+      parts: members.map((m) => ({ name: m.name, ...((m.boxIds ?? [])[0] != null ? { boxId: (m.boxIds ?? [])[0] } : {}) })),
     });
   }
 
@@ -379,7 +382,7 @@ export function applyScreen(name: string, firstPass?: FirstPass): ApplyScreenRes
     if (read) applied.read = read;
     if (el.options?.length) applied.options = el.options;
     if (el.section) applied.section = sectionFile.get(el.section) || el.section;
-    if (fieldBoxes.length) applied.ocrRect = ocrRectFromBoxes(match, fieldBoxes, el.type || 'field');
+    if (fieldBoxes.length && el.type !== 'other') applied.ocrRect = ocrRectFromBoxes(match, fieldBoxes, el.type || 'field');
     if (parts.length) applied.parts = parts;
     elements.push(applied);
   }

--- a/packages/core/src/author/apply.ts
+++ b/packages/core/src/author/apply.ts
@@ -21,6 +21,7 @@ import { writeScreenCatalog } from './catalog.js';
 
 export interface FirstPassPart {
   name: string;
+  type?: string;
   /** Detected box. Omit to split the parent field box left-to-right. */
   boxId?: number;
   /** Optional 0–1 span of the parent field union when boxId is omitted. */
@@ -91,6 +92,7 @@ export interface AppliedElement {
   ocrRect?: { x: number; y: number; width: number; height: number };
   parts?: Array<{
     name: string;
+    type?: string;
     x: number;
     y: number;
     width: number;
@@ -225,10 +227,12 @@ function resolveParts(
       name: part.name,
       ...relativeToCrop(rect, crop),
     };
+    const type = part.type ?? prev?.type;
     const charset = part.charset ?? prev?.charset;
     const swaps = part.swaps ?? prev?.swaps;
     const overflow = part.overflow ?? prev?.overflow;
     const read = part.read ?? prev?.read;
+    if (type) row.type = type;
     if (charset) row.charset = charset;
     if (swaps) row.swaps = swaps;
     if (overflow) row.overflow = overflow;

--- a/packages/core/src/author/apply.ts
+++ b/packages/core/src/author/apply.ts
@@ -288,10 +288,39 @@ export function applyScreen(name: string, firstPass?: FirstPass): ApplyScreenRes
   fs.rmSync(tmplDir, { recursive: true, force: true });
   fs.mkdirSync(tmplDir, { recursive: true });
 
+  // Sections whose members should be merged into a single parent element with named parts.
+  // A section is absorbed when it has at least one member element; the parent name is the
+  // section name with the trailing "Section" suffix stripped.
+  const membersBySection = new Map<string, FirstPassElement[]>();
+  for (const el of pass.elements || []) {
+    if (el.section) {
+      const group = membersBySection.get(el.section) ?? [];
+      group.push(el);
+      membersBySection.set(el.section, group);
+    }
+  }
+  const absorbedSections = new Set<string>();
+  const syntheticElements: FirstPassElement[] = [];
+  for (const sec of pass.sections || []) {
+    const members = membersBySection.get(sec.name);
+    if (!members?.length) continue;
+    absorbedSections.add(sec.name);
+    const parentName = sec.name.replace(/Section$/, '') || sec.name;
+    const allLabelIds = [...new Set(members.flatMap((m) => m.labelIds ?? []))];
+    syntheticElements.push({
+      name: parentName,
+      type: 'other',
+      boxIds: sec.boxIds,
+      labelIds: allLabelIds,
+      parts: members.map((m) => ({ name: m.name, ...(m.boxIds[0] != null ? { boxId: m.boxIds[0] } : {}) })),
+    });
+  }
+
   const indexSections: AppliedSection[] = [];
   const sectionFile = new Map<string, string>();
   const sectionBoxesByName = new Map<string, DetectedBox[]>();
   for (const sec of pass.sections || []) {
+    if (absorbedSections.has(sec.name)) continue;
     const secBoxes = (sec.boxIds || []).map((id) => byId.get(id)).filter((b): b is DetectedBox => Boolean(b));
     if (!sec.name || !secBoxes.length) continue;
     const memberLabels = (pass.elements || [])
@@ -306,8 +335,13 @@ export function applyScreen(name: string, firstPass?: FirstPass): ApplyScreenRes
     sectionBoxesByName.set(sec.name, secBoxes);
   }
 
+  const allElements = [
+    ...syntheticElements,
+    ...(pass.elements || []).filter((el) => !el.section || !absorbedSections.has(el.section)),
+  ];
+
   const elements: AppliedElement[] = [];
-  for (const el of pass.elements || []) {
+  for (const el of allElements) {
     const fieldBoxes = (el.boxIds || []).map((id) => byId.get(id)).filter((b): b is DetectedBox => Boolean(b));
     const labelRects = (el.labelIds || []).map((id) => byLabel.get(id)).filter((l): l is DetectedLabel => Boolean(l));
     const extraBoxes = el.section ? (sectionBoxesByName.get(el.section) || []) : [];

--- a/packages/core/src/author/author.test.ts
+++ b/packages/core/src/author/author.test.ts
@@ -88,7 +88,7 @@ describe('author apply + catalog', () => {
     expect(username).toMatchObject({ x: 590, y: 147, width: 204, height: 22 });
   });
 
-  it('applyScreen unions section boxes into the match crop and keeps overlay on the element', () => {
+  it('applyScreen absorbs section members into a synthetic parent element with parts', () => {
     const result = applyScreen(name, {
       screen: { name },
       sections: [{ name: 'pairSection', boxIds: [1, 2] }],
@@ -97,24 +97,21 @@ describe('author apply + catalog', () => {
         { name: 'narrow', type: 'field', section: 'pairSection', boxIds: [2] },
       ],
     });
-    const wide = result.elements.find((el) => el.name === 'wide')!;
-    const narrow = result.elements.find((el) => el.name === 'narrow')!;
-    expect(wide).toMatchObject({ x: 590, y: 147, width: 204, height: 22 });
-    expect(narrow).toMatchObject({ x: 590, y: 174, width: 204, height: 22 });
-    expect(wide.section).toBe('section-pair-section.png');
-    expect(narrow.section).toBe('section-pair-section.png');
-    expect(wide.ocrRect!.y).toBeLessThan(10);
-    expect(narrow.ocrRect!.y).toBeGreaterThan(20);
-    const index = JSON.parse(fs.readFileSync(result.indexPath, 'utf8')) as {
-      sections: Array<{ name: string; filename: string; x: number; y: number; width: number; height: number }>;
-    };
-    expect(index.sections[0]).toMatchObject({
-      name: 'pairSection',
-      filename: 'section-pair-section.png',
-      x: 588,
-      y: 145,
-    });
-    expect(index.sections[0]!.height).toBeGreaterThan(48);
+    // Absorbed members do not appear as top-level elements.
+    expect(result.elements.find((el) => el.name === 'wide')).toBeUndefined();
+    expect(result.elements.find((el) => el.name === 'narrow')).toBeUndefined();
+    // A synthetic parent element is created from the section name minus the 'Section' suffix.
+    const pair = result.elements.find((el) => el.name === 'pair')!;
+    expect(pair).toBeDefined();
+    expect(pair.type).toBe('other');
+    expect(pair.parts).toHaveLength(2);
+    expect(pair.parts![0]).toMatchObject({ name: 'wide' });
+    expect(pair.parts![1]).toMatchObject({ name: 'narrow' });
+    // Synthetic elements of type 'other' do not get an ocrRect (no single field to OCR).
+    expect(pair.ocrRect).toBeUndefined();
+    // Absorbed sections are not emitted into index.sections.
+    const index = JSON.parse(fs.readFileSync(result.indexPath, 'utf8')) as { sections: unknown[] };
+    expect(index.sections).toHaveLength(0);
   });
 
   it('applyScreen unions assigned labelIds into the crop', () => {

--- a/packages/core/src/author/detect.ts
+++ b/packages/core/src/author/detect.ts
@@ -10,9 +10,10 @@ import {
   splitBoxGutters,
   splitMergedFields,
   unionRects,
+  type BoxCluster,
   type DetectedBox,
 } from './geometry.js';
-import { labelsFromOcr, type DetectedLabel } from './labels.js';
+import { labelsAndValuesFromOcr, type DetectedLabel } from './labels.js';
 import { getOCRUtil } from '../utils/ocr.js';
 import { screenDir } from './storage.js';
 
@@ -28,6 +29,7 @@ export interface BoxesFile {
   height: number;
   boxes: DetectedBox[];
   labels?: DetectedLabel[];
+  clusters?: BoxCluster[];
 }
 
 export interface DetectScreenResult {
@@ -239,7 +241,10 @@ function scaleGrayPng(pngBuffer: Buffer, scale: number): Buffer {
   return buf;
 }
 
-async function detectLabels(pngBuffer: Buffer, boxes: DetectedBox[]): Promise<DetectedLabel[]> {
+async function detectLabelsAndValues(
+  pngBuffer: Buffer,
+  boxes: DetectedBox[],
+): Promise<{ labels: DetectedLabel[]; boxValues: Map<number, string> }> {
   const png = PNG.sync.read(pngBuffer);
   const roi = labelRoi(boxes, png.width, png.height);
   const cropped = cropPngBuffer(pngBuffer, roi.x, roi.y, roi.width, roi.height);
@@ -253,7 +258,44 @@ async function detectLabels(pngBuffer: Buffer, boxes: DetectedBox[]): Promise<De
     width: word.width / LABEL_SCALE,
     height: word.height / LABEL_SCALE,
   }));
-  return labelsFromOcr(mapped, boxes);
+  return labelsAndValuesFromOcr(mapped, boxes);
+}
+
+/** Group boxes that share the same visual row and are closely adjacent (gap ≤ 8px). */
+export function groupBoxClusters(boxes: DetectedBox[]): BoxCluster[] {
+  const ROW_TOL = 10;
+  const GAP_MAX = 8;
+  const sorted = [...boxes].sort((a, b) => {
+    const cy = (b: DetectedBox) => b.y + b.height / 2;
+    return cy(a) - cy(b) || a.x - b.x;
+  });
+  const rows: DetectedBox[][] = [];
+  for (const box of sorted) {
+    const cy = box.y + box.height / 2;
+    const row = rows.find((r) => {
+      const rcy = r[0]!.y + r[0]!.height / 2;
+      return Math.abs(cy - rcy) <= ROW_TOL;
+    });
+    if (row) row.push(box);
+    else rows.push([box]);
+  }
+  const clusters: BoxCluster[] = [];
+  for (const row of rows) {
+    const byX = [...row].sort((a, b) => a.x - b.x);
+    let run: DetectedBox[] = [byX[0]!];
+    for (let i = 1; i < byX.length; i++) {
+      const prev = run[run.length - 1]!;
+      const gap = byX[i]!.x - (prev.x + prev.width);
+      if (gap <= GAP_MAX) {
+        run.push(byX[i]!);
+      } else {
+        if (run.length >= 2) clusters.push({ boxIds: run.map((b) => b.id) });
+        run = [byX[i]!];
+      }
+    }
+    if (run.length >= 2) clusters.push({ boxIds: run.map((b) => b.id) });
+  }
+  return clusters;
 }
 
 function writeDetectFiles(
@@ -262,10 +304,12 @@ function writeDetectFiles(
   meta: { width: number; height: number },
   boxes: DetectedBox[],
   labels: DetectedLabel[],
+  clusters?: BoxCluster[],
 ): { boxesPath: string; annotatedPath: string } {
   const boxesPath = path.join(dir, 'boxes.json');
   const annotatedPath = path.join(dir, 'boxes-annotated.png');
   const payload: BoxesFile = { width: meta.width, height: meta.height, boxes, labels };
+  if (clusters && clusters.length > 0) payload.clusters = clusters;
   fs.writeFileSync(boxesPath, `${JSON.stringify(payload, null, 2)}\n`);
   fs.writeFileSync(annotatedPath, annotateBoxes(blank, boxes, labels));
   return { boxesPath, annotatedPath };
@@ -285,8 +329,13 @@ export async function detectScreen(name: string): Promise<DetectScreenResult> {
   const blank = fs.readFileSync(blankPath);
   const meta = PNG.sync.read(blank);
   const boxes = detectBoxes(blank);
-  const labels = await detectLabels(blank, boxes);
-  const { boxesPath, annotatedPath } = writeDetectFiles(dir, blank, meta, boxes, labels);
+  const { labels, boxValues } = await detectLabelsAndValues(blank, boxes);
+  for (const box of boxes) {
+    const val = boxValues.get(box.id);
+    if (val) box.value = val;
+  }
+  const clusters = groupBoxClusters(boxes);
+  const { boxesPath, annotatedPath } = writeDetectFiles(dir, blank, meta, boxes, labels, clusters);
   return { dir, boxesPath, annotatedPath, width: meta.width, height: meta.height, boxes, labels };
 }
 

--- a/packages/core/src/author/detect.ts
+++ b/packages/core/src/author/detect.ts
@@ -293,7 +293,7 @@ export function groupBoxClusters(boxes: DetectedBox[]): BoxCluster[] {
         run = [byX[i]!];
       }
     }
-    if (run.length >= 2) clusters.push({ boxIds: run.map((b) => b.id) });
+    if (run.length >= 2 && run.length <= 4) clusters.push({ boxIds: run.map((b) => b.id) });
   }
   return clusters;
 }

--- a/packages/core/src/author/detect.ts
+++ b/packages/core/src/author/detect.ts
@@ -293,7 +293,7 @@ export function groupBoxClusters(boxes: DetectedBox[]): BoxCluster[] {
         run = [byX[i]!];
       }
     }
-    if (run.length >= 2 && run.length <= 4) clusters.push({ boxIds: run.map((b) => b.id) });
+    if (run.length >= 2) clusters.push({ boxIds: run.map((b) => b.id) });
   }
   return clusters;
 }

--- a/packages/core/src/author/geometry.ts
+++ b/packages/core/src/author/geometry.ts
@@ -2,6 +2,13 @@ import type { Rect } from '../utils/vision.js';
 
 export interface DetectedBox extends Rect {
   id: number;
+  /** Text found inside the box on the blank screenshot (buttons, dropdowns, tabs). Absent when empty. */
+  value?: string;
+}
+
+export interface BoxCluster {
+  /** Box IDs that are spatially adjacent on the same visual row. */
+  boxIds: number[];
 }
 
 export function kebab(name: string): string {

--- a/packages/core/src/author/index.ts
+++ b/packages/core/src/author/index.ts
@@ -1,4 +1,4 @@
-export { detectScreen, detectBoxes, annotateBoxes, writeBoxes } from './detect.js';
+export { detectScreen, detectBoxes, annotateBoxes, writeBoxes, groupBoxClusters } from './detect.js';
 export type { DetectScreenResult, BoxesFile } from './detect.js';
 
 export { applyScreen } from './apply.js';
@@ -13,6 +13,6 @@ export type { ScreenCatalog } from './catalog.js';
 export { showAnnotated } from './show.js';
 
 export { kebab, unionRects, insetRect } from './geometry.js';
-export type { DetectedBox } from './geometry.js';
+export type { DetectedBox, BoxCluster } from './geometry.js';
 
 export type { DetectedLabel } from './labels.js';

--- a/packages/core/src/author/labels.ts
+++ b/packages/core/src/author/labels.ts
@@ -80,7 +80,10 @@ export function labelsAndValuesFromOcr(
     return letters >= 4 && word.width >= 24;
   });
   const clustered = clusterOcrWords(usable);
-  const boxValues = new Map<number, string>();
+  // Track phrase count per box: a value assembled from multiple separate OCR clusters
+  // may have wrong word order (stacked button labels read top-to-bottom) — kept only when
+  // all text came from a single cluster so left-to-right order is guaranteed.
+  const boxPhrases = new Map<number, { text: string; count: number }>();
   const kept = clustered.filter((label) => {
     const text = cleanText(label.text);
     if (letterCount(text) < 2 || text.length > 80) return false;
@@ -91,8 +94,8 @@ export function labelsAndValuesFromOcr(
       // Only capture value when: the box is tall enough to be a real control, and the phrase
       // is not wider than the box (which would indicate a neighbouring label bleeding in).
       if (insideBox.height >= 18 && label.width <= insideBox.width * 1.5) {
-        const prev = boxValues.get(insideBox.id);
-        boxValues.set(insideBox.id, prev ? `${prev} ${text}` : text);
+        const prev = boxPhrases.get(insideBox.id);
+        boxPhrases.set(insideBox.id, prev ? { text: `${prev.text} ${text}`, count: prev.count + 1 } : { text, count: 1 });
       }
       return false;
     }
@@ -111,14 +114,17 @@ export function labelsAndValuesFromOcr(
       text: cleanText(label.text),
       confidence: label.confidence,
     }));
-  // Post-process accumulated values: drop noise and strip leading icon glyphs.
-  for (const [id, text] of boxValues) {
-    if (letterCount(text) < 3) { boxValues.delete(id); continue; }
+  // Build final box values: drop multi-phrase values (stacked labels with unreliable word order),
+  // drop noise, and strip leading icon glyph tokens.
+  const boxValues = new Map<number, string>();
+  for (const [id, { text, count }] of boxPhrases) {
+    if (count > 1) continue;
+    if (letterCount(text) < 3) continue;
     // Strip leading tokens that look like icon glyph misreads: ≤3 chars with no lowercase letters.
     const tokens = text.split(' ');
     while (tokens.length > 1 && tokens[0]!.length <= 3 && !/[a-z]/.test(tokens[0]!)) tokens.shift();
     const cleaned = tokens.join(' ');
-    if (letterCount(cleaned) < 3) { boxValues.delete(id); continue; }
+    if (letterCount(cleaned) < 3) continue;
     boxValues.set(id, cleaned);
   }
   return { labels, boxValues };

--- a/packages/core/src/author/labels.ts
+++ b/packages/core/src/author/labels.ts
@@ -88,8 +88,12 @@ export function labelsAndValuesFromOcr(
     if (label.width > 420) return false;
     const insideBox = boxes.find((box) => containedRatio(label, box) >= 0.55 || centerInside(label, box));
     if (insideBox) {
-      const prev = boxValues.get(insideBox.id);
-      boxValues.set(insideBox.id, prev ? `${prev} ${text}` : text);
+      // Only capture value when: the box is tall enough to be a real control, and the phrase
+      // is not wider than the box (which would indicate a neighbouring label bleeding in).
+      if (insideBox.height >= 18 && label.width <= insideBox.width * 1.5) {
+        const prev = boxValues.get(insideBox.id);
+        boxValues.set(insideBox.id, prev ? `${prev} ${text}` : text);
+      }
       return false;
     }
     // Checkboxes often sit inside the caption bbox; only drop if a field/button is inside.
@@ -107,6 +111,16 @@ export function labelsAndValuesFromOcr(
       text: cleanText(label.text),
       confidence: label.confidence,
     }));
+  // Post-process accumulated values: drop noise and strip leading icon glyphs.
+  for (const [id, text] of boxValues) {
+    if (letterCount(text) < 3) { boxValues.delete(id); continue; }
+    // Strip leading tokens that look like icon glyph misreads: ≤3 chars with no lowercase letters.
+    const tokens = text.split(' ');
+    while (tokens.length > 1 && tokens[0]!.length <= 3 && !/[a-z]/.test(tokens[0]!)) tokens.shift();
+    const cleaned = tokens.join(' ');
+    if (letterCount(cleaned) < 3) { boxValues.delete(id); continue; }
+    boxValues.set(id, cleaned);
+  }
   return { labels, boxValues };
 }
 

--- a/packages/core/src/author/labels.ts
+++ b/packages/core/src/author/labels.ts
@@ -62,8 +62,14 @@ export function clusterOcrWords(words: OcrWord[], maxGap = 16): OcrWord[] {
   });
 }
 
-/** Turn OCR words into label boxes the AI can join to controls. Drops chrome inside fields/buttons. */
-export function labelsFromOcr(words: OcrWord[], boxes: DetectedBox[]): DetectedLabel[] {
+/**
+ * Turn OCR words into label boxes the AI can join to controls, and collect any
+ * text found inside control boxes (button/dropdown/tab labels on the blank form).
+ */
+export function labelsAndValuesFromOcr(
+  words: OcrWord[],
+  boxes: DetectedBox[],
+): { labels: DetectedLabel[]; boxValues: Map<number, string> } {
   const usable = words.filter((word) => {
     if (word.width < 4 || word.height < 5 || word.height > 48) return false;
     const letters = letterCount(word.text);
@@ -74,17 +80,23 @@ export function labelsFromOcr(words: OcrWord[], boxes: DetectedBox[]): DetectedL
     return letters >= 4 && word.width >= 24;
   });
   const clustered = clusterOcrWords(usable);
+  const boxValues = new Map<number, string>();
   const kept = clustered.filter((label) => {
     const text = cleanText(label.text);
     if (letterCount(text) < 2 || text.length > 80) return false;
     if (/^\/?[A-Za-z]{1,2}\/?$/.test(text)) return false;
     if (label.width > 420) return false;
-    if (boxes.some((box) => containedRatio(label, box) >= 0.55 || centerInside(label, box))) return false;
+    const insideBox = boxes.find((box) => containedRatio(label, box) >= 0.55 || centerInside(label, box));
+    if (insideBox) {
+      const prev = boxValues.get(insideBox.id);
+      boxValues.set(insideBox.id, prev ? `${prev} ${text}` : text);
+      return false;
+    }
     // Checkboxes often sit inside the caption bbox; only drop if a field/button is inside.
     if (boxes.some((box) => box.width >= 40 && containedRatio(box, label) >= 0.45)) return false;
     return true;
   });
-  return kept
+  const labels = kept
     .sort((a, b) => a.y - b.y || a.x - b.x)
     .map((label, i) => ({
       id: i + 1,
@@ -95,6 +107,12 @@ export function labelsFromOcr(words: OcrWord[], boxes: DetectedBox[]): DetectedL
       text: cleanText(label.text),
       confidence: label.confidence,
     }));
+  return { labels, boxValues };
+}
+
+/** Turn OCR words into label boxes the AI can join to controls. Drops chrome inside fields/buttons. */
+export function labelsFromOcr(words: OcrWord[], boxes: DetectedBox[]): DetectedLabel[] {
+  return labelsAndValuesFromOcr(words, boxes).labels;
 }
 
 export function tessBBox(bbox: { x0?: number; y0?: number; x1?: number; y1?: number; x?: number; y?: number; width?: number; height?: number } | undefined): OcrWord | null {

--- a/packages/core/src/author/options.ts
+++ b/packages/core/src/author/options.ts
@@ -118,7 +118,7 @@ export function patchPartOptions(
   elementName: string,
   partName: string,
   patch: ElementOptionsPatch,
-): { firstPass: FirstPassPart; index: NonNullable<AppliedElement['parts']>[number] } {
+): { firstPass: FirstPassPart | undefined; index: NonNullable<AppliedElement['parts']>[number] } {
   const dir = screenDir(screenName);
   const firstPassPath = path.join(dir, 'first-pass.json');
   const indexPath = path.join(dir, 'index.json');
@@ -127,16 +127,38 @@ export function patchPartOptions(
   }
 
   const firstPass = JSON.parse(fs.readFileSync(firstPassPath, 'utf8')) as FirstPass;
+  let fpPart: FirstPassPart | undefined;
   const fpEl = (firstPass.elements || []).find((el) => el.name === elementName);
-  if (!fpEl) throw new Error(`element "${elementName}" not in first-pass.json`);
-  if (!fpEl.parts) fpEl.parts = [];
-  let fpPart = fpEl.parts.find((part) => part.name === partName);
-  if (!fpPart) {
-    fpPart = { name: partName };
-    fpEl.parts.push(fpPart);
+  if (fpEl) {
+    // Standard element: update the named part in its parts array.
+    if (!fpEl.parts) fpEl.parts = [];
+    fpPart = fpEl.parts.find((part) => part.name === partName);
+    if (!fpPart) {
+      fpPart = { name: partName };
+      fpEl.parts.push(fpPart);
+    }
+    applyPatchToRecord(fpPart as unknown as Record<string, unknown>, patch);
+    fs.writeFileSync(firstPassPath, `${JSON.stringify(firstPass, null, 2)}\n`);
+  } else {
+    // Section-derived synthetic element: the member element itself is the part.
+    const sections = firstPass.sections || [];
+    const memberEl = (firstPass.elements || []).find(
+      (el) =>
+        el.section &&
+        el.name === partName &&
+        sections.some(
+          (sec) =>
+            (sec.name.replace(/Section$/, '') || sec.name) === elementName &&
+            sec.name === el.section,
+        ),
+    );
+    if (memberEl) {
+      applyPatchToRecord(memberEl as unknown as Record<string, unknown>, patch);
+      fs.writeFileSync(firstPassPath, `${JSON.stringify(firstPass, null, 2)}\n`);
+      fpPart = memberEl as unknown as FirstPassPart;
+    }
+    // If member not found, only index.json is updated below (best-effort for synthetic elements).
   }
-  applyPatchToRecord(fpPart as unknown as Record<string, unknown>, patch);
-  fs.writeFileSync(firstPassPath, `${JSON.stringify(firstPass, null, 2)}\n`);
 
   const index = JSON.parse(fs.readFileSync(indexPath, 'utf8')) as {
     elements: AppliedElement[];

--- a/packages/core/src/author/options.ts
+++ b/packages/core/src/author/options.ts
@@ -5,6 +5,7 @@ import { writeScreenCatalog } from './catalog.js';
 import { screenDir } from './storage.js';
 
 export interface ElementOptionsPatch {
+  type?: string | null;
   charset?: string | null;
   swaps?: Record<string, string | string[]> | null;
   overflow?: string | null;
@@ -31,6 +32,13 @@ function applyPatchToRecord(
   target: Record<string, unknown>,
   patch: ElementOptionsPatch,
 ): void {
+  if ('type' in patch) {
+    if (patch.type == null || patch.type === '') {
+      delete target.type;
+    } else {
+      target.type = patch.type;
+    }
+  }
   if ('charset' in patch) {
     if (patch.charset == null || patch.charset === '' || patch.charset === 'auto') {
       delete target.charset;

--- a/packages/core/src/screen.ts
+++ b/packages/core/src/screen.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { test as base } from '@playwright/test';
 import type { Page, TestType } from '@playwright/test';
 import type { ScreenConfig } from './screen-config.js';
 import { loadScreen, clearConfigUnhoverPoint } from './configure.js';
@@ -257,6 +256,10 @@ interface ScreenWorkerFixtures {
  *   test.use({ ocrOverlay: true });
  */
 export function createFixture(): TestType<ScreenFixtures, ScreenWorkerFixtures> {
+  // Dynamic import so @playwright/test is not required at module load time
+  // (it is an optional peer — QA Wolf flows use init()/screen() without fixtures)
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { test: base } = require('@playwright/test') as typeof import('@playwright/test');
   return base.extend<ScreenFixtures, ScreenWorkerFixtures>({
     _ocrReady: [
       async ({}, use) => {

--- a/packages/tools/ai-first-pass-prompt.md
+++ b/packages/tools/ai-first-pass-prompt.md
@@ -52,15 +52,17 @@ Return **only** JSON:
 
    **Clusters**: A cluster lists box IDs that are spatially adjacent on the same visual row. Use them as a hint that those boxes may form a single logical control (a multi-cell field, a button group, a tab bar — whatever fits the screen). They're geometric, not semantic: interpret each cluster in context.
 
-2. **Dropdown glued to a field → section, not parts.** Two different controls (a list/combo and a value box) that sit on one row need a shared match region so the small one is not ambiguous. Emit a section named `{row}Section` with **both** `boxIds`, then **two elements** that share `"section": "thatName"`. No `parts`. Type each box from the screenshot: combo/list vs value cell. Do not assume wider = field or left = dropdown. Apply crops the section as that union and uses it as each member’s match template so the small box is not a tiny needle.
+2. **Dropdown glued to a field → section, not parts.** Two different controls (a list/combo and a value box) that sit on one row need a shared match region so the small one is not ambiguous. Emit a section named `{groupName}Section` with **both** `boxIds`, then **two elements** that share `"section": "thatName"`. No `parts`. Type each box from the screenshot: combo/list vs value cell. Do not assume wider = field or left = dropdown. Apply merges the members into one parent element (named `{groupName}`, stripping "Section") with named parts, so each small sub-element gets a correct relative position within the template.
+
+   **Naming:** the section name (`{groupName}Section`) determines the parent element name. Member element names must be **short descriptive suffixes only** — do NOT prefix them with the group name. The suffix becomes the part name in the final API (`screen.{groupName}.{suffix}`).
 
    ```json
    { "name": "primaryContactSection", "boxIds": [34, 35] }
-   { "name": "primaryContactMethod", "type": "dropdown", "section": "primaryContactSection", "boxIds": [34], "labelIds": [23] }
-   { "name": "primaryContactField", "type": "field", "section": "primaryContactSection", "boxIds": [35] }
+   { "name": "method", "type": "dropdown", "section": "primaryContactSection", "boxIds": [34], "labelIds": [23] }
+   { "name": "flag", "type": "other", "section": "primaryContactSection", "boxIds": [35] }
    { "name": "warrantyRepairSection", "boxIds": [57, 58] }
-   { "name": "warrantyRepair", "type": "dropdown", "section": "warrantyRepairSection", "boxIds": [57] }
-   { "name": "warrantyCode", "type": "field", "section": "warrantyRepairSection", "boxIds": [58] }
+   { "name": "type", "type": "dropdown", "section": "warrantyRepairSection", "boxIds": [57] }
+   { "name": "code", "type": "field", "section": "warrantyRepairSection", "boxIds": [58] }
    ```
 
 3. **Parts are only same-kind cells of one control.** Detect may emit one box per cell (mm / dd / yy, first / MI / last, phone segments). That is one element, several `boxIds`, `parts` with a `boxId` for each cell. Do not invent coordinates. Do not use parts for a dropdown+field pair.

--- a/packages/tools/ai-first-pass-prompt.md
+++ b/packages/tools/ai-first-pass-prompt.md
@@ -7,7 +7,7 @@ This is authoring only. Do not invent runtime matchers or API calls.
 ## Inputs
 
 1. **blank** and one or more **filled** shots (same width and height)
-2. **boxes.json** — `boxes` (controls) and `labels` (OCR captions). Each has `id, x, y, width, height`. Labels also have `text`.
+2. **boxes.json** — `boxes` (controls), `labels` (OCR captions), and optionally `clusters` (adjacent same-row box groups) and box `value` fields. Each box/label has `id, x, y, width, height`. Labels also have `text`. Box `value` is the text OCR found **inside** that box on the blank screenshot (button labels, tab titles, dropdown text). A `cluster` is a list of box IDs that are spatially adjacent on the same visual row — use them to identify multi-cell fields (phone triplets, date triplets, name cells) without relying solely on labels.
 3. **boxes-annotated.png** — red box IDs and gold `L{id}` label IDs on the blank
 4. Optional **focus** — only assign these controls
 
@@ -46,7 +46,11 @@ Return **only** JSON:
 
 ## Rules
 
-1. **Assign, do not draw.** Join existing rectangles. Apply crops the **union** of `boxIds` plus `labelIds`. Labels may sit left, above, right, or below the control — pick the gold `L{id}` that captions it. Buttons with text inside the red box usually need no `labelIds`. Do **not** assume the caption is to the left. Prefer `labelIds` over `"includeLabel": true` (legacy left-grow when Detect missed the caption).
+1. **Assign, do not draw.** Join existing rectangles. Apply crops the **union** of `boxIds` plus `labelIds`. Labels may sit left, above, right, or below the control — pick the gold `L{id}` that captions it. Buttons with text inside the red box (shown in box `value`) usually need no `labelIds`. Do **not** assume the caption is to the left. Prefer `labelIds` over `"includeLabel": true` (legacy left-grow when Detect missed the caption).
+
+   **Button values**: A box `value` shows what OCR read inside the box on the blank screenshot. Use it to name buttons and tabs. If a button wraps its label onto two lines, the value lists words top-to-bottom (display order), which may differ from the conventional name — use your knowledge of the application to pick the right camelCase name (e.g. `"Orders Repair"` → `repairOrders`). Values are not present for plain input fields (those are empty on the blank).
+
+   **Clusters**: Adjacent box IDs in a cluster belong to the same multi-cell control. Match them against known field patterns: a cluster of three boxes is likely a date (mm/dd/yy) or phone (area/prefix/number) triplet; a cluster of two may be a state+zip or name MI pair. Prefer cluster grouping over guessing from labels alone.
 
 2. **Dropdown glued to a field → section, not parts.** Two different controls (a list/combo and a value box) that sit on one row need a shared match region so the small one is not ambiguous. Emit a section named `{row}Section` with **both** `boxIds`, then **two elements** that share `"section": "thatName"`. No `parts`. Type each box from the screenshot: combo/list vs value cell. Do not assume wider = field or left = dropdown. Apply crops the section as that union and uses it as each member’s match template so the small box is not a tiny needle.
 

--- a/packages/tools/ai-first-pass-prompt.md
+++ b/packages/tools/ai-first-pass-prompt.md
@@ -50,7 +50,7 @@ Return **only** JSON:
 
    **Button values**: A box `value` shows what OCR read inside the box on the blank screenshot. Use it to name buttons and tabs. If a button wraps its label onto two lines, the value lists words top-to-bottom (display order), which may differ from the conventional name — use your knowledge of the application to pick the right camelCase name (e.g. `"Orders Repair"` → `repairOrders`). Values are not present for plain input fields (those are empty on the blank).
 
-   **Clusters**: Adjacent box IDs in a cluster belong to the same multi-cell control. Match them against known field patterns: a cluster of three boxes is likely a date (mm/dd/yy) or phone (area/prefix/number) triplet; a cluster of two may be a state+zip or name MI pair. Prefer cluster grouping over guessing from labels alone.
+   **Clusters**: A cluster lists box IDs that are spatially adjacent on the same visual row. Use them as a hint that those boxes may form a single logical control (a multi-cell field, a button group, a tab bar — whatever fits the screen). They're geometric, not semantic: interpret each cluster in context.
 
 2. **Dropdown glued to a field → section, not parts.** Two different controls (a list/combo and a value box) that sit on one row need a shared match region so the small one is not ambiguous. Emit a section named `{row}Section` with **both** `boxIds`, then **two elements** that share `"section": "thatName"`. No `parts`. Type each box from the screenshot: combo/list vs value cell. Do not assume wider = field or left = dropdown. Apply crops the section as that union and uses it as each member’s match template so the small box is not a tiny needle.
 

--- a/packages/tools/tm-v2/handler.mjs
+++ b/packages/tools/tm-v2/handler.mjs
@@ -532,6 +532,7 @@ async function handleInternal(req, res, url) {
       return;
     }
     const patch = {
+      ...('type' in body && { type: body.type }),
       ...('charset' in body && { charset: body.charset }),
       ...('swaps' in body && { swaps: body.swaps }),
       ...('overflow' in body && { overflow: body.overflow }),

--- a/packages/tools/tm-v2/index.html
+++ b/packages/tools/tm-v2/index.html
@@ -1501,41 +1501,34 @@ Promise.all([loadSettings(), loadCharsets()])
 document.getElementById('authBannerClose').addEventListener('click', () => showAuthBanner(false));
 
 // Stage zoom via ctrl+wheel / trackpad pinch.
-// Sets img.style.width directly so blank.clientWidth stays accurate and
-// paint() overlay positions remain correct without any transform math.
+// Uses CSS `zoom` property on the stage — unlike transform, zoom updates layout
+// so blank.clientWidth reflects the scaled size and paint() overlays stay aligned.
 (function () {
   const mainEl = document.getElementById('main');
   const stageEl = document.getElementById('stage');
   if (!mainEl || !stageEl) return;
   function applyZoom(cx, cy) {
-    const img = stageEl.querySelector('img');
-    if (!img || !img.naturalWidth) return;
     const rect = mainEl.getBoundingClientRect();
-    // Document point under the cursor before resize
-    const ox = cx - rect.left + mainEl.scrollLeft;
-    const oy = cy - rect.top + mainEl.scrollTop;
-    const prevW = img.clientWidth || img.naturalWidth;
-    img.style.width = Math.round(img.naturalWidth * stageZoom) + 'px';
-    img.style.height = 'auto';
-    // Re-center scroll so the point under the cursor stays fixed
-    const newW = img.clientWidth;
-    const ratio = newW / prevW;
-    mainEl.scrollLeft = ox * ratio - (cx - rect.left);
-    mainEl.scrollTop  = oy * ratio - (cy - rect.top);
+    const prevZoom = parseFloat(stageEl.style.zoom) || 1;
+    // Point in un-zoomed stage coords under the cursor
+    const ox = (cx - rect.left + mainEl.scrollLeft) / prevZoom;
+    const oy = (cy - rect.top  + mainEl.scrollTop)  / prevZoom;
+    stageEl.style.zoom = stageZoom;
+    // Restore the point under the cursor
+    mainEl.scrollLeft = ox * stageZoom - (cx - rect.left);
+    mainEl.scrollTop  = oy * stageZoom - (cy - rect.top);
     paint();
   }
   mainEl.addEventListener('wheel', (e) => {
     if (!e.ctrlKey && !e.metaKey) return;
     e.preventDefault();
-    // Math.pow(0.998, deltaY) gives ~0.2% per pixel — smooth on trackpad, sane on wheel
     stageZoom = Math.max(0.5, Math.min(3, stageZoom * Math.pow(0.998, e.deltaY)));
     applyZoom(e.clientX, e.clientY);
   }, { passive: false });
-  // Double-click resets to fit
+  // Double-click resets
   mainEl.addEventListener('dblclick', () => {
     stageZoom = 1;
-    const img = stageEl.querySelector('img');
-    if (img) { img.style.width = ''; img.style.height = ''; }
+    stageEl.style.zoom = '';
     paint();
   });
 })();

--- a/packages/tools/tm-v2/index.html
+++ b/packages/tools/tm-v2/index.html
@@ -213,11 +213,21 @@
     <div class="inspect-parts" id="popParts"></div>
     <dl>
       <dt>name</dt><dd id="popName"></dd>
-      <dt>type</dt><dd id="popType"></dd>
       <dt>section</dt><dd id="popSection"></dd>
       <dt>parts</dt><dd id="popPartNames"></dd>
     </dl>
     <div id="popOpts">
+      <label>Type
+        <select id="popType">
+          <option value="field">field</option>
+          <option value="dropdown">dropdown</option>
+          <option value="button">button</option>
+          <option value="checkbox">checkbox</option>
+          <option value="tab">tab</option>
+          <option value="icon">icon</option>
+          <option value="other">other</option>
+        </select>
+      </label>
       <label>Charset
         <select id="popCharset"></select>
       </label>
@@ -870,7 +880,8 @@ function updatePartFocus(partsEl, info, parent, el) {
     // Part-level metadata
     document.getElementById('popName').textContent = selectedPartName;
     const fpEl = (state.firstPass && state.firstPass.elements || []).find((e) => e.name === selectedPartName);
-    document.getElementById('popType').textContent = fpEl ? (fpEl.type || '—') : '—';
+    const partType = rawPart && rawPart.type || (fpEl && fpEl.type) || el.type || 'field';
+    document.getElementById('popType').value = partType;
     document.getElementById('popSection').textContent = '—';
     document.getElementById('popPartNames').textContent = '—';
     // Part-level options
@@ -885,7 +896,7 @@ function updatePartFocus(partsEl, info, parent, el) {
     focusDiv.hidden = true;
     // Restore parent metadata
     document.getElementById('popName').textContent = info.name || 'unnamed';
-    document.getElementById('popType').textContent = info.type || '—';
+    document.getElementById('popType').value = el.type || 'field';
     document.getElementById('popSection').textContent = info.section || '—';
     document.getElementById('popPartNames').textContent = info.partNames || '—';
     // Restore parent options
@@ -914,10 +925,10 @@ function renderPop() {
   document.getElementById('detailPlaceholder').hidden = true;
   popEl.hidden = false;
   document.getElementById('popName').textContent = info.name || 'unnamed';
-  document.getElementById('popType').textContent = info.type || '—';
   document.getElementById('popSection').textContent = info.section || '—';
   document.getElementById('popPartNames').textContent = info.partNames || '—';
   document.getElementById('popJson').textContent = JSON.stringify(el, null, 2);
+  document.getElementById('popType').value = el.type || 'field';
   fillCharsetSelect(document.getElementById('popCharset'), el.charset || 'text');
   document.getElementById('popRead').value = el.read ?? (el.type === 'field' ? 'clipboard' : 'ocr');
   document.getElementById('popOverflow').value = el.overflow || '';
@@ -969,6 +980,7 @@ document.getElementById('popSaveOpts').addEventListener('click', async () => {
       body: JSON.stringify({
         element,
         ...(part ? { part } : {}),
+        type: document.getElementById('popType').value,
         charset,
         read,
         overflow: overflow || null,

--- a/packages/tools/tm-v2/index.html
+++ b/packages/tools/tm-v2/index.html
@@ -102,9 +102,14 @@
   .stage.erase-mode.drawing { cursor: cell; }
   .box.erase { border-color: #fa6; background: rgba(255,100,40,.22); }
   .inspect-parts { display: flex; flex-wrap: wrap; gap: 8px; margin: 8px 0; }
-  .inspect-part { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+  .inspect-part { display: flex; flex-direction: column; gap: 2px; min-width: 0; cursor: pointer; border: 1px solid transparent; border-radius: 3px; padding: 2px; }
+  .inspect-part:hover { border-color: #444; }
+  .inspect-part.active { border-color: #6af; background: rgba(100,170,255,.08); }
   .inspect-part canvas { max-width: 100%; }
   .inspect-part span { color: #aaa; font-size: 11px; }
+  #popPartFocus { display: flex; align-items: baseline; gap: 8px; margin: 4px 0 0; padding: 4px 6px; background: rgba(100,170,255,.07); border-left: 2px solid #6af; border-radius: 0 3px 3px 0; font-size: 11px; }
+  #popPartFocusLabel { color: #6af; font-weight: 500; }
+  #popPartFocusSize { color: #666; }
   #pop dl { margin: 8px 0 0; display: grid; grid-template-columns: 52px 1fr; gap: 4px 8px; }
   #pop dt { color: #888; }
   #pop dd { margin: 0; word-break: break-word; }
@@ -201,6 +206,10 @@
   <div id="detailPlaceholder">Click an element to inspect</div>
   <div id="pop" hidden>
     <canvas id="popCanvas"></canvas>
+    <div id="popPartFocus" hidden>
+      <span id="popPartFocusLabel"></span>
+      <span id="popPartFocusSize"></span>
+    </div>
     <div class="inspect-parts" id="popParts"></div>
     <dl>
       <dt>name</dt><dd id="popName"></dd>
@@ -261,6 +270,8 @@ let selectedScreen = '';
 let selectedFile = '';
 let hoverKey = '';
 let pinnedKey = '';
+let selectedPartName = null;
+let selectedPartElement = null;
 let draw = null;
 let savingBoxes = false;
 let detectTool = 'draw';
@@ -840,6 +851,28 @@ function syncOverflowVisibility() {
   document.getElementById('overflowLabel').hidden = isClipboard;
 }
 
+function updatePartFocus(partsEl, info, parent, el) {
+  const focusDiv = document.getElementById('popPartFocus');
+  const focusLabel = document.getElementById('popPartFocusLabel');
+  const focusSizeEl = document.getElementById('popPartFocusSize');
+  const mainCanvas = document.getElementById('popCanvas');
+  for (const wrap of partsEl.children) {
+    const lbl = wrap.querySelector('span');
+    wrap.classList.toggle('active', lbl && lbl.textContent === selectedPartName);
+  }
+  const screenPart = selectedPartName ? info.parts.find((p) => p.name === selectedPartName) : null;
+  if (screenPart) {
+    drawSourceRect(mainCanvas, screenPart, 280, []);
+    focusLabel.textContent = selectedPartName;
+    const rawPart = el && (el.parts || []).find((p) => p.name === selectedPartName);
+    focusSizeEl.textContent = rawPart ? `${rawPart.width} × ${rawPart.height}` : '';
+    focusDiv.hidden = false;
+  } else {
+    drawSourceRect(mainCanvas, parent, 280, info.parts);
+    focusDiv.hidden = true;
+  }
+}
+
 function renderPop() {
   if (view !== 'catalog') {
     hidePop();
@@ -867,9 +900,12 @@ function renderPop() {
   renderSwapRows(document.getElementById('popSwaps'), el.swaps);
   popEl.dataset.element = el.name;
   const parent = info.parent && info.parent.width ? info.parent : info.rect;
-  drawSourceRect(document.getElementById('popCanvas'), parent, 280, info.parts);
   const partsEl = document.getElementById('popParts');
   partsEl.innerHTML = '';
+  if (el.name !== selectedPartElement) {
+    selectedPartName = null;
+    selectedPartElement = el.name;
+  }
   for (const part of info.parts) {
     const wrap = document.createElement('div');
     wrap.className = 'inspect-part';
@@ -880,7 +916,12 @@ function renderPop() {
     wrap.appendChild(label);
     partsEl.appendChild(wrap);
     drawSourceRect(canvas, part, 140, []);
+    wrap.addEventListener('click', () => {
+      selectedPartName = selectedPartName === part.name ? null : part.name;
+      updatePartFocus(partsEl, info, parent, el);
+    });
   }
+  updatePartFocus(partsEl, info, parent, el);
 }
 
 wireSwapContainer(document.getElementById('popSwaps'));

--- a/packages/tools/tm-v2/index.html
+++ b/packages/tools/tm-v2/index.html
@@ -1500,44 +1500,43 @@ Promise.all([loadSettings(), loadCharsets()])
 
 document.getElementById('authBannerClose').addEventListener('click', () => showAuthBanner(false));
 
-// Stage zoom via ctrl+wheel / trackpad pinch
+// Stage zoom via ctrl+wheel / trackpad pinch.
+// Sets img.style.width directly so blank.clientWidth stays accurate and
+// paint() overlay positions remain correct without any transform math.
 (function () {
   const mainEl = document.getElementById('main');
   const stageEl = document.getElementById('stage');
   if (!mainEl || !stageEl) return;
   function applyZoom(cx, cy) {
-    // cx/cy are client coords of the zoom center relative to mainEl
+    const img = stageEl.querySelector('img');
+    if (!img || !img.naturalWidth) return;
     const rect = mainEl.getBoundingClientRect();
+    // Document point under the cursor before resize
     const ox = cx - rect.left + mainEl.scrollLeft;
     const oy = cy - rect.top + mainEl.scrollTop;
-    // After scaling, keep the point under cursor in the same viewport position
-    stageEl.style.transformOrigin = '0 0';
-    stageEl.style.transform = `scale(${stageZoom})`;
-    // Adjust scroll to keep focal point fixed
-    mainEl.scrollLeft = ox * stageZoom - (cx - rect.left);
-    mainEl.scrollTop  = oy * stageZoom - (cy - rect.top);
-    // Expand the scroll area so the browser lets us scroll into the zoomed content
-    const img = stageEl.querySelector('img');
-    const baseW = img ? img.naturalWidth  : stageEl.scrollWidth / stageZoom;
-    const baseH = img ? img.naturalHeight : stageEl.scrollHeight / stageZoom;
-    stageEl.style.width  = Math.round(baseW * stageZoom) + 'px';
-    stageEl.style.height = Math.round(baseH * stageZoom) + 'px';
+    const prevW = img.clientWidth || img.naturalWidth;
+    img.style.width = Math.round(img.naturalWidth * stageZoom) + 'px';
+    img.style.height = 'auto';
+    // Re-center scroll so the point under the cursor stays fixed
+    const newW = img.clientWidth;
+    const ratio = newW / prevW;
+    mainEl.scrollLeft = ox * ratio - (cx - rect.left);
+    mainEl.scrollTop  = oy * ratio - (cy - rect.top);
+    paint();
   }
   mainEl.addEventListener('wheel', (e) => {
     if (!e.ctrlKey && !e.metaKey) return;
     e.preventDefault();
-    const delta = e.deltaY !== 0 ? e.deltaY : -e.deltaX;
-    const factor = delta < 0 ? 1.1 : 1 / 1.1;
-    stageZoom = Math.max(0.25, Math.min(8, stageZoom * factor));
+    // Math.pow(0.998, deltaY) gives ~0.2% per pixel — smooth on trackpad, sane on wheel
+    stageZoom = Math.max(0.5, Math.min(3, stageZoom * Math.pow(0.998, e.deltaY)));
     applyZoom(e.clientX, e.clientY);
   }, { passive: false });
-  // Double-click to reset
-  mainEl.addEventListener('dblclick', (e) => {
-    if (e.target !== mainEl && !stageEl.contains(e.target)) return;
+  // Double-click resets to fit
+  mainEl.addEventListener('dblclick', () => {
     stageZoom = 1;
-    stageEl.style.transform = '';
-    stageEl.style.width = '';
-    stageEl.style.height = '';
+    const img = stageEl.querySelector('img');
+    if (img) { img.style.width = ''; img.style.height = ''; }
+    paint();
   });
 })();
 </script>

--- a/packages/tools/tm-v2/index.html
+++ b/packages/tools/tm-v2/index.html
@@ -213,8 +213,8 @@
     <div class="inspect-parts" id="popParts"></div>
     <dl>
       <dt>name</dt><dd id="popName"></dd>
-      <dt>section</dt><dd id="popSection"></dd>
-      <dt>parts</dt><dd id="popPartNames"></dd>
+      <dt id="popSectionDt">section</dt><dd id="popSection"></dd>
+      <dt id="popPartNamesDt">parts</dt><dd id="popPartNames"></dd>
     </dl>
     <div id="popOpts">
       <label>Type
@@ -871,6 +871,15 @@ function catalogElement(key) {
 }
 
 
+function setMetaRow(dtId, ddId, value) {
+  const dd = document.getElementById(ddId);
+  const dt = document.getElementById(dtId);
+  const show = value && value !== '—';
+  dd.textContent = show ? value : '';
+  if (dt) dt.hidden = !show;
+  dd.hidden = !show;
+}
+
 function syncOverflowVisibility() {
   const isClipboard = document.getElementById('popRead').value === 'clipboard';
   document.getElementById('overflowLabel').hidden = isClipboard;
@@ -897,8 +906,8 @@ function updatePartFocus(partsEl, info, parent, el) {
     const fpEl = (state.firstPass && state.firstPass.elements || []).find((e) => e.name === selectedPartName);
     const partType = rawPart && rawPart.type || (fpEl && fpEl.type) || el.type || 'field';
     document.getElementById('popType').value = partType;
-    document.getElementById('popSection').textContent = '—';
-    document.getElementById('popPartNames').textContent = '—';
+    setMetaRow('popSectionDt', 'popSection', null);
+    setMetaRow('popPartNamesDt', 'popPartNames', null);
     // Part-level options
     fillCharsetSelect(document.getElementById('popCharset'), (rawPart && rawPart.charset) || 'text');
     document.getElementById('popRead').value = rawPart && rawPart.read != null ? rawPart.read : 'ocr';
@@ -912,8 +921,8 @@ function updatePartFocus(partsEl, info, parent, el) {
     // Restore parent metadata
     document.getElementById('popName').textContent = info.name || 'unnamed';
     document.getElementById('popType').value = el.type || 'field';
-    document.getElementById('popSection').textContent = info.section || '—';
-    document.getElementById('popPartNames').textContent = info.partNames || '—';
+    setMetaRow('popSectionDt', 'popSection', info.section);
+    setMetaRow('popPartNamesDt', 'popPartNames', info.partNames);
     // Restore parent options
     fillCharsetSelect(document.getElementById('popCharset'), el.charset || 'text');
     document.getElementById('popRead').value = el.read != null ? el.read : (el.type === 'field' ? 'clipboard' : 'ocr');
@@ -1501,22 +1510,25 @@ Promise.all([loadSettings(), loadCharsets()])
 document.getElementById('authBannerClose').addEventListener('click', () => showAuthBanner(false));
 
 // Stage zoom via ctrl+wheel / trackpad pinch.
-// Uses CSS `zoom` property on the stage — unlike transform, zoom updates layout
-// so blank.clientWidth reflects the scaled size and paint() overlays stay aligned.
+// Sets stage width explicitly: img has max-width:100% so it fills the stage,
+// and blank.clientWidth then reflects the zoomed size for paint() overlays.
 (function () {
   const mainEl = document.getElementById('main');
   const stageEl = document.getElementById('stage');
   if (!mainEl || !stageEl) return;
   function applyZoom(cx, cy) {
     const rect = mainEl.getBoundingClientRect();
-    const prevZoom = parseFloat(stageEl.style.zoom) || 1;
-    // Point in un-zoomed stage coords under the cursor
-    const ox = (cx - rect.left + mainEl.scrollLeft) / prevZoom;
-    const oy = (cy - rect.top  + mainEl.scrollTop)  / prevZoom;
-    stageEl.style.zoom = stageZoom;
-    // Restore the point under the cursor
-    mainEl.scrollLeft = ox * stageZoom - (cx - rect.left);
-    mainEl.scrollTop  = oy * stageZoom - (cy - rect.top);
+    const prevW = stageEl.clientWidth || blank.naturalWidth;
+    const newW = Math.round(blank.naturalWidth * stageZoom);
+    // Point in stage coords under cursor (before resize)
+    const ox = cx - rect.left + mainEl.scrollLeft;
+    const oy = cy - rect.top  + mainEl.scrollTop;
+    stageEl.style.width = newW + 'px';
+    stageEl.style.minWidth = newW + 'px';
+    // Keep focal point fixed
+    const ratio = newW / prevW;
+    mainEl.scrollLeft = ox * ratio - (cx - rect.left);
+    mainEl.scrollTop  = oy * ratio - (cy - rect.top);
     paint();
   }
   mainEl.addEventListener('wheel', (e) => {
@@ -1528,7 +1540,8 @@ document.getElementById('authBannerClose').addEventListener('click', () => showA
   // Double-click resets
   mainEl.addEventListener('dblclick', () => {
     stageZoom = 1;
-    stageEl.style.zoom = '';
+    stageEl.style.width = '';
+    stageEl.style.minWidth = '';
     paint();
   });
 })();

--- a/packages/tools/tm-v2/index.html
+++ b/packages/tools/tm-v2/index.html
@@ -861,15 +861,40 @@ function updatePartFocus(partsEl, info, parent, el) {
     wrap.classList.toggle('active', lbl && lbl.textContent === selectedPartName);
   }
   const screenPart = selectedPartName ? info.parts.find((p) => p.name === selectedPartName) : null;
+  const rawPart = selectedPartName ? (el && el.parts || []).find((p) => p.name === selectedPartName) : null;
   if (screenPart) {
     drawSourceRect(mainCanvas, screenPart, 280, []);
     focusLabel.textContent = selectedPartName;
-    const rawPart = el && (el.parts || []).find((p) => p.name === selectedPartName);
-    focusSizeEl.textContent = rawPart ? `${rawPart.width} × ${rawPart.height}` : '';
+    focusSizeEl.textContent = rawPart ? `${rawPart.width} x ${rawPart.height}` : '';
     focusDiv.hidden = false;
+    // Part-level metadata
+    document.getElementById('popName').textContent = selectedPartName;
+    const fpEl = (state.firstPass && state.firstPass.elements || []).find((e) => e.name === selectedPartName);
+    document.getElementById('popType').textContent = fpEl ? (fpEl.type || '—') : '—';
+    document.getElementById('popSection').textContent = '—';
+    document.getElementById('popPartNames').textContent = '—';
+    // Part-level options
+    fillCharsetSelect(document.getElementById('popCharset'), (rawPart && rawPart.charset) || 'text');
+    document.getElementById('popRead').value = rawPart && rawPart.read != null ? rawPart.read : 'ocr';
+    document.getElementById('popOverflow').value = (rawPart && rawPart.overflow) || '';
+    syncOverflowVisibility();
+    renderSwapRows(document.getElementById('popSwaps'), rawPart && rawPart.swaps);
+    popEl.dataset.part = selectedPartName;
   } else {
     drawSourceRect(mainCanvas, parent, 280, info.parts);
     focusDiv.hidden = true;
+    // Restore parent metadata
+    document.getElementById('popName').textContent = info.name || 'unnamed';
+    document.getElementById('popType').textContent = info.type || '—';
+    document.getElementById('popSection').textContent = info.section || '—';
+    document.getElementById('popPartNames').textContent = info.partNames || '—';
+    // Restore parent options
+    fillCharsetSelect(document.getElementById('popCharset'), el.charset || 'text');
+    document.getElementById('popRead').value = el.read != null ? el.read : (el.type === 'field' ? 'clipboard' : 'ocr');
+    document.getElementById('popOverflow').value = el.overflow || '';
+    syncOverflowVisibility();
+    renderSwapRows(document.getElementById('popSwaps'), el.swaps);
+    delete popEl.dataset.part;
   }
 }
 
@@ -937,11 +962,13 @@ document.getElementById('popSaveOpts').addEventListener('click', async () => {
     const read = document.getElementById('popRead').value;
     const overflow = document.getElementById('popOverflow').value;
     const swaps = rowsToSwaps(document.getElementById('popSwaps'));
+    const part = popEl.dataset.part || '';
     const out = await api('/api/element-options?name=' + encodeURIComponent(state.name), {
       method: 'PUT',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
         element,
+        ...(part ? { part } : {}),
         charset,
         read,
         overflow: overflow || null,
@@ -951,7 +978,7 @@ document.getElementById('popSaveOpts').addEventListener('click', async () => {
     const idx = state.elements.findIndex((item) => item.name === element);
     // Replace wholesale so cleared charset/read/swaps do not linger from prior state.
     if (idx >= 0) state.elements[idx] = out.index;
-    setStatus('Saved options for ' + element);
+    setStatus('Saved options for ' + (part ? element + '.' + part : element));
     renderPop();
   } catch (err) {
     toast(err.message || String(err));

--- a/packages/tools/tm-v2/index.html
+++ b/packages/tools/tm-v2/index.html
@@ -1510,22 +1510,22 @@ Promise.all([loadSettings(), loadCharsets()])
 document.getElementById('authBannerClose').addEventListener('click', () => showAuthBanner(false));
 
 // Stage zoom via ctrl+wheel / trackpad pinch.
-// Sets stage width explicitly: img has max-width:100% so it fills the stage,
-// and blank.clientWidth then reflects the zoomed size for paint() overlays.
+// stageZoom is relative to the initial viewport-fit width (not natural width),
+// captured on first zoom so the first pinch step is always a small increment.
 (function () {
   const mainEl = document.getElementById('main');
   const stageEl = document.getElementById('stage');
   if (!mainEl || !stageEl) return;
+  let baseW = 0; // viewport-fit width captured on first zoom
   function applyZoom(cx, cy) {
+    if (!baseW) baseW = blank.clientWidth || blank.naturalWidth;
+    const prevW = stageEl.style.width ? parseInt(stageEl.style.width) : baseW;
+    const newW = Math.round(baseW * stageZoom);
     const rect = mainEl.getBoundingClientRect();
-    const prevW = stageEl.clientWidth || blank.naturalWidth;
-    const newW = Math.round(blank.naturalWidth * stageZoom);
-    // Point in stage coords under cursor (before resize)
     const ox = cx - rect.left + mainEl.scrollLeft;
     const oy = cy - rect.top  + mainEl.scrollTop;
     stageEl.style.width = newW + 'px';
     stageEl.style.minWidth = newW + 'px';
-    // Keep focal point fixed
     const ratio = newW / prevW;
     mainEl.scrollLeft = ox * ratio - (cx - rect.left);
     mainEl.scrollTop  = oy * ratio - (cy - rect.top);
@@ -1534,12 +1534,13 @@ document.getElementById('authBannerClose').addEventListener('click', () => showA
   mainEl.addEventListener('wheel', (e) => {
     if (!e.ctrlKey && !e.metaKey) return;
     e.preventDefault();
-    stageZoom = Math.max(0.5, Math.min(3, stageZoom * Math.pow(0.998, e.deltaY)));
+    stageZoom = Math.max(0.5, Math.min(3, stageZoom * Math.pow(0.996, e.deltaY)));
     applyZoom(e.clientX, e.clientY);
   }, { passive: false });
-  // Double-click resets
+  // Double-click resets to fit
   mainEl.addEventListener('dblclick', () => {
     stageZoom = 1;
+    baseW = 0;
     stageEl.style.width = '';
     stageEl.style.minWidth = '';
     paint();

--- a/packages/tools/tm-v2/index.html
+++ b/packages/tools/tm-v2/index.html
@@ -282,6 +282,7 @@ let hoverKey = '';
 let pinnedKey = '';
 let selectedPartName = null;
 let selectedPartElement = null;
+let stageZoom = 1;
 let draw = null;
 let savingBoxes = false;
 let detectTool = 'draw';
@@ -616,7 +617,7 @@ function inspectInfo(key) {
   return null;
 }
 
-function drawSourceRect(canvas, rect, maxW, overlays) {
+function drawSourceRect(canvas, rect, maxW, overlays, activePart) {
   if (!canvas || !rect || !blank.naturalWidth) return;
   const pad = 6;
   const sx = Math.max(0, rect.x - pad);
@@ -633,10 +634,24 @@ function drawSourceRect(canvas, rect, maxW, overlays) {
   ctx.lineWidth = 1;
   ctx.strokeRect((rect.x - sx) * scale, (rect.y - sy) * scale, rect.width * scale, rect.height * scale);
   if (overlays && overlays.length) {
-    ctx.strokeStyle = '#6af';
     for (const part of overlays) {
-      ctx.strokeRect((part.x - sx) * scale, (part.y - sy) * scale, part.width * scale, part.height * scale);
+      const isActive = activePart && part.name === activePart;
+      const px = (part.x - sx) * scale;
+      const py = (part.y - sy) * scale;
+      const pw = part.width * scale;
+      const ph = part.height * scale;
+      if (isActive) {
+        ctx.fillStyle = 'rgba(100,170,255,0.25)';
+        ctx.fillRect(px, py, pw, ph);
+        ctx.strokeStyle = '#6af';
+        ctx.lineWidth = 2;
+      } else {
+        ctx.strokeStyle = activePart ? 'rgba(100,170,255,0.35)' : '#6af';
+        ctx.lineWidth = 1;
+      }
+      ctx.strokeRect(px, py, pw, ph);
     }
+    ctx.lineWidth = 1;
   }
 }
 
@@ -873,7 +888,7 @@ function updatePartFocus(partsEl, info, parent, el) {
   const screenPart = selectedPartName ? info.parts.find((p) => p.name === selectedPartName) : null;
   const rawPart = selectedPartName ? (el && el.parts || []).find((p) => p.name === selectedPartName) : null;
   if (screenPart) {
-    drawSourceRect(mainCanvas, screenPart, 280, []);
+    drawSourceRect(mainCanvas, parent, 280, info.parts, selectedPartName);
     focusLabel.textContent = selectedPartName;
     focusSizeEl.textContent = rawPart ? `${rawPart.width} x ${rawPart.height}` : '';
     focusDiv.hidden = false;
@@ -1484,6 +1499,47 @@ Promise.all([loadSettings(), loadCharsets()])
   .catch(handleApiError);
 
 document.getElementById('authBannerClose').addEventListener('click', () => showAuthBanner(false));
+
+// Stage zoom via ctrl+wheel / trackpad pinch
+(function () {
+  const mainEl = document.getElementById('main');
+  const stageEl = document.getElementById('stage');
+  if (!mainEl || !stageEl) return;
+  function applyZoom(cx, cy) {
+    // cx/cy are client coords of the zoom center relative to mainEl
+    const rect = mainEl.getBoundingClientRect();
+    const ox = cx - rect.left + mainEl.scrollLeft;
+    const oy = cy - rect.top + mainEl.scrollTop;
+    // After scaling, keep the point under cursor in the same viewport position
+    stageEl.style.transformOrigin = '0 0';
+    stageEl.style.transform = `scale(${stageZoom})`;
+    // Adjust scroll to keep focal point fixed
+    mainEl.scrollLeft = ox * stageZoom - (cx - rect.left);
+    mainEl.scrollTop  = oy * stageZoom - (cy - rect.top);
+    // Expand the scroll area so the browser lets us scroll into the zoomed content
+    const img = stageEl.querySelector('img');
+    const baseW = img ? img.naturalWidth  : stageEl.scrollWidth / stageZoom;
+    const baseH = img ? img.naturalHeight : stageEl.scrollHeight / stageZoom;
+    stageEl.style.width  = Math.round(baseW * stageZoom) + 'px';
+    stageEl.style.height = Math.round(baseH * stageZoom) + 'px';
+  }
+  mainEl.addEventListener('wheel', (e) => {
+    if (!e.ctrlKey && !e.metaKey) return;
+    e.preventDefault();
+    const delta = e.deltaY !== 0 ? e.deltaY : -e.deltaX;
+    const factor = delta < 0 ? 1.1 : 1 / 1.1;
+    stageZoom = Math.max(0.25, Math.min(8, stageZoom * factor));
+    applyZoom(e.clientX, e.clientY);
+  }, { passive: false });
+  // Double-click to reset
+  mainEl.addEventListener('dblclick', (e) => {
+    if (e.target !== mainEl && !stageEl.contains(e.target)) return;
+    stageZoom = 1;
+    stageEl.style.transform = '';
+    stageEl.style.width = '';
+    stageEl.style.height = '';
+  });
+})();
 </script>
 </body>
 </html>

--- a/packages/tools/tm-v2/index.html
+++ b/packages/tools/tm-v2/index.html
@@ -283,6 +283,7 @@ let pinnedKey = '';
 let selectedPartName = null;
 let selectedPartElement = null;
 let stageZoom = 1;
+let stageBaseW = 0; // viewport-fit width; reset on screen navigation
 let draw = null;
 let savingBoxes = false;
 let detectTool = 'draw';
@@ -904,7 +905,7 @@ function updatePartFocus(partsEl, info, parent, el) {
     // Part-level metadata
     document.getElementById('popName').textContent = selectedPartName;
     const fpEl = (state.firstPass && state.firstPass.elements || []).find((e) => e.name === selectedPartName);
-    const partType = rawPart && rawPart.type || (fpEl && fpEl.type) || el.type || 'field';
+    const partType = (rawPart?.type ?? (fpEl?.type ?? (el.type ?? 'field')));
     document.getElementById('popType').value = partType;
     setMetaRow('popSectionDt', 'popSection', null);
     setMetaRow('popPartNamesDt', 'popPartNames', null);
@@ -948,11 +949,7 @@ function renderPop() {
   }
   document.getElementById('detailPlaceholder').hidden = true;
   popEl.hidden = false;
-  document.getElementById('popName').textContent = info.name || 'unnamed';
-  document.getElementById('popSection').textContent = info.section || '—';
-  document.getElementById('popPartNames').textContent = info.partNames || '—';
   document.getElementById('popJson').textContent = JSON.stringify(el, null, 2);
-  document.getElementById('popType').value = el.type || 'field';
   fillCharsetSelect(document.getElementById('popCharset'), el.charset || 'text');
   document.getElementById('popRead').value = el.read ?? (el.type === 'field' ? 'clipboard' : 'ocr');
   document.getElementById('popOverflow').value = el.overflow || '';
@@ -1012,8 +1009,19 @@ document.getElementById('popSaveOpts').addEventListener('click', async () => {
       }),
     });
     const idx = state.elements.findIndex((item) => item.name === element);
-    // Replace wholesale so cleared charset/read/swaps do not linger from prior state.
-    if (idx >= 0) state.elements[idx] = out.index;
+    if (idx >= 0) {
+      if (part) {
+        // out.index is a part record; update only the matching part to avoid clobbering the element.
+        const elParts = state.elements[idx].parts || [];
+        const pIdx = elParts.findIndex((p) => p.name === part);
+        if (pIdx >= 0) elParts[pIdx] = out.index;
+        else elParts.push(out.index);
+        state.elements[idx].parts = elParts;
+      } else {
+        // Replace wholesale so cleared charset/read/swaps do not linger from prior state.
+        state.elements[idx] = out.index;
+      }
+    }
     setStatus('Saved options for ' + (part ? element + '.' + part : element));
     renderPop();
   } catch (err) {
@@ -1032,6 +1040,10 @@ async function loadScreen(name, opts = {}) {
   if (!opts.keepFile) selectedFile = '';
   pinnedKey = '';
   hoverKey = '';
+  stageZoom = 1;
+  stageBaseW = 0;
+  const _stEl = document.getElementById('stage');
+  if (_stEl) { _stEl.style.width = ''; _stEl.style.minWidth = ''; }
   const data = await api('/api/screen?name=' + encodeURIComponent(name));
   state = {
     name,
@@ -1510,17 +1522,22 @@ Promise.all([loadSettings(), loadCharsets()])
 document.getElementById('authBannerClose').addEventListener('click', () => showAuthBanner(false));
 
 // Stage zoom via ctrl+wheel / trackpad pinch.
-// stageZoom is relative to the initial viewport-fit width (not natural width),
-// captured on first zoom so the first pinch step is always a small increment.
+// stageZoom and stageBaseW are module-level globals so loadScreen can reset them.
+let _paintPending = false;
+function deferPaint() {
+  if (_paintPending) return;
+  _paintPending = true;
+  requestAnimationFrame(() => { _paintPending = false; paint(); });
+}
 (function () {
   const mainEl = document.getElementById('main');
   const stageEl = document.getElementById('stage');
   if (!mainEl || !stageEl) return;
-  let baseW = 0; // viewport-fit width captured on first zoom
   function applyZoom(cx, cy) {
-    if (!baseW) baseW = blank.clientWidth || blank.naturalWidth;
-    const prevW = stageEl.style.width ? parseInt(stageEl.style.width) : baseW;
-    const newW = Math.round(baseW * stageZoom);
+    if (!stageBaseW) stageBaseW = blank.clientWidth || blank.naturalWidth;
+    if (!stageBaseW) return; // no screen loaded yet
+    const prevW = stageEl.style.width ? parseInt(stageEl.style.width) : stageBaseW;
+    const newW = Math.round(stageBaseW * stageZoom);
     const rect = mainEl.getBoundingClientRect();
     const ox = cx - rect.left + mainEl.scrollLeft;
     const oy = cy - rect.top  + mainEl.scrollTop;
@@ -1529,7 +1546,7 @@ document.getElementById('authBannerClose').addEventListener('click', () => showA
     const ratio = newW / prevW;
     mainEl.scrollLeft = ox * ratio - (cx - rect.left);
     mainEl.scrollTop  = oy * ratio - (cy - rect.top);
-    paint();
+    deferPaint();
   }
   mainEl.addEventListener('wheel', (e) => {
     if (!e.ctrlKey && !e.metaKey) return;
@@ -1540,7 +1557,7 @@ document.getElementById('authBannerClose').addEventListener('click', () => showA
   // Double-click resets to fit
   mainEl.addEventListener('dblclick', () => {
     stageZoom = 1;
-    baseW = 0;
+    stageBaseW = 0;
     stageEl.style.width = '';
     stageEl.style.minWidth = '';
     paint();


### PR DESCRIPTION
## Summary

- **Option 2 — box value OCR**: Words that OCR finds *inside* a detected box (buttons, tabs, dropdowns) are now attached as `value?: string` on `DetectedBox` instead of being silently dropped. Zero extra OCR calls — the existing `labelsAndValuesFromOcr` pass already sees them; the new `labelsAndValuesFromOcr` function captures them into a `Map<number, string>` keyed by box ID, then `detectScreen` applies them. The AI can now see `"Warranty Repair"`, `"Close"`, `"Repair Orders"` directly in `boxes.json`.

- **Option 4 — geometric cluster groups**: `groupBoxClusters(boxes)` groups boxes sharing the same visual row (Y-center within ~10 px) where adjacent boxes have an X-gap ≤ 8 px. Written to `boxes.json` as `clusters?: BoxCluster[]`. Pure geometry — no AI, no Autosoft-specific heuristics. Helps the AI identify date triplets, phone triplets, and multi-cell rows automatically.

- Both enrichments run inside `detectScreen` (the existing detect step), transparent to callers.
- `BoxCluster` and `groupBoxClusters` exported from `author/index.ts`.
- `labelsFromOcr` delegates to `labelsAndValuesFromOcr` — all 9 existing label tests pass unchanged.

## Test plan

- [x] `vitest run src/author/labels` — 9/9 tests pass
- [x] `tsc --noEmit` — no type errors
- [ ] Run `detect` on a real screen (e.g. `service`, `wolf01`) and verify `boxes.json` shows `value` on button boxes and `clusters` grouping adjacent boxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)