### PR TITLE
refactor: remove 'v2' naming from Template Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ The Template Manager is a visual authoring tool that helps you create screen con
 
 ```bash
 # From your project root
-npm run tm:v2
+npm run tm
 
 # Or use npx
-npx @rickcedwhat/playwright-smart-vision tm:v2
+npx @rickcedwhat/playwright-smart-vision tm
 ```
 
 Open `http://localhost:3455` in your browser and follow the visual workflow to author your screens.
@@ -347,12 +347,12 @@ This demo renders a complete customer form on HTML5 canvas, perfect for testing 
 
 ## Development Tools
 
-### Template Manager v2
+### Template Manager
 
 Visual authoring tool for creating screen configs:
 
 ```bash
-npm run tm:v2  # http://localhost:3455
+npm run tm  # http://localhost:3455
 ```
 
 ### Serve Test Fixtures

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:unit": "pnpm -r --if-present test:unit",
     "test:e2e": "pnpm -r --if-present test:e2e",
     "dev": "node packages/tools/template-manager-server.mjs",
-    "tm:v2": "pnpm build && pnpm dev",
+    "tm": "pnpm build && pnpm dev",
     "dev:fixtures": "node packages/core/scripts/serve-fixtures.mjs",
     "demo": "node packages/demo/canvas-customer-app/server.mjs",
     "capture": "pnpm --filter @rickcedwhat/playwright-smart-vision test:e2e --grep=CAPTURE_ONLY_NO_TESTS --pass-with-no-tests"

--- a/packages/core/src/author/catalog.ts
+++ b/packages/core/src/author/catalog.ts
@@ -131,7 +131,7 @@ export function screenCatalogSource(
     .join('\n');
 
   const ts = new Date().toISOString();
-  return `// Generated ${ts} by TM v2 — do not edit, re-generated on every save.
+  return `// Generated ${ts} by Template Manager — do not edit, re-generated on every save.
 /** @generated */
 import type { Strategies } from '@rickcedwhat/playwright-smart-vision';
 

--- a/packages/core/src/devtools.ts
+++ b/packages/core/src/devtools.ts
@@ -342,7 +342,7 @@ const FAB_SCRIPT = `(function () {
       overlayBtn.disabled = !currentHasIndex;
       overlayBtn.title = currentHasIndex
         ? (overlayOn ? 'Hide overlay' : 'Show overlay')
-        : (currentScreen ? 'Apply this screen in TM v2 first' : 'Choose a screen first');
+        : (currentScreen ? 'Apply this screen in TM first' : 'Choose a screen first');
       overlayBtn.classList.toggle('on', overlayOn);
     }
 

--- a/packages/core/tests/canvas-desktop.spec.ts
+++ b/packages/core/tests/canvas-desktop.spec.ts
@@ -13,7 +13,7 @@ testWithScreen.setTimeout(180_000);
 /**
  * Canvas Desktop Demo E2E Tests
  * 
- * TODO: These tests require screen configs to be authored using Template Manager v2.
+ * TODO: These tests require screen configs to be authored using Template Manager.
  * 
  * Steps to author screens:
  * 1. Start the canvas demo: `npm run demo`
@@ -21,7 +21,7 @@ testWithScreen.setTimeout(180_000);
  *    - Desktop with CRM icon
  *    - CRM app with "New Customer" button
  *    - Customer form (filled state)
- * 3. Start Template Manager: `npm run tm:v2`
+ * 3. Start Template Manager: `npm run tm`
  * 4. Create screen configs for each state:
  *    - screens/canvas-desktop/
  *    - screens/canvas-crm-app/
@@ -32,17 +32,17 @@ testWithScreen.setTimeout(180_000);
 testWithScreen.skip('Desktop workflow - icon to form', async ({ page, screen }) => {
   await page.goto('http://localhost:3456');
   
-  // TODO: Author desktop screen with TM v2
+  // TODO: Author desktop screen with TM
   // const desktop = screen('canvas-desktop');
   // await desktop.waitFor();
   // await desktop.element('crmIcon').click();
   
-  // TODO: Author CRM app screen with TM v2
+  // TODO: Author CRM app screen with TM
   // const crmApp = screen('canvas-crm-app');
   // await crmApp.waitFor();
   // await crmApp.element('newCustomerButton').click();
   
-  // TODO: Author customer form screen with TM v2
+  // TODO: Author customer form screen with TM
   // const customerForm = screen('canvas-customer-form');
   // await customerForm.waitFor();
   
@@ -59,7 +59,7 @@ testWithScreen.skip('Customer form - fill and verify', async ({ page, screen }) 
   // Wait for canvas to update (give it time to render the form)
   await page.waitForTimeout(500);
   
-  // TODO: Author customer form screen with TM v2
+  // TODO: Author customer form screen with TM
   // const form = screen('canvas-customer-form');
   // await form.waitFor();
   

--- a/packages/tools/ai-first-pass-prompt.md
+++ b/packages/tools/ai-first-pass-prompt.md
@@ -87,4 +87,4 @@ Return **only** JSON:
 
 ## After you write the file
 
-Write `first-pass.json` next to `boxes.json` (under `~/.smart-vision/screens/{name}/`). TM v2 applies automatically when that file is newer than `index.json`, including on Reload. Tell the user to Reload in TM v2. Do not tell them to Apply.
+Write `first-pass.json` next to `boxes.json` (under `~/.smart-vision/screens/{name}/`). TM applies automatically when that file is newer than `index.json`, including on Reload. Tell the user to Reload in TM. Do not tell them to Apply.

--- a/packages/tools/template-manager-server.mjs
+++ b/packages/tools/template-manager-server.mjs
@@ -11,7 +11,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { exec } from 'node:child_process';
-import { handleTmV2Request, initTmV2, tmV2StartupLines, TM_V2_BASE } from './tm-v2/handler.mjs';
+import { handleTmV2Request, initTmV2, tmV2StartupLines, TM_V2_BASE } from './tm/handler.mjs';
 import { PNG } from 'pngjs';
 import { VisionUtil } from '@rickcedwhat/playwright-smart-vision/utils/vision';
 import { OCRUtil, charsetForField, pickFromOptions } from '@rickcedwhat/playwright-smart-vision/utils/ocr';

--- a/packages/tools/tm/handler.mjs
+++ b/packages/tools/tm/handler.mjs
@@ -1,5 +1,5 @@
 /**
- * Template Manager v2 — Local screen authoring and management.
+ * Template Manager — Local screen authoring and management.
  * Mounted under /template-manager on the main tools server (port 2020).
  */
 import fs from 'node:fs';
@@ -15,7 +15,7 @@ export const TM_V2_BASE = '/template-manager';
 const TOOLS_DIR = path.dirname(fileURLToPath(import.meta.url));
 const HTML_FILE = path.join(TOOLS_DIR, 'index.html');
 const HOME = path.join(os.homedir(), '.smart-vision');
-const SETTINGS_FILE = path.join(HOME, 'tm-v2.json');
+const SETTINGS_FILE = path.join(HOME, 'tm.json');
 const CACHE_DIR = path.join(HOME, 'screens');
 const CHARSETS_FILE = path.join(HOME, 'charsets.json');
 const DEFAULTS_FILE = path.join(HOME, 'defaults.json');
@@ -229,7 +229,7 @@ async function handleInternal(req, res, url) {
     try {
       writeScreenCatalog(undefined, incoming, readDefaults());
     } catch (err) {
-      console.error('[tm-v2] catalog regeneration failed after charset save:', err);
+      console.error('[tm] catalog regeneration failed after charset save:', err);
     }
     send(res, 200, { charsets: incoming });
     return;
@@ -252,7 +252,7 @@ async function handleInternal(req, res, url) {
     try {
       writeScreenCatalog(undefined, undefined, incoming);
     } catch (err) {
-      console.error('[tm-v2] catalog regeneration failed after defaults save:', err);
+      console.error('[tm] catalog regeneration failed after defaults save:', err);
     }
     send(res, 200, { defaults: incoming });
     return;
@@ -497,7 +497,7 @@ export async function handleTmV2Request(req, res, url) {
     await handleInternal(req, res, stripTmV2Base(url));
   } catch (err) {
     const msg = String(err instanceof Error ? err.message : err);
-    console.error('[tm-v2]', msg);
+    console.error('[tm]', msg);
     send(res, 500, { error: msg });
   }
   return true;

--- a/packages/tools/tm/index.html
+++ b/packages/tools/tm/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>smart-vision TM v2</title>
+<title>Template Manager - smart-vision</title>
 <style>
   * { box-sizing: border-box; }
   body { margin: 0; font: 13px/1.4 system-ui, sans-serif; background: #111; color: #eee; display: grid; grid-template-rows: auto 1fr; height: 100vh; }


### PR DESCRIPTION
Removes version numbers - just 'Template Manager' now. Changes tm-v2 to tm, updates all references.