### PR TITLE
feat: TM v2 UI (charset section, restart, inline charset) + core API

### DIFF
--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -35,6 +35,8 @@ export type HaveTextOptions = {
   overflowSlop?: number;
   /** Override config `read`. `clipboard` is click / select-all / copy. */
   read?: FieldRead;
+  /** Compare actual and expected case-insensitively. Swap keys are also lowercased automatically. */
+  caseInsensitive?: boolean;
 };
 
 export type WaitForOptions = {
@@ -300,7 +302,10 @@ export class ScreenElement {
       try {
         await this.retryAssertion(() => {
           const actual = this.result.value;
-          return ocrTextMatches(actual, expected, { ...(match.swaps && { swaps: match.swaps }) })
+          return ocrTextMatches(actual, expected, {
+            ...(match.swaps && { swaps: match.swaps }),
+            ...(options?.caseInsensitive && { caseInsensitive: true }),
+          })
             ? undefined
             : `Element "${this.label}" does not contain text "${expected}". Actual: "${actual}"`;
         }, expectTimeout(options?.timeout));
@@ -321,6 +326,7 @@ export class ScreenElement {
         ...(match.swaps !== undefined && { swaps: match.swaps }),
         ...(match.overflow !== undefined && { overflow: match.overflow }),
         ...(options?.overflowSlop !== undefined && { overflowSlop: options.overflowSlop }),
+        ...(options?.caseInsensitive && { caseInsensitive: true }),
       };
       if (match.read === 'clipboard') {
         await this.ensureLocated(options?.timeout);
@@ -359,6 +365,7 @@ export class ScreenElement {
         ...(match.overflow !== undefined && { overflow: match.overflow }),
         ...(options?.overflowSlop !== undefined && { overflowSlop: options.overflowSlop }),
         exact: !match.overflow,
+        ...(options?.caseInsensitive && { caseInsensitive: true }),
       };
       if (match.read === 'clipboard') {
         await this.ensureLocated(options?.timeout);

--- a/packages/core/src/utils/ocr.ts
+++ b/packages/core/src/utils/ocr.ts
@@ -287,26 +287,35 @@ export function ocrTextMatches(
     exact?: boolean;
     overflow?: OcrOverflow;
     overflowSlop?: number;
+    caseInsensitive?: boolean;
   } = {},
 ): boolean {
   if (expected instanceof RegExp) return expected.test(actual);
-  if (options.overflow) {
-    return overflowMatches(
-      actual,
-      expected,
-      options.overflow,
-      options.swaps,
-      options.overflowSlop ?? DEFAULT_OVERFLOW_SLOP,
-    );
+  let a = actual;
+  let e = expected;
+  let swaps = options.swaps;
+  if (options.caseInsensitive) {
+    a = a.toLowerCase();
+    e = e.toLowerCase();
+    if (swaps) {
+      const n: OcrSwaps = {};
+      for (const [k, v] of Object.entries(swaps)) {
+        n[k.toLowerCase()] = typeof v === 'string' ? v.toLowerCase() : v.map(s => s.toLowerCase());
+      }
+      swaps = n;
+    }
   }
-  if (options.exact) return charsMatch(actual, expected, options.swaps);
-  if (actual.includes(expected)) return true;
-  if (!options.swaps || !Object.keys(options.swaps).length) return false;
-  const got = [...actual];
-  const want = [...expected];
+  if (options.overflow) {
+    return overflowMatches(a, e, options.overflow, swaps, options.overflowSlop ?? DEFAULT_OVERFLOW_SLOP);
+  }
+  if (options.exact) return charsMatch(a, e, swaps);
+  if (a.includes(e)) return true;
+  if (!swaps || !Object.keys(swaps).length) return false;
+  const got = [...a];
+  const want = [...e];
   if (want.length > got.length) return false;
   for (let i = 0; i <= got.length - want.length; i++) {
-    if (charsMatch(got.slice(i, i + want.length).join(''), expected, options.swaps)) return true;
+    if (charsMatch(got.slice(i, i + want.length).join(''), e, swaps)) return true;
   }
   return false;
 }

--- a/packages/tools/tm-v2/index.html
+++ b/packages/tools/tm-v2/index.html
@@ -325,6 +325,12 @@
       <label id="charsetLabel">Charset
         <select id="popCharset"></select>
       </label>
+      <div id="popCharsetInline" hidden style="margin-top:-4px;display:grid;gap:3px">
+        <div class="cs-field-label">only</div>
+        <input type="text" id="popCharsetOnly" class="cs-chars-input" placeholder="A-Z, 0-9, @">
+        <div class="cs-field-label">exclude</div>
+        <input type="text" id="popCharsetExclude" class="cs-chars-input" placeholder="I, O, Q  (optional)">
+      </div>
       <label id="overflowLabel">Overflow
         <select id="popOverflow">
           <option value="">default</option>
@@ -972,7 +978,8 @@ document.getElementById('charsetAdd').addEventListener('click', () => {
 });
 
 function fillCharsetSelect(select, selected) {
-  const current = selected ?? '';
+  const isInline = selected && typeof selected === 'object';
+  const current = isInline ? '__inline__' : (selected ?? '');
   const defaultLabel = projectDefaults.defaultCharset
     ? 'default (' + projectDefaults.defaultCharset + ')'
     : 'default';
@@ -987,7 +994,19 @@ function fillCharsetSelect(select, selected) {
       html += `<option value="${esc(name)}"${name === current ? ' selected' : ''}>${esc(name)}</option>`;
     }
   }
+  html += `<option value="__inline__"${current === '__inline__' ? ' selected' : ''}>inline…</option>`;
   select.innerHTML = html;
+  if (isInline) {
+    const cs = selected;
+    document.getElementById('popCharsetOnly').value = (cs.only || []).join(', ');
+    document.getElementById('popCharsetExclude').value = (cs.exclude || []).join(', ');
+  }
+  syncCharsetInline();
+}
+
+function syncCharsetInline() {
+  const isInline = document.getElementById('popCharset').value === '__inline__';
+  document.getElementById('popCharsetInline').hidden = !isInline;
 }
 
 function catalogElement(key) {
@@ -1002,7 +1021,11 @@ function syncOcrFields() {
   const isClipboard = effective === 'clipboard';
   document.getElementById('overflowLabel').hidden = isClipboard;
   document.getElementById('charsetLabel').hidden = isClipboard;
+  if (isClipboard) document.getElementById('popCharsetInline').hidden = true;
+  else syncCharsetInline();
 }
+
+document.getElementById('popCharset').addEventListener('change', syncCharsetInline);
 
 function updatePartFocus(partsEl, info, parent, el) {
   const focusDiv = document.getElementById('popPartFocus');
@@ -1031,8 +1054,8 @@ function updatePartFocus(partsEl, info, parent, el) {
     fillCharsetSelect(document.getElementById('popCharset'), (rawPart && rawPart.charset) || 'text');
     document.getElementById('popRead').value = rawPart && rawPart.read != null ? rawPart.read : 'ocr';
     document.getElementById('popOverflow').value = (rawPart && rawPart.overflow) || '';
-    syncOverflowVisibility();
-    renderSwapRows(document.getElementById('popSwaps'), rawPart && rawPart.swaps);
+    syncOcrFields();
+    elSwapRender(document.getElementById('popSwaps'), rawPart && rawPart.swaps);
     popEl.dataset.part = selectedPartName;
   } else {
     drawSourceRect(mainCanvas, parent, 280, info.parts, undefined, true);
@@ -1046,8 +1069,8 @@ function updatePartFocus(partsEl, info, parent, el) {
     fillCharsetSelect(document.getElementById('popCharset'), el.charset || 'text');
     document.getElementById('popRead').value = el.read != null ? el.read : (el.type === 'field' ? 'clipboard' : 'ocr');
     document.getElementById('popOverflow').value = el.overflow || '';
-    syncOverflowVisibility();
-    renderSwapRows(document.getElementById('popSwaps'), el.swaps);
+    syncOcrFields();
+    elSwapRender(document.getElementById('popSwaps'), el.swaps);
     delete popEl.dataset.part;
   }
 }
@@ -1168,7 +1191,14 @@ document.getElementById('popSaveOpts').addEventListener('click', async () => {
   const element = popEl.dataset.element;
   if (!element || !state.name) return;
   try {
-    const charset = document.getElementById('popCharset').value || null;
+    const charsetSel = document.getElementById('popCharset').value;
+    const charset = charsetSel === '__inline__'
+      ? (() => {
+          const only = document.getElementById('popCharsetOnly').value.split(',').map(s => s.trim()).filter(Boolean);
+          const exclude = document.getElementById('popCharsetExclude').value.split(',').map(s => s.trim()).filter(Boolean);
+          return only.length ? { only, ...(exclude.length ? { exclude } : {}) } : null;
+        })()
+      : (charsetSel || null);
     const read = document.getElementById('popRead').value || null;
     const overflow = document.getElementById('popOverflow').value || null;
     const swaps = elSwapToObj(document.getElementById('popSwaps'));


### PR DESCRIPTION
## Summary

- **TM v2 — Project Defaults charset section**: custom charsets now live in Project Defaults with `only`/`exclude` text inputs and per-charset swap rows (same el-swap block pattern as element swaps)
- **TM v2 — Restart Server**: File menu button that restarts the server process and hard-reloads; restarted server skips `openBrowser()` via `TM_NO_OPEN=1`
- **TM v2 — `fillDefaultCharsetSelect`**: only shows built-in presets (text / digits / alphanumeric), defaults to text, no "(none)" or custom entries
- **TM v2 — inline charset per element** (#105): charset select in element popup has an "inline…" option that reveals `only`/`exclude` inputs; elements with object charsets are shown correctly and saved back to `index.json`
- **Core — `Charset` API**: `Charset.only: string[]` + `Charset.exclude?: string[]`; `charsetToWhitelist()` exported from core, expands range specs (`A-Z`, `0-9`) and subtracts exclude entries
- **Core — `caseInsensitive`** (#98): `HaveTextOptions.caseInsensitive` on `toHaveText` / `toHaveValue` / `toContainText`; lowercases both sides and normalizes swap keys automatically
- Fix: `renderSwapRows` → `elSwapRender`, `syncOverflowVisibility` → `syncOcrFields` (stale refs from prior refactor)

## Test plan

- [ ] Start TM server, open Project Defaults — charset section visible with + add button
- [ ] Add a custom charset with `only: A-Z, 0-9`, save, reload — persists
- [ ] File → Restart Server — server restarts without opening a new browser window; page reloads automatically
- [ ] Select an element — charset select shows "inline…" option; selecting it reveals only/exclude inputs
- [ ] Set inline charset on element, save — `index.json` shows `charset: { only: [...] }` object
- [ ] `toHaveText('HELLO', { caseInsensitive: true })` matches element with value `"hello"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)