### PR TITLE
feat: wire HoverStrategy and DblClickStrategy into element execution

### DIFF
--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -9,7 +9,7 @@ import {
   type OcrSwaps,
 } from './utils/ocr.js';
 import { ocrStep, expectTimeout } from './ocr-step.js';
-import { getClickStrategy, getFillStrategy } from './strategies.js';
+import { getClickStrategy, getFillStrategy, getHoverStrategy, getDblClickStrategy } from './strategies.js';
 
 export const VISIBLE_CONFIDENCE = 0.7;
 
@@ -529,8 +529,13 @@ export class ScreenElement {
       await this.withOverlay(async () => {
         const rect = this.result.ocrLocation ?? this.result.location;
         if (!this.page) throw new Error('Page not provided. Cannot double-click element.');
-        const { x, y } = getClickStrategy().getPoint(rect);
-        await this.page.mouse.dblclick(x, y);
+        const strategy = getDblClickStrategy();
+        if (strategy) {
+          await strategy.dblclick(this.page, rect);
+        } else {
+          const { x, y } = getClickStrategy().getPoint(rect);
+          await this.page.mouse.dblclick(x, y);
+        }
         this.live?.markDirty();
       });
     });
@@ -541,7 +546,12 @@ export class ScreenElement {
       await this.ensureLocated(options?.timeout);
       const rect = this.result.ocrLocation ?? this.result.location;
       if (!this.page) throw new Error('Page not provided. Cannot hover element.');
-      await this.page.mouse.move(rect.x + rect.width / 2, rect.y + rect.height / 2);
+      const strategy = getHoverStrategy();
+      if (strategy) {
+        await strategy.hover(this.page, this.page.locator('body'), rect);
+      } else {
+        await this.page.mouse.move(rect.x + rect.width / 2, rect.y + rect.height / 2);
+      }
     });
   }
 

--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -548,7 +548,7 @@ export class ScreenElement {
       if (!this.page) throw new Error('Page not provided. Cannot hover element.');
       const strategy = getHoverStrategy();
       if (strategy) {
-        await strategy.hover(this.page, this.page.locator('body'), rect);
+        await strategy.hover(this.page, rect);
       } else {
         await this.page.mouse.move(rect.x + rect.width / 2, rect.y + rect.height / 2);
       }

--- a/packages/core/src/utils/ocr.ts
+++ b/packages/core/src/utils/ocr.ts
@@ -69,6 +69,12 @@ export interface Charset {
 
 /** Global OCR strategy set by init(). */
 export interface OcrStrategy {
+  /**
+   * Tesseract language pack to use for recognition. Default: 'eng'.
+   * Use 'fra', 'deu', 'spa', etc. for apps with language-specific text patterns.
+   * Changing this re-initializes the Tesseract worker.
+   */
+  language?: string;
   /** Named charsets available for use via element `charset` field or `infer` map. */
   charsets?: Record<string, Charset>;
   /** Fallback charset when an element has no explicit charset and name-inference finds nothing. */
@@ -86,7 +92,12 @@ export interface OcrStrategy {
 let globalOcrStrategy: OcrStrategy | undefined;
 
 export function setOcrStrategy(strategy: OcrStrategy | undefined): void {
+  const prevLanguage = globalOcrStrategy?.language ?? 'eng';
+  const nextLanguage = strategy?.language ?? 'eng';
   globalOcrStrategy = strategy;
+  if (sharedOCRUtil && prevLanguage !== nextLanguage) {
+    void sharedOCRUtil.initialize(nextLanguage);
+  }
 }
 
 export function getOcrStrategy(): OcrStrategy | undefined {
@@ -432,12 +443,14 @@ export class OCRUtil {
 let sharedOCRUtil: OCRUtil | null = null;
 
 /**
- * Get or create a shared OCR utility instance
+ * Get or create a shared OCR utility instance.
+ * Uses `strategies.ocr.language` when set; falls back to 'eng'.
  */
-export async function getOCRUtil(language = 'eng'): Promise<OCRUtil> {
+export async function getOCRUtil(language?: string): Promise<OCRUtil> {
+  const lang = language ?? globalOcrStrategy?.language ?? 'eng';
   if (!sharedOCRUtil) {
     sharedOCRUtil = new OCRUtil();
-    await sharedOCRUtil.initialize(language);
+    await sharedOCRUtil.initialize(lang);
   }
   return sharedOCRUtil;
 }

--- a/packages/core/src/utils/ocr.ts
+++ b/packages/core/src/utils/ocr.ts
@@ -90,13 +90,14 @@ export interface OcrStrategy {
 }
 
 let globalOcrStrategy: OcrStrategy | undefined;
+let pendingLanguageChange: Promise<void> | null = null;
 
 export function setOcrStrategy(strategy: OcrStrategy | undefined): void {
   const prevLanguage = globalOcrStrategy?.language ?? 'eng';
   const nextLanguage = strategy?.language ?? 'eng';
   globalOcrStrategy = strategy;
   if (sharedOCRUtil && prevLanguage !== nextLanguage) {
-    void sharedOCRUtil.initialize(nextLanguage);
+    pendingLanguageChange = sharedOCRUtil.initialize(nextLanguage);
   }
 }
 
@@ -447,6 +448,10 @@ let sharedOCRUtil: OCRUtil | null = null;
  * Uses `strategies.ocr.language` when set; falls back to 'eng'.
  */
 export async function getOCRUtil(language?: string): Promise<OCRUtil> {
+  if (pendingLanguageChange) {
+    await pendingLanguageChange;
+    pendingLanguageChange = null;
+  }
   const lang = language ?? globalOcrStrategy?.language ?? 'eng';
   if (!sharedOCRUtil) {
     sharedOCRUtil = new OCRUtil();
@@ -459,6 +464,7 @@ export async function getOCRUtil(language?: string): Promise<OCRUtil> {
  * Clean up the shared OCR utility
  */
 export async function cleanupOCR(): Promise<void> {
+  pendingLanguageChange = null;
   if (sharedOCRUtil) {
     await sharedOCRUtil.terminate();
     sharedOCRUtil = null;


### PR DESCRIPTION
Closes #100, #101. Stacks on #108 → #107.

`Strategies.Hover` and `Strategies.DblClick` were added as interfaces and factories in #107. This PR wires them into `.hover()` and `.dblclick()` on `ScreenElement`.

When a strategy is configured, it owns the full interaction lifetime. When none is set, the existing hardcoded behavior is used unchanged — no breaking change.

```ts
init({
  strategies: {
    actions: {
      hover: Strategies.Hover.withDelay(500),
      dblclick: Strategies.DblClick.withDelay(100),
    }
  }
})
```