### PR TITLE
breaking: strategies.actions grouping, Charset only/exclude API, charsets into ocr

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,10 +36,10 @@ export type {
   CustomMatcherFunction,
 } from './types.js';
 
-export { ocrTextMatches } from './utils/ocr.js';
+export { ocrTextMatches, charsetToWhitelist } from './utils/ocr.js';
 export type { Charset, FieldRead, OcrOverflow, OcrSwaps } from './utils/ocr.js';
 export { Strategies } from './screen.js';
-export type { OcrStrategy, ClickStrategy, FillStrategy, CaptureStrategy } from './screen.js';
+export type { OcrStrategy, ClickStrategy, FillStrategy, HoverStrategy, DblClickStrategy, CaptureStrategy, InitStrategies } from './screen.js';
 export { presets, mergeInitOptions } from './presets.js';
 export { createScreen } from './screen-api.js';
 export type { TypedResult } from './screen-api.js';

--- a/packages/core/src/presets.ts
+++ b/packages/core/src/presets.ts
@@ -13,7 +13,9 @@ export const presets = {
    */
   guacamole: {
     strategies: {
-      fill: Strategies.Fill.tripleClickType(),
+      actions: {
+        fill: Strategies.Fill.tripleClickType(),
+      },
       ocr: Strategies.Ocr.default({
         read: 'clipboard' as const,
         swaps: {
@@ -30,7 +32,9 @@ export const presets = {
    */
   rdp: {
     strategies: {
-      fill: Strategies.Fill.charByChar({ delay: 30 }),
+      actions: {
+        fill: Strategies.Fill.charByChar({ delay: 30 }),
+      },
     },
   },
 
@@ -40,7 +44,9 @@ export const presets = {
    */
   webview: {
     strategies: {
-      fill: Strategies.Fill.selectAllType(),
+      actions: {
+        fill: Strategies.Fill.selectAllType(),
+      },
     },
   },
 } as const;

--- a/packages/core/src/screen.ts
+++ b/packages/core/src/screen.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import type { Page, TestType } from '@playwright/test';
 import type { ScreenConfig } from './screen-config.js';
-import { loadScreen, clearConfigUnhoverPoint, configure } from './configure.js';
+import { loadScreen, clearConfigUnhoverPoint, configure, resetGlobalConfig } from './configure.js';
 import { clearScreenHandlers } from './screen-handler.js';
 import { FieldExtractor } from './field-extractor.js';
 import { ScreenResult } from './screen-result.js';

--- a/packages/core/src/screen.ts
+++ b/packages/core/src/screen.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import type { Page, TestType } from '@playwright/test';
 import type { ScreenConfig } from './screen-config.js';
-import { loadScreen, clearConfigUnhoverPoint, configure, resetGlobalConfig } from './configure.js';
+import { loadScreen, clearConfigUnhoverPoint, configure } from './configure.js';
 import { clearScreenHandlers } from './screen-handler.js';
 import { FieldExtractor } from './field-extractor.js';
 import { ScreenResult } from './screen-result.js';

--- a/packages/core/src/screen.ts
+++ b/packages/core/src/screen.ts
@@ -3,11 +3,11 @@ import os from 'node:os';
 import path from 'node:path';
 import type { Page, TestType } from '@playwright/test';
 import type { ScreenConfig } from './screen-config.js';
-import { loadScreen, clearConfigUnhoverPoint, configure, resetGlobalConfig } from './configure.js';
+import { loadScreen, clearConfigUnhoverPoint, configure } from './configure.js';
 import { clearScreenHandlers } from './screen-handler.js';
 import { FieldExtractor } from './field-extractor.js';
 import { ScreenResult } from './screen-result.js';
-import { cleanupOCR, getOCRUtil, setOcrStrategy, type Charset, type FieldRead } from './utils/ocr.js';
+import { cleanupOCR, getOCRUtil, setOcrStrategy, getOcrStrategy, type Charset, type FieldRead } from './utils/ocr.js';
 import { setUnhoverPoint } from './unhover.js';
 import { ensureCvReady } from './utils/vision.js';
 import {
@@ -160,7 +160,18 @@ export async function init(options: InitOptions): Promise<void> {
     setDblClickStrategy(options.strategies.actions.dblclick);
   }
   if (options.strategies?.ocr !== undefined) {
-    setOcrStrategy(options.strategies.ocr);
+    const existing = getOcrStrategy();
+    const next = options.strategies.ocr;
+    const merged = existing
+      ? {
+          ...existing,
+          ...next,
+          ...(next.charsets && existing.charsets
+            ? { charsets: { ...existing.charsets, ...next.charsets } }
+            : {}),
+        }
+      : next;
+    setOcrStrategy(merged);
   }
 
   try {
@@ -239,7 +250,6 @@ export async function release(): Promise<void> {
   setHoverStrategy(undefined);
   setDblClickStrategy(undefined);
   setOcrStrategy(undefined);
-  resetGlobalConfig();
   await cleanupOCR();
 }
 

--- a/packages/core/src/screen.ts
+++ b/packages/core/src/screen.ts
@@ -7,15 +7,19 @@ import { loadScreen, clearConfigUnhoverPoint, configure, resetGlobalConfig } fro
 import { clearScreenHandlers } from './screen-handler.js';
 import { FieldExtractor } from './field-extractor.js';
 import { ScreenResult } from './screen-result.js';
-import { cleanupOCR, getOCRUtil, setCharsetRegistry, setOcrStrategy, type Charset, type FieldRead } from './utils/ocr.js';
+import { cleanupOCR, getOCRUtil, setOcrStrategy, type Charset, type FieldRead } from './utils/ocr.js';
 import { setUnhoverPoint } from './unhover.js';
 import { ensureCvReady } from './utils/vision.js';
 import {
   Strategies,
   setClickStrategy,
   setFillStrategy,
+  setHoverStrategy,
+  setDblClickStrategy,
   type ClickStrategy,
   type FillStrategy,
+  type HoverStrategy,
+  type DblClickStrategy,
   type CaptureStrategy,
   type OcrStrategy,
 } from './strategies.js';
@@ -71,15 +75,20 @@ export function bindOcrScreen(
 
 // ─── init() state ────────────────────────────────────────────────────────────
 
-export interface Strategies {
-  charsets?: Record<string, Charset>;
+export interface InitStrategies {
+  /** OCR configuration: charsets, inference map, global swaps, default charset, read mode. */
   ocr?: OcrStrategy;
-  click?: ClickStrategy;
-  fill?: FillStrategy;
+  /** Interaction strategies for click, fill, hover, and double-click. */
+  actions?: {
+    click?: ClickStrategy;
+    fill?: FillStrategy;
+    hover?: HoverStrategy;
+    dblclick?: DblClickStrategy;
+  };
   capture?: CaptureStrategy;
 }
 
-export { Strategies, type OcrStrategy, type ClickStrategy, type FillStrategy, type CaptureStrategy };
+export { Strategies, type OcrStrategy, type ClickStrategy, type FillStrategy, type HoverStrategy, type DblClickStrategy, type CaptureStrategy };
 
 interface InitOptions {
   page: Page;
@@ -95,7 +104,7 @@ interface InitOptions {
    * Useful when the top-left corner overlaps interactive content.
    */
   unhoverPoint?: { x: number; y: number };
-  strategies?: Strategies;
+  strategies?: InitStrategies;
 }
 
 interface InitState {
@@ -138,14 +147,17 @@ export async function init(options: InitOptions): Promise<void> {
     initState.config.unhoverBeforeCapture = cap.unhover;
     if (cap.unhoverPoint !== undefined) setUnhoverPoint(cap.unhoverPoint);
   }
-  if (options.strategies?.click !== undefined) {
-    setClickStrategy(options.strategies.click);
+  if (options.strategies?.actions?.click !== undefined) {
+    setClickStrategy(options.strategies.actions.click);
   }
-  if (options.strategies?.fill !== undefined) {
-    setFillStrategy(options.strategies.fill);
+  if (options.strategies?.actions?.fill !== undefined) {
+    setFillStrategy(options.strategies.actions.fill);
   }
-  if (options.strategies?.charsets) {
-    setCharsetRegistry(options.strategies.charsets);
+  if (options.strategies?.actions?.hover !== undefined) {
+    setHoverStrategy(options.strategies.actions.hover);
+  }
+  if (options.strategies?.actions?.dblclick !== undefined) {
+    setDblClickStrategy(options.strategies.actions.dblclick);
   }
   if (options.strategies?.ocr !== undefined) {
     setOcrStrategy(options.strategies.ocr);
@@ -224,7 +236,8 @@ export async function release(): Promise<void> {
   clearScreenHandlers();
   setClickStrategy(undefined);
   setFillStrategy(undefined);
-  setCharsetRegistry({});
+  setHoverStrategy(undefined);
+  setDblClickStrategy(undefined);
   setOcrStrategy(undefined);
   resetGlobalConfig();
   await cleanupOCR();

--- a/packages/core/src/strategies.test.ts
+++ b/packages/core/src/strategies.test.ts
@@ -197,17 +197,17 @@ describe('presets', () => {
   beforeEach(() => { setFillStrategy(undefined); });
   afterEach(() => { setFillStrategy(undefined); });
 
-  it('presets.guacamole.strategies.fill uses tripleClickType', async () => {
+  it('presets.guacamole.strategies.actions.fill uses tripleClickType', async () => {
     const { presets } = await import('./presets.js');
     const page = mockPage();
-    await presets.guacamole.strategies.fill.fill(page, rect, 'val');
+    await presets.guacamole.strategies.actions.fill.fill(page, rect, 'val');
     expect(page.mouse.click).toHaveBeenCalledWith(140, 220, { clickCount: 3 });
   });
 
-  it('presets.rdp.strategies.fill uses charByChar with delay 30', async () => {
+  it('presets.rdp.strategies.actions.fill uses charByChar with delay 30', async () => {
     const { presets } = await import('./presets.js');
     const page = mockPage();
-    await presets.rdp.strategies.fill.fill(page, rect, 'val');
+    await presets.rdp.strategies.actions.fill.fill(page, rect, 'val');
     expect(page.keyboard.type).toHaveBeenCalledWith('val', { delay: 30 });
   });
 });

--- a/packages/core/src/strategies.ts
+++ b/packages/core/src/strategies.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 import type { Rect } from './types.js';
 import type { OcrStrategy } from './utils/ocr.js';
 export type { OcrStrategy };
@@ -15,6 +15,16 @@ export interface FillStrategy {
   fill(page: Page, rect: Rect, text: string): Promise<void>;
 }
 
+export interface HoverStrategy {
+  /** Full hover lifetime: move to the element, wait, done. */
+  hover(page: Page, locator: Locator, rect: Rect): Promise<void>;
+}
+
+export interface DblClickStrategy {
+  /** Full double-click lifetime. */
+  dblclick(page: Page, rect: Rect): Promise<void>;
+}
+
 export interface CaptureStrategy {
   unhover: boolean;
   unhoverPoint?: { x: number; y: number };
@@ -24,6 +34,8 @@ export interface CaptureStrategy {
 
 let globalClickStrategy: ClickStrategy | undefined;
 let globalFillStrategy: FillStrategy | undefined;
+let globalHoverStrategy: HoverStrategy | undefined;
+let globalDblClickStrategy: DblClickStrategy | undefined;
 
 export function setClickStrategy(s: ClickStrategy | undefined): void {
   globalClickStrategy = s;
@@ -31,12 +43,24 @@ export function setClickStrategy(s: ClickStrategy | undefined): void {
 export function setFillStrategy(s: FillStrategy | undefined): void {
   globalFillStrategy = s;
 }
+export function setHoverStrategy(s: HoverStrategy | undefined): void {
+  globalHoverStrategy = s;
+}
+export function setDblClickStrategy(s: DblClickStrategy | undefined): void {
+  globalDblClickStrategy = s;
+}
 
 export function getClickStrategy(): ClickStrategy {
   return globalClickStrategy ?? Strategies.Click.center();
 }
 export function getFillStrategy(): FillStrategy {
   return globalFillStrategy ?? Strategies.Fill.selectAllType();
+}
+export function getHoverStrategy(): HoverStrategy | undefined {
+  return globalHoverStrategy;
+}
+export function getDblClickStrategy(): DblClickStrategy | undefined {
+  return globalDblClickStrategy;
 }
 
 // ─── Strategies namespace ─────────────────────────────────────────────────────
@@ -135,6 +159,54 @@ export const Strategies = {
         async fill(page, rect, text) {
           await page.mouse.click(rect.x + rect.width / 2, rect.y + rect.height / 2);
           await page.keyboard.insertText(text);
+        },
+      };
+    },
+  },
+
+  Hover: {
+    /**
+     * Hover over the element for `ms` milliseconds, then resolve.
+     * Use in environments where hover-triggered UI needs time to appear
+     * (tooltips, dropdowns) before the next action.
+     */
+    withDelay(ms: number): HoverStrategy {
+      return {
+        async hover(page, locator, rect) {
+          await page.mouse.move(rect.x + rect.width / 2, rect.y + rect.height / 2);
+          await page.waitForTimeout(ms);
+        },
+      };
+    },
+
+    /** Hover over the element with no additional delay. */
+    default(): HoverStrategy {
+      return {
+        async hover(page, _locator, rect) {
+          await page.mouse.move(rect.x + rect.width / 2, rect.y + rect.height / 2);
+        },
+      };
+    },
+  },
+
+  DblClick: {
+    /** Double-click the center of the element rect. Default behavior. */
+    default(): DblClickStrategy {
+      return {
+        async dblclick(page, rect) {
+          await page.mouse.dblclick(rect.x + rect.width / 2, rect.y + rect.height / 2);
+        },
+      };
+    },
+
+    /**
+     * Double-click with a delay between the two clicks.
+     * Use in remote desktop environments where rapid clicks may not register.
+     */
+    withDelay(ms: number): DblClickStrategy {
+      return {
+        async dblclick(page, rect) {
+          await page.mouse.dblclick(rect.x + rect.width / 2, rect.y + rect.height / 2, { delay: ms });
         },
       };
     },

--- a/packages/core/src/strategies.ts
+++ b/packages/core/src/strategies.ts
@@ -1,4 +1,4 @@
-import type { Locator, Page } from '@playwright/test';
+import type { Page } from '@playwright/test';
 import type { Rect } from './types.js';
 import type { OcrStrategy } from './utils/ocr.js';
 export type { OcrStrategy };
@@ -17,7 +17,7 @@ export interface FillStrategy {
 
 export interface HoverStrategy {
   /** Full hover lifetime: move to the element, wait, done. */
-  hover(page: Page, locator: Locator, rect: Rect): Promise<void>;
+  hover(page: Page, rect: Rect): Promise<void>;
 }
 
 export interface DblClickStrategy {
@@ -172,8 +172,9 @@ export const Strategies = {
      */
     withDelay(ms: number): HoverStrategy {
       return {
-        async hover(page, locator, rect) {
-          await page.mouse.move(rect.x + rect.width / 2, rect.y + rect.height / 2);
+        async hover(page, rect) {
+          const { x, y } = getClickStrategy().getPoint(rect);
+          await page.mouse.move(x, y);
           await page.waitForTimeout(ms);
         },
       };
@@ -182,8 +183,9 @@ export const Strategies = {
     /** Hover over the element with no additional delay. */
     default(): HoverStrategy {
       return {
-        async hover(page, _locator, rect) {
-          await page.mouse.move(rect.x + rect.width / 2, rect.y + rect.height / 2);
+        async hover(page, rect) {
+          const { x, y } = getClickStrategy().getPoint(rect);
+          await page.mouse.move(x, y);
         },
       };
     },
@@ -194,7 +196,8 @@ export const Strategies = {
     default(): DblClickStrategy {
       return {
         async dblclick(page, rect) {
-          await page.mouse.dblclick(rect.x + rect.width / 2, rect.y + rect.height / 2);
+          const { x, y } = getClickStrategy().getPoint(rect);
+          await page.mouse.dblclick(x, y);
         },
       };
     },
@@ -206,7 +209,8 @@ export const Strategies = {
     withDelay(ms: number): DblClickStrategy {
       return {
         async dblclick(page, rect) {
-          await page.mouse.dblclick(rect.x + rect.width / 2, rect.y + rect.height / 2, { delay: ms });
+          const { x, y } = getClickStrategy().getPoint(rect);
+          await page.mouse.dblclick(x, y, { delay: ms });
         },
       };
     },

--- a/packages/core/src/utils/ocr.test.ts
+++ b/packages/core/src/utils/ocr.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { ocrTextMatches, normalizeOcrText, charsetForField, setOcrStrategy, getOcrStrategy, resolveOcrCharset } from './ocr.js';
+import { ocrTextMatches, normalizeOcrText, charsetForField, charsetToWhitelist, setOcrStrategy, getOcrStrategy, resolveOcrCharset } from './ocr.js';
 
 // ---------------------------------------------------------------------------
 // ocrTextMatches
@@ -239,5 +239,57 @@ describe('resolveOcrCharset', () => {
     setOcrStrategy({ infer: { phone: 'digits', phoneNumber: 'alnum' } });
     const result = resolveOcrCharset('phoneNumber');
     expect(['digits', 'alnum']).toContain(result);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// charsetToWhitelist
+// ---------------------------------------------------------------------------
+
+describe('charsetToWhitelist', () => {
+  it('expands a single uppercase range', () => {
+    const wl = charsetToWhitelist({ only: ['A-Z'] });
+    expect(wl).toBe('ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+  });
+
+  it('expands a digit range', () => {
+    const wl = charsetToWhitelist({ only: ['0-9'] });
+    expect(wl).toBe('0123456789');
+  });
+
+  it('includes literal single chars', () => {
+    const wl = charsetToWhitelist({ only: ['@', '.', '_'] });
+    expect([...wl].sort().join('')).toBe('.@_');
+  });
+
+  it('combines ranges and literals', () => {
+    const wl = charsetToWhitelist({ only: ['A-C', '0', '@'] });
+    expect([...wl].sort().join('')).toBe('0@ABC');
+  });
+
+  it('removes excluded chars from only', () => {
+    const wl = charsetToWhitelist({ only: ['A-Z'], exclude: ['I', 'O', 'Q'] });
+    expect(wl).not.toContain('I');
+    expect(wl).not.toContain('O');
+    expect(wl).not.toContain('Q');
+    expect(wl.length).toBe(23);
+  });
+
+  it('exclude of a char not in only is a no-op', () => {
+    const wl = charsetToWhitelist({ only: ['A-C'], exclude: ['Z'] });
+    expect([...wl].sort().join('')).toBe('ABC');
+  });
+
+  it('expands a Unicode range (Latin-1 Supplement)', () => {
+    const wl = charsetToWhitelist({ only: ['À-Â'] });
+    expect(wl).toBe('ÀÁÂ');
+  });
+
+  it('throws when only is empty', () => {
+    expect(() => charsetToWhitelist({ only: [] })).toThrow();
+  });
+
+  it('throws on invalid range where start > end', () => {
+    expect(() => charsetToWhitelist({ only: ['Z-A'] })).toThrow();
   });
 });

--- a/packages/core/src/utils/ocr.ts
+++ b/packages/core/src/utils/ocr.ts
@@ -13,16 +13,64 @@ export const CHARSET_PRESETS: Record<string, string> = {
   vin: `${UPPER}${LOWER}${DIGITS}`,
 };
 
-/** A named charset bundling a Tesseract whitelist with expected OCR confusions. */
+/**
+ * Expand a single range spec to a string of characters.
+ * A three-character spec like 'A-Z' or 'À-ÿ' expands by Unicode codepoint.
+ * Any other string is returned as-is (single char or multi-char literal).
+ */
+function expandRangeSpec(spec: string): string {
+  if (spec.length === 3 && spec[1] === '-') {
+    const start = spec.charCodeAt(0);
+    const end = spec.charCodeAt(2);
+    if (start > end) throw new Error(`Invalid charset range '${spec}': start must be ≤ end`);
+    let out = '';
+    for (let i = start; i <= end; i++) out += String.fromCharCode(i);
+    return out;
+  }
+  return spec;
+}
+
+/**
+ * Expand a Charset's only/exclude arrays into the flat string passed to
+ * `tessedit_char_whitelist`. Throws if only is empty or exclude is provided
+ * without only.
+ */
+export function charsetToWhitelist(charset: Charset): string {
+  if (!charset.only || charset.only.length === 0) {
+    throw new Error('Charset must include at least one entry in `only`');
+  }
+  const chars = new Set<string>();
+  for (const spec of charset.only) {
+    for (const ch of expandRangeSpec(spec)) chars.add(ch);
+  }
+  if (charset.exclude) {
+    for (const spec of charset.exclude) {
+      for (const ch of expandRangeSpec(spec)) chars.delete(ch);
+    }
+  }
+  return [...chars].join('');
+}
+
+/** A named charset bundling a Tesseract character allowlist with expected OCR confusions. */
 export interface Charset {
-  /** Tesseract character whitelist passed directly to `tessedit_char_whitelist`. */
-  chars: string;
+  /**
+   * Characters to allow. Each entry is either a single character, a multi-character
+   * literal, or a Unicode range like 'A-Z', '0-9', 'À-ÿ'.
+   */
+  only: string[];
+  /**
+   * Characters to remove from the only set. Same range notation as only.
+   * Requires only — error if used alone.
+   */
+  exclude?: string[];
   /** Expected glyph → OCR glyphs that are acceptable in its place. */
   swaps?: OcrSwaps;
 }
 
 /** Global OCR strategy set by init(). */
 export interface OcrStrategy {
+  /** Named charsets available for use via element `charset` field or `infer` map. */
+  charsets?: Record<string, Charset>;
   /** Fallback charset when an element has no explicit charset and name-inference finds nothing. */
   defaultCharset?: string;
   /** Map from element-name substring (case-insensitive) → charset name. Checked before built-in heuristics. */
@@ -35,17 +83,7 @@ export interface OcrStrategy {
   read?: FieldRead;
 }
 
-let charsetRegistry: Record<string, Charset> = {};
 let globalOcrStrategy: OcrStrategy | undefined;
-
-/**
- * Called by `init()` to register user-defined charsets.
- * Merges into the existing registry — subsequent calls accumulate charsets rather than replacing them.
- * Call `setCharsetRegistry({})` (or `release()`) to clear.
- */
-export function setCharsetRegistry(registry: Record<string, Charset>): void {
-  charsetRegistry = { ...charsetRegistry, ...registry };
-}
 
 export function setOcrStrategy(strategy: OcrStrategy | undefined): void {
   globalOcrStrategy = strategy;
@@ -71,9 +109,9 @@ export function resolveOcrCharset(elementName: string): string | undefined {
   return defaultCharset;
 }
 
-/** Look up a registered charset by name, or return undefined if not found. */
+/** Look up a named charset from the active OcrStrategy, or return undefined if not found. */
 export function lookupCharset(name: string): Charset | undefined {
-  return charsetRegistry[name];
+  return globalOcrStrategy?.charsets?.[name];
 }
 
 /**
@@ -89,9 +127,8 @@ export function resolveCharsetSwaps(charset: string | Charset | undefined): OcrS
 export function charsetForField(name = '', type = '', preset = 'auto'): string | undefined {
   if (type === 'checkbox') return undefined;
   if (preset && preset !== 'auto') {
-    // User-registered charsets take priority over built-in presets.
     const custom = lookupCharset(preset);
-    if (custom) return custom.chars;
+    if (custom) return charsetToWhitelist(custom);
     if (CHARSET_PRESETS[preset]) return CHARSET_PRESETS[preset];
   }
   const key = `${name} ${type}`.toLowerCase();

--- a/packages/tools/template-manager-server.mjs
+++ b/packages/tools/template-manager-server.mjs
@@ -1057,7 +1057,7 @@ function listen(port) {
 
   server.listen(port, () => {
     const dest = destinations(loadSettings());
-    const url = `http://localhost:${port}/template-manager`;
+    const url = `http://localhost:${port}${TM_V2_BASE}`;
     console.log(`Hub:              ${url}`);
     for (const line of tmV2StartupLines(port)) console.log(line);
     console.log(`config.ts → ${dest.configRoot}`);


### PR DESCRIPTION
Closes #99, #102, #103.

## Changes

### `strategies.actions` grouping (#99)
`strategies.click` and `strategies.fill` move under `strategies.actions`. `HoverStrategy` and `DblClickStrategy` interfaces are added (implementations land in follow-up PRs for #100/#101).

```ts
// before
init({ strategies: { click: ..., fill: ... } })

// after
init({ strategies: { actions: { click: ..., fill: ..., hover: ..., dblclick: ... } } })
```

### Charset `only`/`exclude` API (#102)
`Charset.chars: string` (raw Tesseract whitelist) replaced by structured `only`/`exclude` arrays with Unicode range expansion.

```ts
// before
{ chars: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789' }

// after
{ only: ['A-Z', '0-9'] }

// VIN
{ only: ['A-Z', '0-9'], exclude: ['I', 'O', 'Q'] }

// Western European names
{ only: ['A-Z', 'a-z', 'À-ÿ', ' ', '-'] }
```

`charsetToWhitelist(charset)` expands ranges and builds the `tessedit_char_whitelist` string. Ranges are Unicode-aware (`'À-ÿ'` = U+00C0–U+00FF).

### `charsets` into `strategies.ocr` (#103)

```ts
// before
init({ strategies: { charsets: { state: ... }, ocr: { infer: ... } } })

// after
init({ strategies: { ocr: { charsets: { state: ... }, infer: ... } } })
```

## Tests

225 passing, no failures.