### PR TITLE
feat: OcrStrategy.language — surface Tesseract language pack

### DIFF
--- a/packages/core/src/utils/ocr.ts
+++ b/packages/core/src/utils/ocr.ts
@@ -69,6 +69,12 @@ export interface Charset {
 
 /** Global OCR strategy set by init(). */
 export interface OcrStrategy {
+  /**
+   * Tesseract language pack to use for recognition. Default: 'eng'.
+   * Use 'fra', 'deu', 'spa', etc. for apps with language-specific text patterns.
+   * Changing this re-initializes the Tesseract worker.
+   */
+  language?: string;
   /** Named charsets available for use via element `charset` field or `infer` map. */
   charsets?: Record<string, Charset>;
   /** Fallback charset when an element has no explicit charset and name-inference finds nothing. */
@@ -86,7 +92,12 @@ export interface OcrStrategy {
 let globalOcrStrategy: OcrStrategy | undefined;
 
 export function setOcrStrategy(strategy: OcrStrategy | undefined): void {
+  const prevLanguage = globalOcrStrategy?.language ?? 'eng';
+  const nextLanguage = strategy?.language ?? 'eng';
   globalOcrStrategy = strategy;
+  if (sharedOCRUtil && prevLanguage !== nextLanguage) {
+    void sharedOCRUtil.initialize(nextLanguage);
+  }
 }
 
 export function getOcrStrategy(): OcrStrategy | undefined {
@@ -432,12 +443,14 @@ export class OCRUtil {
 let sharedOCRUtil: OCRUtil | null = null;
 
 /**
- * Get or create a shared OCR utility instance
+ * Get or create a shared OCR utility instance.
+ * Uses `strategies.ocr.language` when set; falls back to 'eng'.
  */
-export async function getOCRUtil(language = 'eng'): Promise<OCRUtil> {
+export async function getOCRUtil(language?: string): Promise<OCRUtil> {
+  const lang = language ?? globalOcrStrategy?.language ?? 'eng';
   if (!sharedOCRUtil) {
     sharedOCRUtil = new OCRUtil();
-    await sharedOCRUtil.initialize(language);
+    await sharedOCRUtil.initialize(lang);
   }
   return sharedOCRUtil;
 }

--- a/packages/core/src/utils/ocr.ts
+++ b/packages/core/src/utils/ocr.ts
@@ -90,13 +90,14 @@ export interface OcrStrategy {
 }
 
 let globalOcrStrategy: OcrStrategy | undefined;
+let pendingLanguageChange: Promise<void> | null = null;
 
 export function setOcrStrategy(strategy: OcrStrategy | undefined): void {
   const prevLanguage = globalOcrStrategy?.language ?? 'eng';
   const nextLanguage = strategy?.language ?? 'eng';
   globalOcrStrategy = strategy;
   if (sharedOCRUtil && prevLanguage !== nextLanguage) {
-    void sharedOCRUtil.initialize(nextLanguage);
+    pendingLanguageChange = sharedOCRUtil.initialize(nextLanguage);
   }
 }
 
@@ -447,6 +448,10 @@ let sharedOCRUtil: OCRUtil | null = null;
  * Uses `strategies.ocr.language` when set; falls back to 'eng'.
  */
 export async function getOCRUtil(language?: string): Promise<OCRUtil> {
+  if (pendingLanguageChange) {
+    await pendingLanguageChange;
+    pendingLanguageChange = null;
+  }
   const lang = language ?? globalOcrStrategy?.language ?? 'eng';
   if (!sharedOCRUtil) {
     sharedOCRUtil = new OCRUtil();
@@ -459,6 +464,7 @@ export async function getOCRUtil(language?: string): Promise<OCRUtil> {
  * Clean up the shared OCR utility
  */
 export async function cleanupOCR(): Promise<void> {
+  pendingLanguageChange = null;
   if (sharedOCRUtil) {
     await sharedOCRUtil.terminate();
     sharedOCRUtil = null;


### PR DESCRIPTION
Closes #104. Stacks on #107.

Add `language?: string` to `OcrStrategy`. Default `'eng'` — no change for existing users.

```ts
init({
  strategies: {
    ocr: {
      language: 'fra',
      charsets: { ... },
    }
  }
})
```

- `setOcrStrategy` re-initializes the Tesseract worker when `language` changes between calls
- `getOCRUtil` reads `globalOcrStrategy?.language` when no explicit lang is passed
- Language and charset are independent: `language` controls which neural net weights are used; `only`/`exclude` controls which characters appear in output