### PR TITLE
fix: readable swap display in assertion error messages

### DIFF
--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -58,7 +58,7 @@ function formatExpected(expected: string | RegExp): string {
 
 function formatSwaps(swaps: OcrSwaps): string {
   return Object.entries(swaps).map(([from, to]) => {
-    const targets = (typeof to === 'string' ? [to] : [...to]).join('|');
+    const targets = (typeof to === 'string' ? [to] : to).join('|');
     return `[${from}]→[${targets}]`;
   }).join(', ');
 }

--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -58,8 +58,8 @@ function formatExpected(expected: string | RegExp): string {
 
 function formatSwaps(swaps: OcrSwaps): string {
   return Object.entries(swaps).map(([from, to]) => {
-    const allowed = (typeof to === 'string' ? [to] : [...to]).join('|');
-    return `${from}→${allowed}`;
+    const targets = (typeof to === 'string' ? [to] : [...to]).join('|');
+    return `[${from}]→[${targets}]`;
   }).join(', ');
 }
 

--- a/packages/core/src/screen.ts
+++ b/packages/core/src/screen.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import type { Page, TestType } from '@playwright/test';
 import type { ScreenConfig } from './screen-config.js';
-import { loadScreen, clearConfigUnhoverPoint, configure } from './configure.js';
+import { loadScreen, clearConfigUnhoverPoint, configure, resetGlobalConfig } from './configure.js';
 import { clearScreenHandlers } from './screen-handler.js';
 import { FieldExtractor } from './field-extractor.js';
 import { ScreenResult } from './screen-result.js';
@@ -226,6 +226,7 @@ export async function release(): Promise<void> {
   setFillStrategy(undefined);
   setCharsetRegistry({});
   setOcrStrategy(undefined);
+  resetGlobalConfig();
   await cleanupOCR();
 }
 

--- a/packages/tools/template-manager-server.mjs
+++ b/packages/tools/template-manager-server.mjs
@@ -11,7 +11,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { exec } from 'node:child_process';
-import { handleTmV2Request, initTmV2, tmV2StartupLines } from './tm-v2/handler.mjs';
+import { handleTmV2Request, initTmV2, tmV2StartupLines, TM_V2_BASE } from './tm-v2/handler.mjs';
 import { PNG } from 'pngjs';
 import { VisionUtil } from '@rickcedwhat/playwright-smart-vision/utils/vision';
 import { OCRUtil, charsetForField, pickFromOptions } from '@rickcedwhat/playwright-smart-vision/utils/ocr';
@@ -910,7 +910,7 @@ async function handle(req, res) {
   }
 
   if (req.method === 'GET' && url.pathname === '/') {
-    res.writeHead(302, { Location: '/template-manager' });
+    res.writeHead(302, { Location: TM_V2_BASE });
     res.end();
     return;
   }


### PR DESCRIPTION
## Summary

- `formatSwaps()` previously rendered unquoted characters directly, so swaps involving `'` and `"` (like the guacamole preset's curly-quote swaps) produced unreadable output like `'→'|', "→"|'`
- Now wraps each character in `[]`, e.g. `[']→['|'], ["]→["|"]`

## Test plan
- [ ] Trigger a `toHaveText` failure on an element that has quote swaps configured (e.g. guacamole preset) and confirm the error message is readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)