### PR TITLE
fix: code-review fixes, part types in generated.ts, v0.4.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rickcedwhat/playwright-smart-vision",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Computer-vision and OCR-based element assertions for Playwright — local, fast, no GPT Vision required",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/author/apply.ts
+++ b/packages/core/src/author/apply.ts
@@ -319,7 +319,11 @@ export function applyScreen(name: string, firstPass?: FirstPass): ApplyScreenRes
       type: 'other',
       boxIds: sec.boxIds,
       labelIds: allLabelIds,
-      parts: members.map((m) => ({ name: m.name, ...((m.boxIds ?? [])[0] != null ? { boxId: (m.boxIds ?? [])[0] } : {}) })),
+      parts: members.map((m) => ({
+        name: m.name,
+        ...(m.type ? { type: m.type } : {}),
+        ...((m.boxIds ?? [])[0] != null ? { boxId: (m.boxIds ?? [])[0] } : {}),
+      })),
     });
   }
 

--- a/packages/core/src/author/author.test.ts
+++ b/packages/core/src/author/author.test.ts
@@ -231,7 +231,9 @@ describe('author apply + catalog', () => {
     expect(src).toContain('export type ScreenName');
     expect(src).toContain('keyof typeof screens extends never');
     expect(src).toContain('export type ElementName');
-    expect(src).not.toContain('type: "field"');
+    expect(src).toContain('export type PartName');
+    expect(src).toContain('export type PartType');
+    expect(src).toContain('type: "field"');
     expect(src).not.toContain('export type Screens');
     expect(fs.readFileSync(dest, 'utf8')).toBe(src);
     expect(fs.readFileSync(path.join(root, 'generated.ts'), 'utf8')).toContain('"html-login"');

--- a/packages/core/src/author/catalog.ts
+++ b/packages/core/src/author/catalog.ts
@@ -29,8 +29,15 @@ export interface ScreenCatalog {
   [screen: string]: readonly string[];
 }
 
+export interface CatalogPart {
+  name: string;
+  type?: string;
+}
+
 export interface CatalogElement {
   name: string;
+  type?: string;
+  parts?: CatalogPart[];
 }
 
 interface CatalogScreen {
@@ -47,11 +54,23 @@ function listScreens(root: string): CatalogScreen[] {
     if (!fs.existsSync(indexPath)) continue;
     try {
       const raw = JSON.parse(fs.readFileSync(indexPath, 'utf8')) as {
-        elements?: Array<{ name?: string }>;
+        elements?: Array<{ name?: string; type?: string; parts?: Array<{ name?: string; type?: string }> }>;
       };
       const elements = (raw.elements ?? [])
-        .filter((el): el is { name: string } => Boolean(el.name))
-        .map((el) => ({ name: el.name }));
+        .filter((el) => Boolean(el.name))
+        .map((el) => {
+          const entry: CatalogElement = { name: el.name! };
+          if (el.type) entry.type = el.type;
+          const parts = (el.parts ?? []).filter((p) => Boolean(p.name));
+          if (parts.length) {
+            entry.parts = parts.map((p) => {
+              const part: CatalogPart = { name: p.name! };
+              if (p.type) part.type = p.type;
+              return part;
+            });
+          }
+          return entry;
+        });
       out.push({ name: ent.name, elements });
     } catch {
       // skip unreadable index.json
@@ -86,7 +105,13 @@ export function screenCatalogSource(charsets?: Record<string, unknown>): string 
       const key = toCamelCase(s.name);
       const elementsBody = s.elements.length
         ? s.elements
-            .map((el) => `      ${JSON.stringify(el.name)}: ${JSON.stringify(el.name)},`)
+            .map((el) => {
+              const typeStr = el.type ? `, type: ${JSON.stringify(el.type)}` : '';
+              const partsStr = el.parts?.length
+                ? `, parts: {${el.parts.map((p) => `${JSON.stringify(p.name)}: ${JSON.stringify(p.type ?? 'field')}`).join(', ')}}`
+                : '';
+              return `      ${JSON.stringify(el.name)}: { name: ${JSON.stringify(el.name)}${typeStr}${partsStr} },`;
+            })
             .join('\n')
         : '';
       return `  ${key}: {\n    name: ${JSON.stringify(s.name)},\n    elements: {\n${elementsBody}\n    },\n  },`;
@@ -110,7 +135,21 @@ type _ScreenKey<S extends ScreenName> = {
   [K in keyof typeof screens]: (typeof screens)[K]['name'] extends S ? K : never;
 }[keyof typeof screens];
 
-export type ElementName<S extends ScreenName> = keyof (typeof screens)[_ScreenKey<S>]['elements'] & string;
+type _Screen<S extends ScreenName> = (typeof screens)[_ScreenKey<S>];
+
+export type ElementName<S extends ScreenName> = keyof _Screen<S>['elements'] & string;
+
+export type PartName<S extends ScreenName, E extends ElementName<S>> =
+  _Screen<S>['elements'][E] extends { parts: infer P } ? keyof P & string : never;
+
+export type PartType<S extends ScreenName, E extends ElementName<S>, P extends PartName<S, E>> =
+  _Screen<S>['elements'][E] extends { parts: infer Parts }
+    ? Parts extends Record<string, string>
+      ? P extends keyof Parts
+        ? Parts[P]
+        : never
+      : never
+    : never;
 `;
 }
 


### PR DESCRIPTION
## Summary

- **8 code-review bug fixes** from the PR #94 review (all confirmed/plausible findings):
  - Part save no longer clobbers `state.elements[idx]` with a bare part record
  - `stageZoom` + stage width reset on every `loadScreen` (wrong zoom on nav fixed)
  - `paint()` in zoom handler throttled through `deferPaint` (rAF) — no more 60 Hz DOM thrash
  - `ocrRect` skipped for synthetic `type:'other'` elements (no garbage OCR)
  - `m.boxIds` guarded against undefined in synthetic part builder
  - Duplicate stripped section names deduped (silent PNG overwrite prevented)
  - `patchPartOptions` handles section-derived elements without 500 error
  - `||` → `??` for `rawPart.type` (explicit empty type no longer silently overridden)
  - Dead `renderPop` writes removed; `updatePartFocus` is the sole source of truth

- **Part types in `generated.ts`**:
  - `apply.ts`: synthetic element parts now include the member element's `type`
  - `catalog.ts`: reads `type` and `parts[].type` from index.json; emits `{ name, type, parts: { partName: partType } }` per element
  - New utility types: `PartName<S, E>` and `PartType<S, E, P>` in the generated output
  - `PartType<'customer-info', 'salesAgent', 'code'>` now resolves to `"dropdown"`

- **Unit test** rewritten for section absorption behavior

- **v0.4.0**

## Test plan
- [ ] `npx vitest run packages/core/src/author/author.test.ts` — all 11 pass
- [ ] Open TM v2, zoom in on a screen, navigate to another screen — zoom resets
- [ ] Save a part option — inspector stays intact after save
- [ ] Run `applyScreen` on a screen with sections — check `generated.ts` has part types

🤖 Generated with [Claude Code](https://claude.com/claude-code)