### PR TITLE
refactor: remove GCS/QA Wolf infrastructure from Template Manager

### DIFF
--- a/packages/tools/tm-v2/handler.mjs
+++ b/packages/tools/tm-v2/handler.mjs
@@ -1,11 +1,10 @@
 /**
- * Template Manager v2 — GCS screens (QA Wolf team-storage).
+ * Template Manager v2 — Local screen authoring and management.
  * Mounted under /template-manager on the main tools server (port 2020).
  */
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { PNG } from 'pngjs';
 import { configure } from '@rickcedwhat/playwright-smart-vision/configure';
@@ -18,9 +17,6 @@ const HTML_FILE = path.join(TOOLS_DIR, 'index.html');
 const HOME = path.join(os.homedir(), '.smart-vision');
 const SETTINGS_FILE = path.join(HOME, 'tm-v2.json');
 const CACHE_DIR = path.join(HOME, 'screens');
-const DEFAULT_GCS = 'gs://qawolf-prod-team-storage/clzn2wsor00hcda0ickzd3544/screens';
-
-const RUNTIME_FILES = ['blank.png', 'index.json'];
 const CHARSETS_FILE = path.join(HOME, 'charsets.json');
 const DEFAULTS_FILE = path.join(HOME, 'defaults.json');
 
@@ -31,28 +27,12 @@ function readDefaults() {
   } catch { return {}; }
 }
 
-function normalizeGcs(raw) {
-  const uri = String(raw || '').trim().replace(/\/+$/, '');
-  if (!uri.startsWith('gs://')) {
-    throw new Error('GCS URI must start with gs://');
-  }
-  return uri;
-}
-
-function assertScreensUri(gcsUri) {
-  const uri = normalizeGcs(gcsUri);
-  if (!uri.endsWith('/screens')) {
-    throw new Error('GCS URI must end with /screens — refusing to push anywhere else');
-  }
-  return uri;
-}
-
 function readSettings() {
   try {
     const raw = JSON.parse(fs.readFileSync(SETTINGS_FILE, 'utf8'));
-    return { gcsUri: normalizeGcs(raw.gcsUri || DEFAULT_GCS) };
+    return raw && typeof raw === 'object' ? raw : {};
   } catch {
-    return { gcsUri: DEFAULT_GCS };
+    return {};
   }
 }
 
@@ -108,74 +88,6 @@ function kebab(name) {
     .toLowerCase();
 }
 
-function runGcloud(args) {
-  return new Promise((resolve, reject) => {
-    const child = spawn('gcloud', args, { stdio: ['ignore', 'pipe', 'pipe'] });
-    let stdout = '';
-    let stderr = '';
-    child.stdout.on('data', (chunk) => {
-      stdout += chunk;
-    });
-    child.stderr.on('data', (chunk) => {
-      stderr += chunk;
-    });
-    child.on('error', () => {
-      reject(new Error('gcloud not found — install the Google Cloud SDK and run gcloud auth login'));
-    });
-    child.on('close', (code) => {
-      if (code !== 0) reject(new Error(stderr.trim() || stdout.trim() || `gcloud exited ${code}`));
-      else resolve(`${stdout}${stderr ? `\n${stderr}` : ''}`.trim());
-    });
-  });
-}
-
-function parseLs(stdout, gcsPrefix) {
-  const prefix = `${gcsPrefix.replace(/\/+$/, '')}/`;
-  const dirs = new Set();
-  const files = new Set();
-  for (const line of stdout.split('\n')) {
-    const trimmed = line.trim();
-    if (!trimmed.startsWith('gs://') || trimmed.endsWith(':')) continue;
-    if (!trimmed.startsWith(prefix)) continue;
-    const rest = trimmed.slice(prefix.length);
-    if (!rest) continue;
-    const parts = rest.replace(/\/+$/, '').split('/').filter(Boolean);
-    if (parts.length !== 1) continue;
-    const name = parts[0];
-    if (!/^[a-zA-Z0-9._-]+$/.test(name)) continue;
-    if (trimmed.endsWith('/')) dirs.add(name);
-    else files.add(name);
-  }
-  return { dirs: [...dirs].sort(), files: [...files].sort() };
-}
-
-const _gcsCache = new Map();
-const GCS_CACHE_TTL = 30_000;
-
-function invalidateGcsCache() {
-  _gcsCache.clear();
-}
-
-async function listGcsPrefix(gcsUri, relPath) {
-  const base = relPath ? `${gcsUri}/${relPath}` : gcsUri;
-  const cached = _gcsCache.get(base);
-  if (cached && Date.now() - cached.ts < GCS_CACHE_TTL) return cached.result;
-  try {
-    const stdout = await runGcloud(['storage', 'ls', `${base}/`]);
-    const result = parseLs(stdout, base);
-    _gcsCache.set(base, { ts: Date.now(), result });
-    return result;
-  } catch (err) {
-    const msg = String(err instanceof Error ? err.message : err);
-    if (/matched no objects/i.test(msg)) {
-      const result = { dirs: [], files: [] };
-      _gcsCache.set(base, { ts: Date.now(), result });
-      return result;
-    }
-    throw err;
-  }
-}
-
 function listLocalPrefix(relPath) {
   const dir = relPath ? path.join(CACHE_DIR, ...relPath.split('/')) : CACHE_DIR;
   if (!fs.existsSync(dir)) return { dirs: [], files: [] };
@@ -199,125 +111,6 @@ function listLocalScreens() {
 
 function isSafeFileName(name) {
   return /^[a-zA-Z0-9._-]+$/.test(name);
-}
-
-function screenRuntimePlan(name) {
-  const dir = screenDir(name);
-  const missing = [];
-  for (const file of RUNTIME_FILES) {
-    if (!fs.existsSync(path.join(dir, file))) missing.push(file);
-  }
-  const tmplDir = path.join(dir, 'templates');
-  const templates = [];
-  if (!fs.existsSync(tmplDir) || !fs.statSync(tmplDir).isDirectory()) {
-    missing.push('templates/');
-  } else {
-    for (const ent of fs.readdirSync(tmplDir, { withFileTypes: true })) {
-      if (!ent.isFile() || !ent.name.endsWith('.png') || !isSafeFileName(ent.name)) continue;
-      templates.push(ent.name);
-    }
-    if (!templates.length) missing.push('templates/*.png');
-  }
-  if (missing.length) {
-    return { name, ready: false, reason: `missing ${missing.join(', ')}`, files: [] };
-  }
-  return {
-    name,
-    ready: true,
-    files: [
-      ...RUNTIME_FILES.map((file) => `${name}/${file}`),
-      ...templates.map((file) => `${name}/templates/${file}`),
-    ],
-  };
-}
-
-function stageRuntimeScreen(name, stagingRoot) {
-  const src = screenDir(name);
-  const dest = path.join(stagingRoot, name);
-  fs.mkdirSync(path.join(dest, 'templates'), { recursive: true });
-  for (const file of RUNTIME_FILES) {
-    fs.copyFileSync(path.join(src, file), path.join(dest, file));
-  }
-  const tmplDir = path.join(src, 'templates');
-  for (const ent of fs.readdirSync(tmplDir, { withFileTypes: true })) {
-    if (!ent.isFile() || !ent.name.endsWith('.png') || !isSafeFileName(ent.name)) continue;
-    fs.copyFileSync(path.join(tmplDir, ent.name), path.join(dest, 'templates', ent.name));
-  }
-}
-
-async function rsync(src, dest, { dryRun = false } = {}) {
-  if (!src.startsWith('gs://')) fs.mkdirSync(src, { recursive: true });
-  if (!dest.startsWith('gs://')) fs.mkdirSync(dest, { recursive: true });
-  const args = ['storage', 'rsync', '-r'];
-  if (dryRun) args.push('--dry-run');
-  args.push(src, dest);
-  return runGcloud(args);
-}
-
-async function pushRuntimeScreens({ names, dryRun }) {
-  await ensureConfigured();
-  const gcsUri = assertScreensUri(readSettings().gcsUri);
-  const requested = names?.length
-    ? names.map((name) => assertScreenName(name))
-    : listLocalScreens();
-  const plans = requested.map(screenRuntimePlan);
-  const ready = plans.filter((plan) => plan.ready);
-  const skipped = plans.filter((plan) => !plan.ready);
-  if (!ready.length) {
-    throw new Error('no runtime-ready screens to push (need blank.png, index.json, templates/*.png)');
-  }
-
-  const staging = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-v2-push-'));
-  const logs = [];
-  try {
-    for (const plan of ready) {
-      stageRuntimeScreen(plan.name, staging);
-      const dest = `${gcsUri}/${plan.name}`;
-      const log = await rsync(path.join(staging, plan.name), dest, { dryRun });
-      logs.push({
-        screen: plan.name,
-        dest,
-        files: plan.files,
-        gcloud: log.trim(),
-      });
-    }
-    const catalogLocal = path.join(CACHE_DIR, 'generated.ts');
-    if (fs.existsSync(catalogLocal)) {
-      const dest = `${gcsUri}/generated.ts`;
-      const log = dryRun
-        ? `Would copy ${catalogLocal} to ${dest}`
-        : await runGcloud(['storage', 'cp', catalogLocal, dest]);
-      logs.push({
-        screen: 'generated.ts',
-        dest,
-        files: ['generated.ts'],
-        gcloud: String(log).trim(),
-      });
-    }
-    if (fs.existsSync(CHARSETS_FILE)) {
-      const dest = `${gcsUri}/charsets.json`;
-      const log = dryRun
-        ? `Would copy ${CHARSETS_FILE} to ${dest}`
-        : await runGcloud(['storage', 'cp', CHARSETS_FILE, dest]);
-      logs.push({
-        screen: 'charsets.json',
-        dest,
-        files: ['charsets.json'],
-        gcloud: String(log).trim(),
-      });
-    }
-  } finally {
-    fs.rmSync(staging, { recursive: true, force: true });
-  }
-
-  return {
-    dryRun,
-    deletes: false,
-    gcsUri,
-    pushed: ready.map((plan) => plan.name),
-    skipped: skipped.map((plan) => ({ name: plan.name, reason: plan.reason })),
-    operations: logs,
-  };
 }
 
 let _configured = false;
@@ -400,7 +193,7 @@ async function handleInternal(req, res, url) {
 
   if (req.method === 'PUT' && url.pathname === '/api/settings') {
     const body = JSON.parse(await readBody(req));
-    const settings = { gcsUri: normalizeGcs(body.gcsUri) };
+    const settings = body && typeof body === 'object' ? body : {};
     writeSettings(settings);
     send(res, 200, { ...settings, cacheDir: CACHE_DIR });
     return;
@@ -465,46 +258,11 @@ async function handleInternal(req, res, url) {
     return;
   }
 
-  if (req.method === 'GET' && url.pathname === '/api/remote') {
-    const names = await listGcsPrefix(readSettings().gcsUri, '').then((listing) => listing.dirs);
-    send(res, 200, { screens: names });
-    return;
-  }
-
-  if (req.method === 'POST' && url.pathname === '/api/pull') {
-    const body = JSON.parse(await readBody(req) || '{}');
-    const gcsUri = readSettings().gcsUri;
-    const screen = body.name ? assertScreenName(body.name) : '';
-    if (screen) await rsync(`${gcsUri}/${screen}`, screenDir(screen));
-    else await rsync(gcsUri, CACHE_DIR);
-    invalidateGcsCache();
-    send(res, 200, { ok: true, localScreens: listLocalScreens() });
-    return;
-  }
-
   if (req.method === 'GET' && url.pathname === '/api/ls') {
     const rel = (url.searchParams.get('path') || '').replace(/^\/+|\/+$/g, '');
     if (rel.includes('..')) throw new Error('invalid path');
-    const gcsUri = readSettings().gcsUri;
-    let remote = { dirs: [], files: [] };
-    let remoteError = null;
-    try {
-      remote = await listGcsPrefix(gcsUri, rel);
-    } catch (err) {
-      remoteError = String(err instanceof Error ? err.message : err);
-    }
     const local = listLocalPrefix(rel);
-    send(res, 200, { path: rel, remote, local, remoteError });
-    return;
-  }
-
-  if (req.method === 'POST' && url.pathname === '/api/push') {
-    const body = JSON.parse(await readBody(req) || '{}');
-    const dryRun = body.dryRun === true;
-    const names = body.name ? [assertScreenName(body.name)] : undefined;
-    const result = await pushRuntimeScreens({ names, dryRun });
-    if (!dryRun) invalidateGcsCache();
-    send(res, 200, result);
+    send(res, 200, { path: rel, local });
     return;
   }
 
@@ -728,12 +486,8 @@ async function handleInternal(req, res, url) {
 /** One-time startup (cache dir, default settings, catalog). */
 export function initTmV2() {
   fs.mkdirSync(CACHE_DIR, { recursive: true });
-  if (!fs.existsSync(SETTINGS_FILE)) writeSettings({ gcsUri: DEFAULT_GCS });
+  if (!fs.existsSync(SETTINGS_FILE)) writeSettings({});
   ensureConfigured().catch((err) => console.error(err));
-}
-
-function isAuthError(msg) {
-  return /gcloud not found|active account|auth login|UNAUTHENTICATED|invalid authentication credentials|credentials do not satisfy|could not refresh|invalid_grant|AccessDeniedException/i.test(msg);
 }
 
 /** Returns true when the request was handled. */
@@ -744,19 +498,14 @@ export async function handleTmV2Request(req, res, url) {
   } catch (err) {
     const msg = String(err instanceof Error ? err.message : err);
     console.error('[tm-v2]', msg);
-    if (isAuthError(msg)) {
-      send(res, 401, { error: 'GCS auth error — run: gcloud auth login', authRequired: true });
-    } else {
-      send(res, 500, { error: msg });
-    }
+    send(res, 500, { error: msg });
   }
   return true;
 }
 
 export function tmV2StartupLines(port) {
   return [
-    `Template Manager (GCS): http://localhost:${port}${TM_V2_BASE}`,
-    `Local cache: ${CACHE_DIR}`,
-    `GCS: ${readSettings().gcsUri}`,
+    `Template Manager: http://localhost:${port}${TM_V2_BASE}`,
+    `Local screens: ${CACHE_DIR}`,
   ];
 }

--- a/packages/tools/tm-v2/index.html
+++ b/packages/tools/tm-v2/index.html
@@ -64,29 +64,6 @@
   .tree-row .twist-spacer { width: 1.2em; flex-shrink: 0; }
   .tree .active { background: #243a24; color: #cfc; }
   .tree .local .name { color: #8c8; }
-  .push-off { opacity: 0.55; }
-  #pushModal {
-    position: fixed; inset: 0; z-index: 40;
-    background: rgba(0,0,0,0.65);
-    display: flex; align-items: center; justify-content: center;
-    padding: 24px;
-  }
-  #pushModal[hidden] { display: none; }
-  .push-card {
-    width: min(720px, 94vw); max-height: 86vh;
-    background: #1c1c1c; border: 1px solid #555; border-radius: 10px;
-    padding: 16px; display: flex; flex-direction: column; gap: 10px;
-  }
-  .push-card h3 { margin: 0; font-size: 15px; }
-  .push-card p { margin: 0; color: #ccc; }
-  #pushLog {
-    flex: 1; min-height: 160px; max-height: 48vh; overflow: auto;
-    margin: 0; padding: 10px; background: #111; border: 1px solid #333;
-    border-radius: 6px; color: #cfc;
-    font: 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
-    white-space: pre-wrap;
-  }
-  .push-actions { display: flex; gap: 8px; justify-content: flex-end; }
   .stage { position: relative; display: inline-block; min-width: 100%; }
   .stage img { display: block; max-width: 100%; height: auto; }
   .stage img[hidden] { display: none; }
@@ -178,8 +155,6 @@
     <div class="dropdown">
       <button type="button" class="dd-item" id="menuConfigure">Configure…</button>
       <div class="dd-sep"></div>
-      <button type="button" class="dd-item" id="pullAll">Pull GCS</button>
-      <button type="button" class="dd-item" id="pushAll">Push GCS</button>
       <div class="dd-sep"></div>
       <button type="button" class="dd-item" id="restartServer">Restart Server</button>
     </div>
@@ -217,7 +192,6 @@
   <span id="status"></span>
 
   <!-- Preserved for JS compatibility -->
-  <input id="gcs" type="text" spellcheck="false" hidden aria-hidden="true">
   <button type="button" id="saveSettings" hidden aria-hidden="true"></button>
   <button type="button" id="resetMenuBtn" hidden aria-hidden="true"></button>
   <div id="resetMenu" hidden></div>
@@ -231,8 +205,6 @@
       <input type="text" id="configEnvName" placeholder="e.g. Production — QAWolf" spellcheck="false">
     </div>
     <div class="config-field">
-      <label for="configGcsUri">GCS URI</label>
-      <input type="text" id="configGcsUri" spellcheck="false" placeholder="gs://bucket/path/screens">
     </div>
     <div class="config-actions">
       <button type="button" class="primary" id="configSave">Save</button>
@@ -240,24 +212,8 @@
     </div>
   </div>
 </div>
-<div id="pushModal" hidden>
-  <div class="push-card">
-    <h3 id="pushTitle">GCS push</h3>
-    <p id="pushSummary"></p>
-    <pre id="pushLog"></pre>
-    <div class="push-actions">
-      <button id="pushCancel" type="button">Close</button>
-    </div>
-  </div>
-</div>
 <div class="layout">
 <aside>
-  <div id="authBanner" hidden>
-    GCS auth required — run in terminal:
-    <code>gcloud auth login</code>
-    then reload.
-    <button id="authBannerClose" type="button">Dismiss</button>
-  </div>
   <div id="tree" class="tree"></div>
 </aside>
 <main id="main">
@@ -368,7 +324,6 @@ const TM_BASE = (() => {
 
 const statusEl = document.getElementById('status');
 const toastEl = document.getElementById('toast');
-const gcs = document.getElementById('gcs');
 const treeEl = document.getElementById('tree');
 const blank = document.getElementById('blank');
 const overlays = document.getElementById('overlays');
@@ -403,29 +358,6 @@ function toast(msg) {
   toast.t = setTimeout(() => { toastEl.style.display = 'none'; }, 4000);
 }
 
-function formatPushResult(out) {
-  const lines = [];
-  lines.push(out.dryRun ? 'DRY RUN — nothing was written.' : 'PUSH COMPLETE');
-  lines.push('Deletes: never (' + String(out.deletes) + ')');
-  lines.push('Destination prefix: ' + out.gcsUri);
-  lines.push('Screens: ' + (out.pushed || []).join(', '));
-  if ((out.skipped || []).length) {
-    lines.push('Skipped:');
-    for (const row of out.skipped) lines.push('  - ' + row.name + ': ' + row.reason);
-  }
-  lines.push('');
-  for (const op of out.operations || []) {
-    lines.push('== ' + op.screen + ' → ' + op.dest);
-    for (const file of op.files || []) lines.push('  ' + file);
-    if (op.gcloud) {
-      lines.push('-- gcloud --');
-      lines.push(op.gcloud);
-    }
-    lines.push('');
-  }
-  return lines.join('\n');
-}
-
 async function api(path, opts) {
   const res = await fetch(TM_BASE + path, opts);
   const body = await res.json().catch(() => ({}));
@@ -437,43 +369,31 @@ async function api(path, opts) {
   return body;
 }
 
-function showAuthBanner(visible = true) {
-  document.getElementById('authBanner').hidden = !visible;
-}
-
 function handleApiError(err) {
   setStatus(err.message, true);
-  if (err.authRequired) showAuthBanner();
 }
 
-function mergeListing(remote, local) {
-  const dirs = [...new Set([...(remote.dirs || []), ...(local.dirs || [])])].sort();
-  const files = [...new Set([...(remote.files || []), ...(local.files || [])])].sort();
-  const localSet = new Set([...(local.dirs || []), ...(local.files || [])]);
-  return { dirs, files, localSet };
-}
-
-
-function listingHtml(rel, merged) {
+function listingHtml(rel, listing) {
   let html = '';
-  for (const dir of merged.dirs) {
+  const dirs = listing.dirs || [];
+  const files = listing.files || [];
+  for (const dir of dirs) {
     const path = rel ? rel + '/' + dir : dir;
     const screen = path.split('/')[0];
     const isRoot = !rel;
     const active = isRoot && path === selectedScreen ? ' active' : '';
-    const local = merged.localSet.has(dir) ? ' local' : '';
     html += '<div class="tree-node" data-path="' + path + '">' +
-      '<div class="tree-row dir' + active + local + '" data-screen="' + screen + '">' +
+      '<div class="tree-row dir' + active + ' local" data-screen="' + screen + '">' +
       '<button type="button" class="twist" aria-expanded="false" aria-label="expand">▸</button>' +
       '<span class="name">' + dir + '/</span>' +
       '</div>' +
       '<div class="tree-kids" hidden></div></div>';
   }
-  for (const file of merged.files) {
+  for (const file of files) {
     const path = rel ? rel + '/' + file : file;
     const screen = path.split('/')[0];
     const active = path === selectedFile ? ' active' : '';
-    html += '<div class="tree-row file' + active + (merged.localSet.has(file) ? ' local' : '') + '" data-path="' + path + '" data-screen="' + screen + '">' +
+    html += '<div class="tree-row file' + active + ' local" data-path="' + path + '" data-screen="' + screen + '">' +
       '<span class="twist-spacer"></span>' +
       '<span class="name">' + file + '</span></div>';
   }
@@ -482,13 +402,7 @@ function listingHtml(rel, merged) {
 
 async function renderTree() {
   const root = await api('/api/ls?path=');
-  treeEl.innerHTML = listingHtml('', mergeListing(root.remote, root.local));
-  if (root.remoteError) {
-    const note = document.createElement('div');
-    note.style.cssText = 'color:#666;font-size:11px;padding:6px 4px;';
-    note.textContent = 'GCS offline — showing local only';
-    treeEl.insertBefore(note, treeEl.firstChild);
-  }
+  treeEl.innerHTML = listingHtml('', root.local);
 }
 
 function highlightTree() {
@@ -542,7 +456,6 @@ async function expandNode(node, open) {
   if (!node.dataset.loaded) {
     const listing = await api('/api/ls?path=' + encodeURIComponent(node.dataset.path));
     kids.innerHTML = listingHtml(node.dataset.path, mergeListing(listing.remote, listing.local)) || '<div class="muted">empty</div>';
-    if (listing.remoteError) kids.insertAdjacentHTML('afterbegin', '<div style="color:#666;font-size:11px;padding:2px 4px">GCS offline</div>');
     node.dataset.loaded = '1';
   }
   if (open !== undefined) {
@@ -557,7 +470,6 @@ async function expandNode(node, open) {
 
 async function loadSettings() {
   const s = await api('/api/settings');
-  gcs.value = s.gcsUri;
   cacheDir = s.cacheDir || '';
   if (typeof updateEnvDisplay === 'function') updateEnvDisplay();
 }
@@ -1271,7 +1183,7 @@ async function loadScreen(name, opts = {}) {
       for (const id of el.boxIds || []) state.names[id] = el.name;
     }
   }
-  if (!data.hasBlank) setStatus(name + ' has no local blank.png — Pull GCS', true);
+  if (!data.hasBlank) setStatus(name + ' has no local blank.png', true);
   else if (data.applied) setStatus((opts.status || name) + ' — applied first-pass.json');
   else setStatus(opts.status || name);
   updateMeta();
@@ -1517,7 +1429,7 @@ blank.addEventListener('error', () => {
   overlays.innerHTML = '';
   if (selectedFile) setStatus('could not display ' + selectedFile, true);
   else if (!state.name) setStatus('no screen selected', true);
-  else setStatus(state.name + ' has no local blank.png — Pull GCS', true);
+  else setStatus(state.name + ' has no local blank.png', true);
 });
 window.addEventListener('resize', paint);
 
@@ -1621,8 +1533,8 @@ treeEl.addEventListener('click', async (e) => {
     const isLocal = fileRow.classList.contains('local');
     selectedFile = filePath;
     if (!isLocal) {
-      setStatus(filePath + ' — not pulled locally (File → Pull GCS)', true);
-      showFileMessage('Not available locally — use File → Pull GCS to download.');
+      setStatus(filePath + ' — not available locally', true);
+      showFileMessage('Not available locally.');
       return;
     }
     if (isRootFile) {
@@ -1642,51 +1554,11 @@ treeEl.addEventListener('click', async (e) => {
 
 document.getElementById('saveSettings').onclick = async () => {
   try {
-    await api('/api/settings', { method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ gcsUri: gcs.value }) });
-    setStatus('saved URI');
+    await api('/api/settings', { method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify({}) });
+    setStatus('saved settings');
     await renderTree();
   } catch (err) { handleApiError(err); }
 };
-document.getElementById('pullAll').onclick = async () => {
-  if (!confirm('Pull from GCS? This will overwrite local screens (blank.png, index.json, boxes, templates) with whatever is in GCS.')) return;
-  try {
-    setStatus('pulling…');
-    const out = await api('/api/pull', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' });
-    setStatus('pulled ' + out.localScreens.length + ' local screens');
-    showAuthBanner(false);
-    await renderTree();
-    if (currentScreen()) await loadScreen(currentScreen(), { keepView: true });
-  } catch (err) { handleApiError(err); }
-};
-document.getElementById('pushAll').onclick = async () => {
-  if (!confirm('Push to GCS? This will overwrite the remote GCS path with your local screens.')) return;
-  const modal = document.getElementById('pushModal');
-  try {
-    setStatus('pushing to GCS…');
-    const out = await api('/api/push', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ dryRun: false }),
-    });
-    document.getElementById('pushTitle').textContent = 'GCS push complete';
-    document.getElementById('pushSummary').textContent =
-      'Copied blank.png, index.json, and templates/*.png. Nothing was deleted.';
-    document.getElementById('pushLog').textContent = formatPushResult(out);
-    modal.hidden = false;
-    setStatus('pushed ' + (out.pushed || []).join(', '));
-    showAuthBanner(false);
-    await renderTree();
-  } catch (err) { handleApiError(err); }
-};
-document.getElementById('pushCancel').onclick = () => {
-  document.getElementById('pushModal').hidden = true;
-};
-document.getElementById('pushModal').addEventListener('click', (e) => {
-  if (e.target.id === 'pushModal') document.getElementById('pushModal').hidden = true;
-});
-document.addEventListener('keydown', (e) => {
-  if (e.key === 'Escape') document.getElementById('pushModal').hidden = true;
-});
 document.getElementById('copyPrompt').onclick = async () => {
   try {
     const name = currentScreen();
@@ -1813,7 +1685,6 @@ Promise.all([loadSettings(), loadCharsets(), loadDefaults()])
   .then(() => setView('source'))
   .catch(handleApiError);
 
-document.getElementById('authBannerClose').addEventListener('click', () => showAuthBanner(false));
 
 // Stage zoom via ctrl+wheel / trackpad pinch.
 // stageZoom and stageBaseW are module-level globals so loadScreen can reset them.
@@ -1901,7 +1772,6 @@ document.addEventListener('keydown', e => {
 
 // ── Configure modal ────────────────────────────────────────────────────────────
 function openConfigure() {
-  document.getElementById('configGcsUri').value = gcs.value;
   document.getElementById('configEnvName').value = localStorage.getItem('tm-env-name') || '';
   document.getElementById('configModal').hidden = false;
   document.querySelectorAll('.menu-trigger').forEach(t => t.classList.remove('open'));
@@ -1912,7 +1782,7 @@ function closeConfigure() {
 }
 function updateEnvDisplay() {
   const name = localStorage.getItem('tm-env-name') || '';
-  document.getElementById('envName').textContent = name || gcs.value;
+  document.getElementById('envName').textContent = name || 'local';
 }
 
 document.getElementById('restartServer').onclick = async () => {
@@ -1944,16 +1814,12 @@ document.getElementById('configModal').addEventListener('click', e => {
 });
 document.getElementById('configSave').addEventListener('click', async () => {
   const name = document.getElementById('configEnvName').value.trim();
-  gcs.value = document.getElementById('configGcsUri').value.trim();
   localStorage.setItem('tm-env-name', name);
   updateEnvDisplay();
   closeConfigure();
   document.getElementById('saveSettings').click();
 });
 document.getElementById('configEnvName').addEventListener('keydown', e => {
-  if (e.key === 'Enter') document.getElementById('configGcsUri').focus();
-});
-document.getElementById('configGcsUri').addEventListener('keydown', e => {
   if (e.key === 'Enter') document.getElementById('configSave').click();
   if (e.key === 'Escape') closeConfigure();
 });

--- a/packages/tools/tm-v2/index.html
+++ b/packages/tools/tm-v2/index.html
@@ -202,7 +202,7 @@
     <h3>Configure Environment</h3>
     <div class="config-field">
       <label for="configEnvName">Name</label>
-      <input type="text" id="configEnvName" placeholder="e.g. Production — QAWolf" spellcheck="false">
+      <input type="text" id="configEnvName" placeholder="e.g. Production" spellcheck="false">
     </div>
     <div class="config-field">
     </div>


### PR DESCRIPTION
## Summary

Removes Google Cloud Storage integration and QA Wolf-specific infrastructure from Template Manager v2, making it a simpler local-first tool.

## Changes

### Removed from `handler.mjs`:
- `listGcsPrefix()`, `_gcsCache`, `invalidateGcsCache()`
- `DEFAULT_GCS` constant (hardcoded QA Wolf bucket)
- `normalizeGcs()`, `assertScreensUri()`
- `runGcloud()` function and gcloud CLI integration
- `rsync()` and `pushRuntimeScreens()` functions
- `/api/pull`, `/api/push`, `/api/remote` endpoints
- Simplified `/api/ls` to local-only
- Removed GCS auth error handling

### Removed from `index.html`:
- "Pull GCS" and "Push GCS" buttons
- GCS URI configuration modal input
- Push result modal
- GCS status indicators and auth banner
- `formatPushResult()`, `mergeListing()` functions
- All GCS-related event handlers

### Updated:
- `renderTree()` now only shows local screens
- `listingHtml()` simplified for local-only display
- Startup messages no longer reference GCS
- Error messages no longer suggest "Pull GCS"

## Benefits

✅ Simpler architecture (no cloud dependencies)
✅ Easier for contributors to run locally
✅ No hardcoded QA Wolf credentials/buckets
✅ Faster startup (no GCS auth checks)
✅ More general-purpose tool

## Impact

- **Breaking for QA Wolf users**: GCS sync no longer available
- **Non-breaking for everyone else**: Local functionality unchanged

## Migration Path

Users needing remote storage can:
- Version control screens with git
- Use network drives or shared folders
- Use CI artifact storage

## Testing

- ✅ Verified all GCS/gcloud references removed (~385 lines removed)
- ✅ Local filesystem operations remain intact
- ✅ Template Manager structure unchanged

## Related

- Closes #116
- Part of making the library general-purpose (see #122)
